### PR TITLE
Check sam_read1 return val for >= 0, not == 0

### DIFF
--- a/fastqpreprocessing/src/htslib_tagsort.cpp
+++ b/fastqpreprocessing/src/htslib_tagsort.cpp
@@ -316,7 +316,9 @@ public:
     unsigned int cur_num_read = 0;
     while (cur_num_read < options_.alignments_per_batch)
     {
-      if (sam_read1(sam_file_ptr_, bam_hdr_, aln_arr_[thread_index][cur_num_read]) == 0)
+      // The documentation claims 0 means success, but I see code using >= and even >,
+      // so it looks like actually positive means success. I guess >= is safest, then.
+      if (sam_read1(sam_file_ptr_, bam_hdr_, aln_arr_[thread_index][cur_num_read]) >= 0)
         cur_num_read++;
       else
         break;


### PR DESCRIPTION
The documentation for the sam_read1() function claims that a return value of 0 means success, but it looks like actually positive means success. Checking for 0 here was causing TagSort to never actually process any input.