### PR TITLE
overhaul TagSort, especially tagsort.cpp and metricgatherer.cpp

### DIFF
--- a/fastqpreprocessing/Makefile
+++ b/fastqpreprocessing/Makefile
@@ -4,9 +4,9 @@ LIBS = -LlibStatGen -lStatGen -lz -lpthread -lstdc++fs -Lgzstream -lgzstream
 
 install: bin/fastqprocess bin/TagSort bin/fastq_slideseq bin/fastq_metrics bin/samplefastq
 
-COMMON_OBJ = obj/utilities.o obj/input_options.o obj/fastq_common.o
+COMMON_OBJ = obj/input_options.o obj/fastq_common.o obj/whitelist_data.o
 
-TAGSORT_OBJ = obj/tagsort.o obj/htslib_tagsort.o obj/metricgatherer.o obj/input_options.o
+TAGSORT_OBJ = obj/tagsort.o obj/htslib_tagsort.o obj/metricgatherer.o obj/mitochondrial_gene_selector.o obj/alignment_datatype.o obj/tagsort_input_options.o
 
 obj/%.o: src/%.cpp src/*.h
 	$(CC) -c -o $@ $<  -IlibStatGen/include -Ihtslib -Igzstream

--- a/fastqpreprocessing/src/alignment_datatype.cpp
+++ b/fastqpreprocessing/src/alignment_datatype.cpp
@@ -1,0 +1,146 @@
+#include "alignment_datatype.h"
+
+#include <cassert>
+#include <iostream>
+
+TagOrder getTagOrder(INPUT_OPTIONS_TAGSORT options)
+{
+  assert(options.tag_order.size() == 3);
+  // the order of the three tags are defined by the order of the supplied input arguments
+  // tag.order [tag_name] -> order map
+  if (options.tag_order[options.barcode_tag] == 0 &&
+      options.tag_order[options.gene_tag] == 1 &&
+      options.tag_order[options.umi_tag] == 2)
+  {
+    return TagOrder::BGU;
+  }
+  if (options.tag_order[options.umi_tag] == 0 &&
+      options.tag_order[options.barcode_tag] == 1 &&
+      options.tag_order[options.gene_tag] == 2)
+  {
+    return TagOrder::UBG;
+  }
+  if (options.tag_order[options.umi_tag] == 0 &&
+      options.tag_order[options.gene_tag] == 1 &&
+      options.tag_order[options.barcode_tag] == 2)
+  {
+    return TagOrder::UGB;
+  }
+  if (options.tag_order[options.gene_tag] == 0 &&
+      options.tag_order[options.umi_tag] == 1 &&
+      options.tag_order[options.barcode_tag] == 2)
+  {
+    return TagOrder::GUB;
+  }
+  if (options.tag_order[options.gene_tag] == 0 &&
+      options.tag_order[options.barcode_tag] == 1 &&
+      options.tag_order[options.umi_tag] == 2)
+  {
+    return TagOrder::GBU;
+  }
+  return TagOrder::BUG;
+}
+
+TagTriple makeTriplet(std::string barcode, std::string umi, std::string gene_id,
+                      TagOrder tag_order)
+{
+  switch (tag_order)
+  {
+    case TagOrder::BUG: return TagTriple(barcode, umi, gene_id);
+    case TagOrder::BGU: return TagTriple(barcode, gene_id, umi);
+    case TagOrder::UBG: return TagTriple(umi, barcode, gene_id);
+    case TagOrder::UGB: return TagTriple(umi, gene_id, barcode);
+    case TagOrder::GUB: return TagTriple(gene_id, umi, barcode);
+    case TagOrder::GBU: return TagTriple(gene_id, barcode, umi);
+    default: crash("no such TagOrder"); return TagTriple("","","");
+  }
+}
+
+LineFields::LineFields(
+    TagTriple _tag_triple, std::string _reference, std::string _alignment_location,
+    int _position, int _is_strand,
+    float _barcode_qual, float _cell_barcode_base_above_30,
+    float _genomic_read_quality, float _genomic_reads_base_quality_above_30,
+    int _number_mappings, int _perfect_molecule_barcode, int _read_spliced,
+    int _read_is_duplicate, int _cell_barcode_perfect,
+    float _molecule_barcode_base_above_30)
+: tag_triple(_tag_triple),
+  reference(_reference),
+  alignment_location(_alignment_location),
+  position(_position),
+  is_strand(_is_strand),
+  barcode_qual(_barcode_qual),
+  cell_barcode_base_above_30(_cell_barcode_base_above_30),
+  genomic_read_quality(_genomic_read_quality),
+  genomic_reads_base_quality_above_30(_genomic_reads_base_quality_above_30),
+  number_mappings(_number_mappings),
+  perfect_molecule_barcode(_perfect_molecule_barcode),
+  read_spliced(_read_spliced),
+  read_is_duplicate(_read_is_duplicate),
+  cell_barcode_perfect(_cell_barcode_perfect),
+  molecule_barcode_base_above_30(_molecule_barcode_base_above_30) {}
+
+LineFields::LineFields(std::string const& s)
+{
+  std::string first_tag =                           getNextField(s); // 0
+  std::string second_tag =                          getNextField(s); // 1
+  std::string third_tag =                           getNextField(s); // 2
+  tag_triple = TagTriple(first_tag, second_tag, third_tag);
+  reference =                           getNextField(s); // 3
+  alignment_location =                  getNextField(s); // 4
+  position =                            std::stoi(getNextField(s)); // 5
+  is_strand =                           std::stoi(getNextField(s)); // 6
+  barcode_qual =                        std::stof(getNextField(s)); // 7 unused
+  cell_barcode_base_above_30 =          std::stof(getNextField(s)); // 8
+  genomic_read_quality =                std::stof(getNextField(s)); // 9
+  genomic_reads_base_quality_above_30 = std::stof(getNextField(s)); // 10
+  number_mappings =                     std::stoi(getNextField(s)); // 11
+  perfect_molecule_barcode =            std::stoi(getNextField(s)); // 12
+  read_spliced =                        std::stoi(getNextField(s)); // 13
+  read_is_duplicate =                   std::stoi(getNextField(s)); // 14
+  cell_barcode_perfect =                std::stoi(getNextField(s)); // 15
+  molecule_barcode_base_above_30 =      std::stof(getNextField(s)); // 16
+}
+
+void LineFields::writeTabbedToFile(std::ofstream& outfile)
+{
+  outfile << tag_triple.first << "\t"
+          << tag_triple.second << "\t"
+          << tag_triple.third << "\t"
+          << reference << "\t"
+          << alignment_location << "\t"
+          << position << "\t"
+          << is_strand << "\t"
+          << barcode_qual << "\t"
+          << cell_barcode_base_above_30 << "\t"
+          << genomic_read_quality << "\t"
+          << genomic_reads_base_quality_above_30  << "\t"
+          << number_mappings  << "\t"
+          << perfect_molecule_barcode << "\t"
+          << read_spliced << "\t"
+          << read_is_duplicate << "\t"
+          << cell_barcode_perfect << "\t"
+          << molecule_barcode_base_above_30 << "\n";
+}
+
+std::string LineFields::getNextField(std::string const& s)
+{
+  cur_tab_ = s.find('\t', cur_start_);
+  if (cur_tab_ == std::string::npos)
+  {
+    if (fields_gotten_ != 16)
+      crash("Found " + std::to_string(fields_gotten_+1) + " fields in line; expected 17");
+
+    cur_tab_ = s.length();
+    std::string ret(s.data() + cur_start_, cur_tab_ - cur_start_);
+    fields_gotten_++;
+    return ret;
+  }
+  else
+  {
+    std::string ret(s.data() + cur_start_, cur_tab_ - cur_start_);
+    cur_start_ = cur_tab_ + 1;
+    fields_gotten_++;
+    return ret;
+  }
+}

--- a/fastqpreprocessing/src/alignment_datatype.h
+++ b/fastqpreprocessing/src/alignment_datatype.h
@@ -1,0 +1,67 @@
+#ifndef TAGSORT_ALIGNMENT_DATATYPE_H_
+#define TAGSORT_ALIGNMENT_DATATYPE_H_
+
+#include <fstream>
+#include <string>
+
+#include "tagsort_input_options.h"
+
+struct TagTriple
+{
+public:
+  TagTriple() {}
+  TagTriple(std::string one, std::string two, std::string three)
+    : first(one), second(two), third(three) {}
+  std::string first;
+  std::string second;
+  std::string third;
+};
+
+// TODO better name
+struct LineFields
+{
+public:
+  explicit LineFields(std::string const& s);
+  LineFields(
+      TagTriple _tag_triple, std::string _reference, std::string _alignment_location,
+      int _position, int _is_strand,
+      float _barcode_qual, float _cell_barcode_base_above_30,
+      float _genomic_read_quality, float _genomic_reads_base_quality_above_30,
+      int _number_mappings, int _perfect_molecule_barcode, int _read_spliced,
+      int _read_is_duplicate, int _cell_barcode_perfect,
+      float _molecule_barcode_base_above_30);
+
+  void writeTabbedToFile(std::ofstream& outfile);
+
+  TagTriple tag_triple; // (0,1,2) barcode umi and gene_id, not necessarily in that order
+  std::string reference; // 3
+  std::string alignment_location; // (4) aka biotype (TODO which is more accurate? or is this wrong?)
+  int position; // 5
+  int is_strand; // (6) 1 for yes, 0 for no
+  float barcode_qual; // 7
+  float cell_barcode_base_above_30; // 8
+  float genomic_read_quality; // 9
+  float genomic_reads_base_quality_above_30; // 10
+  int number_mappings; // 11
+  int perfect_molecule_barcode; // (12) 1 for yes, 0 for no
+  // cigar N field (3) indicates a read is spliced if the value is non-zero
+  int read_spliced; // (13) 1 for yes, 0 for no
+  int read_is_duplicate; // (14) 1 for yes, 0 for no
+  int cell_barcode_perfect; // (15) 1 for yes, 0 for no
+  float molecule_barcode_base_above_30; // (16) fraction of umi qual score > 30
+
+private:
+  std::string getNextField(std::string const& s);
+
+  size_t cur_start_ = 0;
+  size_t cur_tab_ = std::string::npos;
+  int fields_gotten_ = 0;
+};
+
+enum class TagOrder { BUG, BGU, UBG, UGB, GUB, GBU };
+TagOrder getTagOrder(INPUT_OPTIONS_TAGSORT options);
+
+TagTriple makeTriplet(std::string barcode, std::string umi, std::string gene_id,
+                      TagOrder tag_order);
+
+#endif // TAGSORT_ALIGNMENT_DATATYPE_H_

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -7,7 +7,7 @@
 // number of samrecords per buffer in each reader
 constexpr size_t kSamRecordBufferSize = 10000;
 #include "input_options.h"
-#include "utilities.h"
+#include "whitelist_data.h"
 
 #include "FastQFile.h"
 #include "FastQStatus.h"

--- a/fastqpreprocessing/src/fastq_metrics.h
+++ b/fastqpreprocessing/src/fastq_metrics.h
@@ -5,11 +5,14 @@
 #include <unordered_map>
 #include <vector>
 #include <thread>
+
 #include "BaseAsciiMap.h"
-#include "utilities.h"
-#include "input_options.h"
 #include "FastQFile.h"
 #include "FastQStatus.h"
+
+#include "input_options.h"
+#include "whitelist_data.h"
+
 
 class PositionWeightMatrix
 {

--- a/fastqpreprocessing/src/htslib_tagsort.h
+++ b/fastqpreprocessing/src/htslib_tagsort.h
@@ -1,16 +1,14 @@
 #ifndef __HTSLIB_TAG_SORT__
 #define __HTSLIB_TAG_SORT__
 
-#include <htslib/sam.h>
-#include "input_options.h"
-#include "utilities.h"
+#include "tagsort_input_options.h"
 
+#include <string>
+#include <vector>
 
 // From the input bam, arbitrarily split the records into a number of groups,
 // sort each group, and write each sorted group to a file, each randomly named.
 // Returns the file paths of the created sorted partial files.
-std::vector<std::string> create_sorted_file_splits_htslib(INPUT_OPTIONS_TAGSORT options);
-
-void crash(std::string msg);
+std::vector<std::string> splitAndPartialSortToFiles(INPUT_OPTIONS_TAGSORT options);
 
 #endif

--- a/fastqpreprocessing/src/input_options.cpp
+++ b/fastqpreprocessing/src/input_options.cpp
@@ -1,14 +1,19 @@
 #include "input_options.h"
 
-#include <experimental/filesystem>
-#include <regex>
+#include <filesystem>
 #include <getopt.h>
 #include <cassert>
 #include <iostream>
 #include <cmath>
 
-namespace fs = std::experimental::filesystem;
 using std::string;
+
+void crash(std::string msg)
+{
+  std::cout << msg << std::endl;
+  std::cerr << msg << std::endl;
+  exit(1);
+}
 
 int64_t filesize(string const& filename)
 {
@@ -29,7 +34,7 @@ void printFileInfo(std::vector<string> const& fastqs,
     std::cout << "INFO " << type << " files:" << std::endl;
     for (unsigned int i= 0; i < fastqs.size(); i++)
     {
-      if (fs::exists(fastqs[i].c_str()))
+      if (std::filesystem::exists(fastqs[i].c_str()))
       {
         std::cout << "\t " << fastqs[i]  <<  " exists, file size "
                   <<  filesize(fastqs[i])  <<  std::endl;
@@ -73,203 +78,6 @@ int64_t get_num_blocks(InputOptionsFastqProcess const& options)
 int64_t get_num_blocks(INPUT_OPTIONS_FASTQ_READ_STRUCTURE const& options)
 {
   return get_num_blocks(options.I1s, options.R1s, options.R2s, options.bam_size);
-}
-
-INPUT_OPTIONS_TAGSORT readOptionsTagsort(int argc, char** argv)
-{
-  INPUT_OPTIONS_TAGSORT options;
-  int c;
-  int i;
-
-  static struct option long_options[] =
-  {
-    /* These options set a flag. */
-    {"compute-metric",             no_argument,       0, 'm'},
-    {"output-sorted-info",         no_argument,       0, 'n'},
-    /* These options don’t set a flag.
-       We distinguish them by their indices. */
-    {"bam-input",                  required_argument, 0, 'b'},
-    {"gtf-file",                   required_argument, 0, 'a'},
-    {"temp-folder",                required_argument, 0, 't'},
-    {"sorted-output",              required_argument, 0, 'o'},
-    {"metric-output",              required_argument, 0, 'M'},
-    {"alignments-per-thread",      required_argument, 0, 'p'},
-    {"nthreads",                   required_argument, 0, 'T'},
-    {"barcode-tag",                required_argument, 0, 'C'},
-    {"umi-tag",                    required_argument, 0, 'U'},
-    {"gene-tag",                   required_argument, 0, 'G'},
-    {"metric-type",                required_argument, 0, 'K'},
-    {"mitochondrial-gene-names-filename", required_argument, 0, 'g'},
-    {0, 0, 0, 0}
-  };
-
-  // help messages when the user types -h
-  const char* help_messages[] =
-  {
-    "compute metric, metrics are computed if this option is provided [optional]",
-    "sorted output file is produced if this option is provided [optional]",
-    "input bam file [required]",
-    "gtf file (unzipped) required then metric type is cell [required with metric cell]",
-    "temp folder for disk sorting [options: default /tmp]",
-    "sorted output file [optional]",
-    "metric file, the metrics are output in this file  [optional]",
-    "number of alignments per thread [optional: default 1000000], if this number is increased then more RAM is required but reduces the number of file splits",
-    "number of threads [optional: default 1]",
-    "barcode-tag the call barcode tag [required]",
-    "umi-tag the umi tag [required]: the tsv file output is sorted according the tags in the options barcode-tag, umi-tag or gene-tag",
-    "gene-tag the gene tag [required]",
-    "metric type, either \"cell\" or \"gene\" [required]",
-    "file listing gene names, one per line, that the program should care about. [required, may omit if you want mouse or human]"
-  };
-
-
-  /* getopt_long stores the option index here. */
-  int option_index = 0;
-  int curr_size = 0;
-  while ((c = getopt_long(argc, argv,
-                          "b:a:t:no:mM:p:T:C:U:G:K:",
-                          long_options,
-                          &option_index)) !=- 1)
-  {
-    // process the option or arguments
-    switch (c)
-    {
-    case 'm':
-      options.compute_metric = true;
-      break;
-    case 'n':
-      options.output_sorted_info = true;
-      break;
-    case 0:
-      /* If this option set a flag, do nothing else now. */
-      if (long_options[option_index].flag != 0)
-        break;
-      printf("option %s", long_options[option_index].name);
-      if (optarg)
-        printf(" with arg %s", optarg);
-      printf("\n");
-      break;
-    case 'b':
-      options.bam_input = string(optarg);
-      break;
-    case 'a':
-      options.gtf_file = string(optarg);
-      break;
-    case 't':
-      options.temp_folder = string(optarg);
-      break;
-    case 'o':
-      options.sorted_output_file = string(optarg);
-      break;
-    case 'M':
-      options.metric_output_file = string(optarg);
-      break;
-    case 'p':
-      options.alignments_per_batch = atoi(optarg);
-      break;
-    case 'T':
-      options.nthreads = atoi(optarg);
-      break;
-    case 'C':
-      options.barcode_tag = string(optarg);
-      curr_size = options.tag_order.size();
-      options.tag_order[string(optarg)] = curr_size;
-      break;
-    case 'U':
-      options.umi_tag = string(optarg);
-      curr_size = options.tag_order.size();
-      options.tag_order[string(optarg)] = curr_size;
-      break;
-    case 'G':
-      options.gene_tag = string(optarg);
-      curr_size = options.tag_order.size();
-      options.tag_order[string(optarg)] = curr_size;
-      break;
-    case 'K':
-      options.metric_type = string(optarg);
-      break;
-    case 'g':
-      options.mitochondrial_gene_names_filename = string(optarg);
-      break;
-    case '?':
-    case 'h':
-      i = 0;
-      printf("Usage: %s [options] \n", argv[0]);
-      while (long_options[i].name != 0)
-      {
-        printf("\t--%-20s  %-25s  %-35s\n", long_options[i].name,
-               long_options[i].has_arg == no_argument?
-               "no argument" : "required_argument",
-               help_messages[i]);
-        i = i + 1;
-      }
-      /* getopt_long already printed an error message. */
-      exit(0);
-      break;
-    default:
-      abort();
-    }
-  }
-
-  // Check the options
-  // either metric computation or the sorted tsv file must be produced
-  if (!options.output_sorted_info && !options.compute_metric)
-    crash("ERROR: The choice of either the sorted alignment info or metric computation must be specified");
-
-  if (options.compute_metric && options.metric_output_file.empty())
-    crash("ERROR: Must specify --metric-output when specifying --compute-metric");
-
-  if (options.output_sorted_info && options.sorted_output_file.empty())
-    crash("ERROR: Must specify --sorted-output when specifying --output-sorted-info");
-
-  // metric type must be either of type cell or gene
-  if (options.metric_type != "cell" && options.metric_type != "gene")
-    crash("ERROR: --metric-type must either be \"cell\" or \"gene\"");
-
-  // if metric type is cell then the gtf file must be provided
-  if (options.metric_type == "cell" && options.gtf_file.empty())
-    crash("ERROR: The gtf file name must be provided with metric_type \"cell\"");
-
-  // the gtf file should not be gzipped
-  std::regex reg1(".gz$", std::regex_constants::icase);
-  if (std::regex_search(options.gtf_file, reg1))
-    crash("ERROR: The gtf file must not be gzipped");
-
-  // bam input file must be there
-  if (options.bam_input.empty())
-    crash("ERROR: Must specify a input file name");
-
-  // check for input file
-  if (!fs::exists(options.bam_input.c_str()))
-    crash("ERROR: bam_input " + options.bam_input + " is missing!");
-
-  // check for the temp folder
-  if (!fs::exists(options.temp_folder.c_str()))
-    crash("ERROR: temp folder " + options.temp_folder + " is missing!");
-
-  // check for three distinct tags, barcode, umi and gene_id tags
-  if (options.tag_order.size() != 3)
-    crash("ERROR:  Must have three distinct tags");
-  bool seen_tag_index[3] = { false, false, false };
-  for (auto [tag, index] : options.tag_order)
-  {
-    if (index < 0 || index > 2)
-      crash("Invalid tag index " + std::to_string(index) + "; must be 0 1 or 2");
-    else
-      seen_tag_index[index] = true;
-  }
-  if (!(seen_tag_index[0] && seen_tag_index[1] && seen_tag_index[2]))
-    crash("Need tag indices 0 1 and 2");
-
-  // The size of a set of aligments for in-memory sorting must be positive
-  if (options.alignments_per_batch < 1000)
-    crash("ERROR: The number of alignments per thread must be at least 1000");
-
-  // The number of threads must be between 1 and kMaxTagsortThreads
-  if (options.nthreads > kMaxTagsortThreads || options.nthreads < 1)
-    crash("ERROR: The number of threads must be between 1 and " + std::to_string(kMaxTagsortThreads));
-
-  return options;
 }
 
 InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)

--- a/fastqpreprocessing/src/input_options.h
+++ b/fastqpreprocessing/src/input_options.h
@@ -1,13 +1,10 @@
 #ifndef __SCTOOLS_FASTQPREPROCESSING_INPUT_OPTIONS_H_
 #define __SCTOOLS_FASTQPREPROCESSING_INPUT_OPTIONS_H_
 
-#include "utilities.h"
-
 #include <string>
 #include <vector>
 
-constexpr unsigned int kMaxTagsortThreads = 30;
-constexpr unsigned int kDefaultNumAlignsPerThread = 1000000;
+void crash(std::string msg);
 
 struct INPUT_OPTIONS_FASTQ_READ_STRUCTURE
 {
@@ -26,7 +23,6 @@ struct INPUT_OPTIONS_FASTQ_READ_STRUCTURE
 
   std::string sample_id;
 };
-
 
 // Structure to hold input options for fastqprocess
 struct InputOptionsFastqProcess
@@ -49,41 +45,7 @@ struct InputOptionsFastqProcess
   std::string sample_id;
 };
 
-
-// Structure to hold input options for tagsort
-struct INPUT_OPTIONS_TAGSORT
-{
-  std::string metric_type;
-  bool output_sorted_info = false;
-  bool compute_metric = false;
-  // name of the bam file
-  std::string bam_input;
-  // name of the gtf file
-  std::string gtf_file;
-  // temp folder for disk sorting
-  std::string temp_folder = "/tmp/";
-
-  std::string metric_output_file;
-  // sorted tsv output file
-  std::string sorted_output_file;
-
-  // Size (in number of alignments) of individual chunks to sort in a batch and
-  // write to a partial file. Approximately 20 million alignments makes 1 GB bam file.
-  unsigned int alignments_per_batch = kDefaultNumAlignsPerThread;
-  unsigned int nthreads = 1;
-  std::string barcode_tag;
-  std::string umi_tag;
-  std::string gene_tag;
-
-  // order of the tags to sort by
-  std::unordered_map<std::string, unsigned int> tag_order;
-
-  std::string mitochondrial_gene_names_filename;
-};
-
 InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv);
-
-INPUT_OPTIONS_TAGSORT readOptionsTagsort(int argc, char** argv);
 
 INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** argv);
 

--- a/fastqpreprocessing/src/metricgatherer.cpp
+++ b/fastqpreprocessing/src/metricgatherer.cpp
@@ -1,332 +1,244 @@
 #include "metricgatherer.h"
 
-template<typename T>
-inline void freeContainer(T& p_container)
-{
-  T empty;
-  using std::swap;
-  swap(p_container, empty);
-}
+#include "mitochondrial_gene_selector.h"
 
+constexpr int kMetricsFloatPrintPrecision = 10;
 
 std::string to_nan(float x)
 {
   std::stringstream s;
-  s << std::setprecision(10) << x;
+  s << std::setprecision(kMetricsFloatPrintPrecision) << x;
   return x==-1 ? "nan" : s.str();
 }
 
-void Metrics::clear()
+MetricGatherer::MetricGatherer(std::string metric_output_file)
 {
-  n_reads = 0;
+  metrics_outfile_.open(metric_output_file);
+  if (!metrics_outfile_)
+    crash("Failed to open for writing " + metric_output_file);
+  metrics_outfile_ << std::setprecision(kMetricsFloatPrintPrecision);
+}
+
+MetricGatherer::~MetricGatherer() {}
+
+void MetricGatherer::clearCellAndGeneCommon()
+{
+  n_reads_ = 0;
   // noise_reads = 0; //# long polymers, N-sequences; NotImplemented
-  freeContainer(_fragment_histogram);
-  freeContainer(_molecule_histogram);
+  fragment_histogram_.clear();
+  molecule_histogram_.clear();
 
-  freeContainer(_molecule_barcode_fraction_bases_above_30);
-  perfect_molecule_barcodes = 0;
-  freeContainer(_genomic_reads_fraction_bases_quality_above_30);
-  freeContainer(_genomic_read_quality);
+  molecule_barcode_fraction_bases_above_30_.clear();
+  perfect_molecule_barcodes_ = 0;
+  genomic_reads_fraction_bases_quality_above_30_.clear();
+  genomic_read_quality_.clear();
 
-  reads_mapped_exonic = 0;
-  reads_mapped_intronic = 0;
-  reads_mapped_utr = 0;
+  reads_mapped_exonic_ = 0;
+  reads_mapped_intronic_ = 0;
+  reads_mapped_utr_ = 0;
 
   // alignment uniqueness information
-  reads_mapped_uniquely = 0;
-  reads_mapped_multiple = 0;
-  duplicate_reads = 0;
+  reads_mapped_uniquely_ = 0;
+  reads_mapped_multiple_ = 0;
+  duplicate_reads_ = 0;
 
   // alignment splicing information
-  spliced_reads = 0;
-  antisense_reads = 0;
-  plus_strand_reads = 0;  // strand balance
-
-  // higher-order methods, filled in by finalize() when all data is extracted
-  molecule_barcode_fraction_bases_above_30_mean = -1;
-  molecule_barcode_fraction_bases_above_30_variance = -1;
-  genomic_reads_fraction_bases_quality_above_30_mean = -1;
-  genomic_reads_fraction_bases_quality_above_30_variance = -1;
-  genomic_read_quality_mean = -1;
-  genomic_read_quality_variance  = -1;
-  n_molecules = -1;
-  n_fragments = -1;
-  reads_per_molecule = -1;
-  reads_per_fragment = -1;
-  fragments_per_molecule = -1;
-  fragments_with_single_read_evidence = -1;
-  molecules_with_single_read_evidence = -1;
+  spliced_reads_ = 0;
 }
 
-
-void Metrics::output_metrics(std::ofstream& fmetric_out)
+void MetricGatherer::ingestLineCellAndGeneCommon(LineFields const& fields)
 {
-  fmetric_out << std::setprecision(10) <<  prev_tag << ","
-              << n_reads << ","
-              << noise_reads << ","
-              << perfect_molecule_barcodes << ","
-              << reads_mapped_exonic << ","
-              << reads_mapped_intronic << ","
-              << reads_mapped_utr << ","
-              << reads_mapped_uniquely << ","
-              << reads_mapped_multiple << ","
-              << duplicate_reads << ","
-              << spliced_reads << ","
-              << antisense_reads << ","
-              << molecule_barcode_fraction_bases_above_30_mean << ","
-              << to_nan(molecule_barcode_fraction_bases_above_30_variance) << ","
-              << genomic_reads_fraction_bases_quality_above_30_mean << ","
-              << to_nan(genomic_reads_fraction_bases_quality_above_30_variance) << ","
-              << to_nan(genomic_read_quality_mean) << ","
-              << to_nan(genomic_read_quality_variance) << ","
-              << n_molecules << ","
-              << n_fragments << ","
-              << reads_per_molecule << ","
-              << reads_per_fragment << ","
-              << fragments_per_molecule << ","
-              << fragments_with_single_read_evidence << ","
-              << molecules_with_single_read_evidence;
-}
-
-
-constexpr unsigned int kOffset = 3;
-void Metrics::parse_line(std::string& str, std::ofstream& fmetric_out,
-                         std::unordered_set<std::string>& mitochondrial_genes,
-                         MetricType metric_type)
-{
-  char line[1000];
-  std::string NONE("None");
-  std::size_t len = str.copy(line, str.size(), 0);
-  line[str.size()]='\0';
-
-  assert(len < 1000);
-
-  char* c = line;
-
-  unsigned int k = 0;
-  record[k] = c;
-  while (*c!='\0')
-  {
-    if (*c == '\t')
-    {
-      *c='\0';
-      record[++k] = c + 1;
-    }
-    c++;
-  }
-
-  assert(k==16);
-
-  std::string current_tag = record[0];
-
-  // ignore the None gene
-  if (current_tag.compare(NONE)==0)
-    return;
-
-  // load the tags
-  std::string first_tag, second_tag, third_tag;
-  first_tag = record[0];
-  second_tag = record[1];
-  third_tag = record[2];
-  if (metric_type == MetricType::Gene && first_tag.find(",")!=std::string::npos)
-    return;
-
-  std::string tags = first_tag + std::string("-") + second_tag + std::string("-") + third_tag;
-  if (prev_tag.compare(current_tag)!=0 && prev_tag.size()!=0)
-  {
-    finalize(mitochondrial_genes);
-    output_metrics(fmetric_out);
-    output_metrics_extra(fmetric_out);
-    clear();
-  }
-
-  parse_extra_fields(first_tag, second_tag, third_tag, record);
-
-  n_reads += 1;
+  n_reads_++;
 
   // the tags passed to this function define a molecule, this increments the counter,
   // identifying a new molecule only if a new tag combination is observed
+  std::string hyphenated_tags = fields.tag_triple.first + "-" +
+                                fields.tag_triple.second + "-" +
+                                fields.tag_triple.third;
+  molecule_histogram_[hyphenated_tags] += 1;
 
-  /* updating the molecule histogram with tags */
-  if (_molecule_histogram.find(tags)==_molecule_histogram.end())
-    _molecule_histogram[tags] = 0;
-  _molecule_histogram[tags] += 1;
+  molecule_barcode_fraction_bases_above_30_.update(fields.molecule_barcode_base_above_30);
+  perfect_molecule_barcodes_ += fields.perfect_molecule_barcode;
 
-  _molecule_barcode_fraction_bases_above_30.update(std::stof(record[kOffset + 13]));
-  perfect_molecule_barcodes += std::stoi(record[kOffset + 9]);
+  genomic_reads_fraction_bases_quality_above_30_.update(fields.genomic_reads_base_quality_above_30);
+  genomic_read_quality_.update(fields.genomic_read_quality);
 
-  _genomic_reads_fraction_bases_quality_above_30.update(std::stof(record[kOffset + 7]));
-  _genomic_read_quality.update(std::stof(record[kOffset + 6]));
+  // only do aligned-read-specific stuff if the read is mapped
+  if (fields.reference != "*")
+    parseAlignedReadFields(fields, hyphenated_tags);
+}
 
-  // the remaining portions deal with aligned reads, so if the read is not mapped, we are
-  // done with it
-  if (std::string(record[kOffset + 0]).compare("*")==0)
-    return;
-
+void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags)
+{
   // get components that define a unique sequence fragment and increment the histogram
-  std::string position_str = record[kOffset + 2];
-  std::string strand = std::stoi(std::string(record[kOffset + 3]))==1 ? "true" : "false";
-  std::string reference = record[kOffset + 0];
+  std::string is_strand = (fields.is_strand == 1 ? "true" : "false");
+  std::string ref_pos_str_tags = fields.reference + "\t" +
+                                 std::to_string(fields.position) + "\t" +
+                                 is_strand + "\t" + hyphenated_tags;
+  fragment_histogram_[ref_pos_str_tags] += 1;
 
-  std::string _ref_pos_str_tags = reference + std::string("\t") +
-                                  position_str + std::string("\t") +
-                                  strand + std::string("\t") + tags;
-  std::string ref_pos_str_tags = std::to_string(std::hash<std::string> {}(_ref_pos_str_tags));
-
-  /* updating the fragment histogram with tag, strand and pos */
-  if (_fragment_histogram.find(ref_pos_str_tags)==_fragment_histogram.end())
-    _fragment_histogram[ref_pos_str_tags] = 0;
-  _fragment_histogram[ref_pos_str_tags] += 1;
-
-  std::string alignment_location = std::string(record[kOffset + 1]);
-  if (alignment_location == "CODING")
-    reads_mapped_exonic += 1;
-  else if (alignment_location == "INTRONIC")
-    reads_mapped_intronic += 1;
-  else if (alignment_location == "UTR")
-    reads_mapped_utr += 1;
+  if (fields.alignment_location == "CODING")
+    reads_mapped_exonic_ += 1;
+  else if (fields.alignment_location == "INTRONIC")
+    reads_mapped_intronic_ += 1;
+  else if (fields.alignment_location == "UTR")
+    reads_mapped_utr_ += 1;
 
   // in futher check if read maps outside window (when we add a  gene model)
   // and  create distances from terminate side (needs gene model) uniqueness
-  int number_mappings = std::stoi(std::string(record[kOffset + 8]));
-
-  if (number_mappings==1)
-    reads_mapped_uniquely += 1;
+  if (fields.number_mappings == 1)
+    reads_mapped_uniquely_ += 1;
   else
-    reads_mapped_multiple += 1;  // without multi-mapping, this number is zero!
+    reads_mapped_multiple_ += 1;  // without multi-mapping, this number is zero!
 
-  duplicate_reads += std::stoi(std::string(record[kOffset + 11]));
-
-  // cigar N field (3) indicates a read is spliced if the value is non-zero
-  spliced_reads += std::stoi(std::string(record[kOffset + 10]));
-
-  prev_tag = current_tag;
+  duplicate_reads_ += fields.read_is_duplicate;
+  spliced_reads_ += fields.read_spliced;
 }
 
-
-//  Calculate metrics that require information from all molecules of an entity
-//  ``finalize()`` replaces attributes in-place that were initialized by the constructor as
-//  ``None`` with a value calculated across all molecule data that has been aggregated.
-
-void Metrics::finalize(std::unordered_set<std::string>& mitochondrial_genes)
+void MetricGatherer::outputMetricsLineCellAndGeneCommon()
 {
-  molecule_barcode_fraction_bases_above_30_mean =
-      _molecule_barcode_fraction_bases_above_30.getMean();
+  float reads_per_molecule = -1.0f;   // float("nan")
+  if (molecule_histogram_.size() != 0)
+    reads_per_molecule = n_reads_ / (float)molecule_histogram_.size();
 
-  molecule_barcode_fraction_bases_above_30_variance =
-      _molecule_barcode_fraction_bases_above_30.calculate_variance();
+  float reads_per_fragment = -1.0f; //float("nan")
+  if (fragment_histogram_.size() != 0)
+    reads_per_fragment = n_reads_ / (float)fragment_histogram_.size();
 
-  genomic_reads_fraction_bases_quality_above_30_mean =
-      _genomic_reads_fraction_bases_quality_above_30.getMean();
+  float fragments_per_molecule = -1.0f; // float("nan")
+  if (molecule_histogram_.size() != 0)
+    fragments_per_molecule = fragment_histogram_.size() / (float)molecule_histogram_.size();
 
-  genomic_reads_fraction_bases_quality_above_30_variance =
-      _genomic_reads_fraction_bases_quality_above_30.calculate_variance();
-
-  genomic_read_quality_mean = _genomic_read_quality.getMean();
-
-  genomic_read_quality_variance = _genomic_read_quality.calculate_variance();
-
-  n_molecules = _molecule_histogram.size();
-
-  n_fragments = _fragment_histogram.size();
-
-  reads_per_molecule = -1;   // float("nan")
-  if (n_molecules != 0)
-    reads_per_molecule = n_reads / n_molecules;
-
-  reads_per_fragment = -1; //float("nan")
-  if (n_fragments != 0)
-    reads_per_fragment = n_reads / n_fragments;
-
-  fragments_per_molecule = -1; // float("nan")
-  if (n_molecules != 0)
-    fragments_per_molecule = n_fragments / n_molecules;
-
-  fragments_with_single_read_evidence = 0;
-  for (auto const& [key, val] : _fragment_histogram)
+  int fragments_with_single_read_evidence = 0;
+  for (auto const& [key, val] : fragment_histogram_)
     if (val == 1)
       fragments_with_single_read_evidence++;
 
-  molecules_with_single_read_evidence = 0;
-  for (auto const& [key, val] : _molecule_histogram)
+  int molecules_with_single_read_evidence = 0;
+  for (auto const& [key, val] : molecule_histogram_)
     if (val == 1)
       molecules_with_single_read_evidence++;
+
+  metrics_outfile_
+      << prev_tag_ << ","
+      << n_reads_ << ","
+      << noise_reads << ","
+      << perfect_molecule_barcodes_ << ","
+      << reads_mapped_exonic_ << ","
+      << reads_mapped_intronic_ << ","
+      << reads_mapped_utr_ << ","
+      << reads_mapped_uniquely_ << ","
+      << reads_mapped_multiple_ << ","
+      << duplicate_reads_ << ","
+      << spliced_reads_ << ","
+      << kAntisenseReads << ","
+      << molecule_barcode_fraction_bases_above_30_.getMean() << ","
+      << to_nan(molecule_barcode_fraction_bases_above_30_.calculateVariance()) << ","
+      << genomic_reads_fraction_bases_quality_above_30_.getMean() << ","
+      << to_nan(genomic_reads_fraction_bases_quality_above_30_.calculateVariance()) << ","
+      << to_nan(genomic_read_quality_.getMean()) << ","
+      << to_nan(genomic_read_quality_.calculateVariance()) << ","
+      << molecule_histogram_.size() << ","
+      << fragment_histogram_.size() << ","
+      << reads_per_molecule << ","
+      << reads_per_fragment << ","
+      << fragments_per_molecule << ","
+      << fragments_with_single_read_evidence << ","
+      << molecules_with_single_read_evidence;
 }
 
-////////////////  CellMetrics ////////////////////////
-std::string CellMetrics::getHeader()
+
+
+
+////////////////  CellMetricGatherer ////////////////////////
+
+CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
+                                       std::string gtf_file,
+                                       std::string mitochondrial_gene_names_filename)
+  : MetricGatherer(metric_output_file)
 {
+  if (gtf_file.empty())
+    crash("CellMetricGatherer needs a non-empty gtf_file name!");
+  // it's ok if mitochondrial_gene_names_filename is empty;
+  // getInterestingMitochondrialGenes() has logic to handle that case.
+  mitochondrial_genes_ = getInterestingMitochondrialGenes(
+      gtf_file, mitochondrial_gene_names_filename);
+
+  // write metrics csv header
   std::string s;
   for (int i=0; i<24; i++)
-    s += std::string(",") + common_headers[i]; // TODO ok to start with ,?
+    metrics_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<11; i++)
-    s += std::string(",") + cell_specific_headers[i];
-  return s;
+    metrics_outfile_ << "," << cell_specific_headers[i];
+  metrics_outfile_ << "\n";
 }
 
-// Parses a record to extract gene-specific information
-void CellMetrics::parse_extra_fields(const std::string& first_tag,
-                                     const std::string& second_tag,
-                                     const std::string& third_tag,
-                                     char** record)
+bool MetricGatherer::cellAndGeneIsItTimeToOutput(std::string const& first_tag)
 {
-  _cell_barcode_fraction_bases_above_30.update(std::stof(record[kOffset + 5]));
-  perfect_cell_barcodes += std::stoi(record[kOffset + 12]);
+  // TODO?     is it ok that both cell and gene move on based only on the first tag?
+  //           hmm sort of? it sounds like the user is expected to know to pass the
+  //           tag types in the order that will make this work. so ideally it
+  //           shouldn't be like that, but that would probably mean also remaking
+  //           or even removing that "tag order" command line arg.
+  return prev_tag_ != first_tag && !prev_tag_.empty();
+}
 
-  std::string record_str(record[kOffset + 1]);
-  if (!record_str.empty()) // TODO can the empty check be skipped, or is there a non-empty non-unmapped case?
+void CellMetricGatherer::ingestLine(std::string const& str)
+{
+  LineFields fields(str);
+
+  if (fields.tag_triple.first == "None")
+    return; // ignore the None gene
+
+  // One line of metrics file output per tag.
+  if (cellAndGeneIsItTimeToOutput(fields.tag_triple.first))
   {
-    if (record_str == "INTERGENIC")
-      reads_mapped_intergenic += 1;
+    outputMetricsLine();
+    clear();
+  }
+
+  ingestLineCellAndGeneCommon(fields);
+
+  // BEGIN cell-metric-specific stuff
+  cell_barcode_fraction_bases_above_30_.update(fields.cell_barcode_base_above_30);
+  perfect_cell_barcodes_ += fields.cell_barcode_perfect;
+
+  if (!fields.alignment_location.empty())
+  {
+    if (fields.alignment_location == "INTERGENIC")
+      reads_mapped_intergenic_ += 1;
   }
   else
-    reads_unmapped += 1;
+    reads_unmapped_ += 1;
 
-  /* updating the genes histogram with tags */
-  if (_genes_histogram.find(third_tag) == _genes_histogram.end())
-    _genes_histogram[third_tag] = 0;
-  _genes_histogram[third_tag] += 1;
+  genes_histogram_[std::string(fields.tag_triple.third)] += 1;
+  // END cell-metric-specific stuff
+
+  // TODO is it ok that we don't update prev_tag_ if reference==* ? since prev_tag_
+  //      is involved in deciding when to write a metrics line, it seems like this
+  //      could mess with metrics output, which includes the stuff that is updated
+  //      in this function before the `if reference==* return`.
+  if (fields.reference != "*")
+    prev_tag_ = fields.tag_triple.first;
 }
 
-void CellMetrics::output_metrics_extra(std::ofstream& fmetric_out)
+void CellMetricGatherer::outputMetricsLine()
 {
-  fmetric_out << std::setprecision(10)
-              << "," << perfect_cell_barcodes
-              << "," << reads_mapped_intergenic
-              << "," << reads_unmapped
-              << "," << reads_mapped_too_many_loci
-              << std::setprecision(10)
-              << "," << to_nan(cell_barcode_fraction_bases_above_30_variance)
-              << "," << cell_barcode_fraction_bases_above_30_mean
-              << "," << n_genes
-              << "," << genes_detected_multiple_observations
-              << "," << n_mitochondrial_genes
-              << "," << n_mitochondrial_molecules
-              << "," << pct_mitochondrial_molecules
-              << std::endl;
-}
+  outputMetricsLineCellAndGeneCommon();
 
-void CellMetrics::finalize(std::unordered_set<std::string>& mitochondrial_genes)
-{
-  // call the finalize function in the parent class
-  Metrics::finalize(mitochondrial_genes);
+  // The number of genes that are observed by more than one read in this cell
+  int genes_detected_multiple_observations = 0;
+  // The number of mitochondrial genes detected by this cell
+  int n_mitochondrial_genes = 0;
+  // The number of molecules from mitochondrial genes detected for this cell
+  int n_mitochondrial_molecules = 0;
+  float pct_mitochondrial_molecules = 0.0f;
 
-  cell_barcode_fraction_bases_above_30_mean =
-      _cell_barcode_fraction_bases_above_30.getMean();
-
-  cell_barcode_fraction_bases_above_30_variance =
-      _cell_barcode_fraction_bases_above_30.calculate_variance();
-
-  n_genes = _genes_histogram.size();
-
-  genes_detected_multiple_observations = 0;
-  n_mitochondrial_genes = 0;
-  n_mitochondrial_molecules = 0;
-  for (auto const& [gene, count] : _genes_histogram)
+  for (auto const& [gene, count] : genes_histogram_)
   {
     if (count > 1)
       genes_detected_multiple_observations++;
-    if (mitochondrial_genes.find(gene) != mitochondrial_genes.end())
+    if (mitochondrial_genes_.find(gene) != mitochondrial_genes_.end())
     {
       n_mitochondrial_genes++;
       n_mitochondrial_molecules += count;
@@ -336,83 +248,101 @@ void CellMetrics::finalize(std::unordered_set<std::string>& mitochondrial_genes)
   if (n_mitochondrial_molecules > 0)
   {
     int tot_molecules = 0;
-    for (auto const& [gene, count] : _genes_histogram)
+    for (auto const& [gene, count] : genes_histogram_)
       tot_molecules += count;
 
     // TODO BUG associativity and integer division combine to make this always 0
-    pct_mitochondrial_molecules = (n_mitochondrial_molecules/tot_molecules * 100.0);
+    pct_mitochondrial_molecules = (n_mitochondrial_molecules/tot_molecules * 100.0f);
   }
   else
-    pct_mitochondrial_molecules = 0.0;
+    pct_mitochondrial_molecules = 0.0f;
+
+  metrics_outfile_
+      << "," << perfect_cell_barcodes_
+      << "," << reads_mapped_intergenic_
+      << "," << reads_unmapped_
+      << "," << kReadsMappedTooManyLoci
+      << "," << to_nan(cell_barcode_fraction_bases_above_30_.calculateVariance())
+      << "," << cell_barcode_fraction_bases_above_30_.getMean()
+      << "," << genes_histogram_.size()
+      << "," << genes_detected_multiple_observations
+      << "," << n_mitochondrial_genes
+      << "," << n_mitochondrial_molecules
+      << "," << pct_mitochondrial_molecules
+      << "\n";
 }
 
-void CellMetrics::clear()
+void CellMetricGatherer::clear()
 {
-  // call the clear function in the parent class
-  Metrics::clear();
+  clearCellAndGeneCommon();
 
-  _cell_barcode_fraction_bases_above_30.clear();
-  perfect_cell_barcodes = 0;
-  reads_mapped_intergenic = 0;
-  reads_unmapped = 0;
-  reads_mapped_too_many_loci = 0;
-  _genes_histogram.clear();
-
-  n_genes = 0;
-  genes_detected_multiple_observations = 0;
-  n_mitochondrial_genes = 0;
-  n_mitochondrial_molecules = 0;
-  pct_mitochondrial_molecules = 0;
+  cell_barcode_fraction_bases_above_30_.clear();
+  perfect_cell_barcodes_ = 0;
+  reads_mapped_intergenic_ = 0;
+  reads_unmapped_ = 0;
+  genes_histogram_.clear();
 }
 
 
-////////////////  GeneMetrics ////////////////////////
-std::string GeneMetrics::getHeader()
+////////////////  GeneMetricGatherer ////////////////////////
+GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file)
+  : MetricGatherer(metric_output_file)
 {
+  // write metrics csv header
   std::string s;
   for (int i=0; i<24; i++)
-    s += std::string(",") + common_headers[i]; // TODO ok to start with ,?
+    metrics_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<2; i++)
-    s += std::string(",") + gene_specific_headers[i];
-  return s;
+    metrics_outfile_ << "," << gene_specific_headers[i];
+  metrics_outfile_ << "\n";
 }
 
-void GeneMetrics::parse_extra_fields(const std::string& first_tag,
-                                     const std::string& second_tag,
-                                     const std::string& third_tag,
-                                     char** record)
+void GeneMetricGatherer::ingestLine(std::string const& str)
 {
-  // updating the cell histogram with tags
-  if (_cells_histogram.find(second_tag)==_cells_histogram.end())
-    _cells_histogram[second_tag] = 0;
+  LineFields fields(str);
 
-  _cells_histogram[second_tag] += 1;
+  if (fields.tag_triple.first == "None")
+    return; // ignore the None gene
+  if (fields.tag_triple.first.find(',') != std::string::npos)
+    return;
+
+  // One line of metrics file output per tag.
+  if (cellAndGeneIsItTimeToOutput(fields.tag_triple.first))
+  {
+    outputMetricsLine();
+    clear();
+  }
+
+  ingestLineCellAndGeneCommon(fields);
+
+  // BEGIN gene-metric-specific stuff
+  cells_histogram_[std::string(fields.tag_triple.second)] += 1;
+  // END gene-metric-specific stuff
+
+  // TODO is it ok that we don't update prev_tag_ if reference==* ? since prev_tag_
+  //      is involved in deciding when to write a metrics line, it seems like this
+  //      could mess with metrics output, which includes the stuff that is updated
+  //      in this function before the `if reference==* return`.
+  if (fields.reference != "*")
+    prev_tag_ = fields.tag_triple.first;
 }
 
-void GeneMetrics::output_metrics_extra(std::ofstream& fmetric_out)
+void GeneMetricGatherer::outputMetricsLine()
 {
-  fmetric_out <<  ","  << number_cells_detected_multiple
-              <<  ","  << number_cells_expressing
-              << std::endl;
-}
+  outputMetricsLineCellAndGeneCommon();
 
-void GeneMetrics::finalize(std::unordered_set<std::string>& mitochondrial_genes)
-{
-  // call the finalize function in the parent class
-  Metrics::finalize(mitochondrial_genes);
-
-  number_cells_expressing = _cells_histogram.size();
-  number_cells_detected_multiple = 0;
-  for (auto const& [cell, count] : _cells_histogram)
+  int number_cells_detected_multiple = 0;
+  for (auto const& [cell, count] : cells_histogram_)
     if (count > 1)
       number_cells_detected_multiple++;
+
+  metrics_outfile_ <<  ","  << number_cells_detected_multiple
+              <<  ","  << cells_histogram_.size()
+              << "\n";
 }
 
-void GeneMetrics::clear()
+void GeneMetricGatherer::clear()
 {
-  // call the clear function in the parent class
-  Metrics::clear();
-  number_cells_detected_multiple = 0;
-  number_cells_expressing = 0;
-  freeContainer(_cells_histogram);
+  clearCellAndGeneCommon();
+  cells_histogram_.clear();
 }

--- a/fastqpreprocessing/src/metricgatherer.h
+++ b/fastqpreprocessing/src/metricgatherer.h
@@ -3,7 +3,6 @@
 
 #include <unordered_map>
 #include <string>
-#include <regex>
 #include <iostream>
 #include <vector>
 #include <assert.h>
@@ -12,30 +11,13 @@
 #include <math.h>
 #include <unordered_set>
 
-enum class MetricType { Cell, Gene };
+#include "alignment_datatype.h"
+#include "tagsort_input_options.h"
 
-/*
-    Methods
-    -------
-    update(new_value: float)
-        incorporate new_value into the online estimate of mean and variance
-    getMean()
-        return the mean value
-    calculate_variance()
-        calculate and return the variance
-    mean_and_variance()
-        return both mean and variance
-*/
 class OnlineGaussianSufficientStatistic
 {
-private:
-  double _mean_squared_error = 0.0;
-  double sum_EX2 = 0.0;
-  double _mean = 0.0;
-  double _sum = 0.0;
-  double _count = 0.0;
-
 public:
+  // incorporates new_value into the online estimate of mean and variance
   void update(double new_value)
   {
     _count += 1.0;
@@ -51,7 +33,7 @@ public:
   }
 
   // calculate and return the variance
-  double calculate_variance()
+  double calculateVariance()
   {
     if (_count < 2)
       return -1.0;
@@ -66,67 +48,37 @@ public:
     _sum = 0;
     sum_EX2 = 0.0;
   }
+
+private:
+  double _mean_squared_error = 0.0;
+  double sum_EX2 = 0.0;
+  double _mean = 0.0;
+  double _sum = 0.0;
+  double _count = 0.0;
 };
 
-class Metrics
+// Base class for recording metrics from a stream of (sorted-by-tag-triple)
+// alignment lines.
+class MetricGatherer
 {
-private:
-  // count information
-  int n_reads = 0;
-  const int noise_reads = 0; //# long polymers, N-sequences; NotImplemented
+public:
+  MetricGatherer(std::string metric_output_file);
+  virtual ~MetricGatherer();
 
-  std::unordered_map<std::string, int> _fragment_histogram;
-  std::unordered_map<std::string, int> _molecule_histogram;
-
-  // molecule information
-  OnlineGaussianSufficientStatistic _molecule_barcode_fraction_bases_above_30;
-
-  int perfect_molecule_barcodes = 0;
-
-  OnlineGaussianSufficientStatistic _genomic_reads_fraction_bases_quality_above_30;
-
-  OnlineGaussianSufficientStatistic _genomic_read_quality;
-
-  // alignment location information
-  int reads_mapped_exonic = 0;
-  int reads_mapped_intronic = 0;
-  int reads_mapped_utr = 0;
-
-  // in future we can implement this when we have a gene model
-  // self.reads_mapped_outside_window = 0  # reads should be within 1000 bases of UTR
-  // self._read_distance_from_termination_site = OnlineGaussianSufficientStatistic()
-
-  // alignment uniqueness information
-  int reads_mapped_uniquely = 0;
-  int reads_mapped_multiple = 0;
-  int duplicate_reads = 0;
-
-  // alignment splicing information
-  int spliced_reads = 0;
-  int antisense_reads = 0;
-  int plus_strand_reads = 0;  // strand balance
-
-  // higher-order methods, filled in by finalize() when all data is extracted
-  float molecule_barcode_fraction_bases_above_30_mean = -1;
-  float molecule_barcode_fraction_bases_above_30_variance = -1;
-  float genomic_reads_fraction_bases_quality_above_30_mean = -1;
-  float genomic_reads_fraction_bases_quality_above_30_variance = -1;
-  float genomic_read_quality_mean = -1;
-  float genomic_read_quality_variance  = -1;
-  float n_molecules = -1;
-  float n_fragments = -1;
-  float reads_per_molecule = -1;
-  float reads_per_fragment = -1;
-  float fragments_per_molecule = -1;
-  int fragments_with_single_read_evidence = -1;
-  int molecules_with_single_read_evidence = -1;
-
-  // TODO separate these 2 out from the above, all of which gets clear()d
-  std::string prev_tag;
-  char* record[20];
+  virtual void ingestLine(std::string const& str) = 0;
+  virtual void outputMetricsLine() = 0;
 
 protected:
-  std::string common_headers[24] =
+  // Each line of metric output is built from all alignments with a given tag.
+  // After that output is written, the gatherer resets its recording state for
+  // the next group. This function does that.
+  virtual void clear() = 0;
+  bool cellAndGeneIsItTimeToOutput(std::string const& first_tag);
+  void ingestLineCellAndGeneCommon(LineFields const& fields);
+  void outputMetricsLineCellAndGeneCommon();
+  void clearCellAndGeneCommon();
+
+  const std::string kCommonHeaders[24] =
   {
     "n_reads",
     "noise_reads",
@@ -154,55 +106,75 @@ protected:
     "molecules_with_single_read_evidence"
   };
 
+  void parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags);
 
-public:
-  virtual ~Metrics() {}
-  //  get the headers
-  virtual std::string getHeader() = 0;
+  std::unordered_map<std::string, int> molecule_histogram_;
+  std::ofstream metrics_outfile_;
 
-  void parse_line(std::string& str, std::ofstream& fmetric_out,
-                  std::unordered_set<std::string>& mitochondrial_genes,
-                  MetricType metric_type);
+  std::string prev_tag_;
 
-  void output_metrics(std::ofstream& fmetric_out);
-  virtual void output_metrics_extra(std::ofstream& fmetric_out) = 0;
-  virtual void parse_extra_fields(const std::string& first_tag,
-                                  const std::string& second_tag,
-                                  const std::string& third_tag,
-                                  char** record) = 0;
-  virtual void finalize(std::unordered_set<std::string>& mitochondrial_genes);
-  virtual void clear();
+private:
+  // count information
+  int n_reads_ = 0;
+  const int noise_reads = 0; //# long polymers, N-sequences; NotImplemented
+
+  std::unordered_map<std::string, int> fragment_histogram_;
+
+  // molecule information
+  OnlineGaussianSufficientStatistic molecule_barcode_fraction_bases_above_30_;
+
+  int perfect_molecule_barcodes_ = 0;
+
+  OnlineGaussianSufficientStatistic genomic_reads_fraction_bases_quality_above_30_;
+
+  OnlineGaussianSufficientStatistic genomic_read_quality_;
+
+  // alignment location information
+  int reads_mapped_exonic_ = 0;
+  int reads_mapped_intronic_ = 0;
+  int reads_mapped_utr_ = 0;
+
+  // in future we can implement this when we have a gene model
+  // self.reads_mapped_outside_window = 0  # reads should be within 1000 bases of UTR
+  // self._read_distance_from_termination_site = OnlineGaussianSufficientStatistic()
+
+  // alignment uniqueness information
+  int reads_mapped_uniquely_ = 0;
+  int reads_mapped_multiple_ = 0;
+  int duplicate_reads_ = 0;
+
+  // alignment splicing information
+  int spliced_reads_ = 0;
+  const int kAntisenseReads = 0; // TODO is never changed from 0
+  // int plus_strand_reads_ = 0;  // strand balance (currently unused)
 };
 
-class CellMetrics: public Metrics
+class CellMetricGatherer: public MetricGatherer
 {
-private:
-  int perfect_cell_barcodes; // The number of reads whose cell barcodes contain no errors (tag ``CB`` == ``CR``)
-  int reads_mapped_intergenic; // The number of reads mapped to an intergenic region for this cell
+public:
+  CellMetricGatherer(std::string metric_output_file,
+                     std::string gtf_file,
+                     std::string mitochondrial_gene_names_filename);
+  void ingestLine(std::string const& str) override;
+  void outputMetricsLine() override;
 
-  // reads unmapped
-  int reads_unmapped;
+protected:
+  void clear() override;
+
+private:
+  std::unordered_set<std::string> mitochondrial_genes_;
+
+  int perfect_cell_barcodes_ = 0; // The number of reads whose cell barcodes contain no errors (tag ``CB`` == ``CR``)
+  int reads_mapped_intergenic_ = 0; // The number of reads mapped to an intergenic region for this cell
+
+  int reads_unmapped_ = 0;
+
   //  The number of reads that were mapped to too many loci across the genome and as a
   //  consequence, are reported unmapped by the aligner
-  int reads_mapped_too_many_loci;
+  const int kReadsMappedTooManyLoci = 0; // TODO is never changed from 0
 
-  // The variance of the fraction of Illumina base calls for the cell barcode sequence that
-  // are greater than 30, across molecules
-  float cell_barcode_fraction_bases_above_30_variance;
-
-  // The average fraction of Illumina base calls for the cell barcode sequence that
-  // are greater than 30, across molecules
-  float cell_barcode_fraction_bases_above_30_mean;
-
-  int n_genes;  //The number of genes detected by this cell
-
-  int genes_detected_multiple_observations; // The number of genes that are observed by more than one read in this cell
-  int n_mitochondrial_genes; // The number of mitochondrial genes detected by this cell
-  int n_mitochondrial_molecules; // The number of molecules from mitochondrial genes detected for this cell
-  int pct_mitochondrial_molecules; // The percentage of molecules from mitoc
-
-  OnlineGaussianSufficientStatistic _cell_barcode_fraction_bases_above_30;
-  std::unordered_map<std::string, int> _genes_histogram;
+  OnlineGaussianSufficientStatistic cell_barcode_fraction_bases_above_30_;
+  std::unordered_map<std::string, int> genes_histogram_;
 
   std::string cell_specific_headers[11] =
   {
@@ -210,7 +182,11 @@ private:
     "reads_mapped_intergenic",
     "reads_unmapped",
     "reads_mapped_too_many_loci",
+    // The variance of the fraction of Illumina base calls for the cell barcode
+    // sequence that are greater than 30, across molecules
     "cell_barcode_fraction_bases_above_30_variance",
+    // The average fraction of Illumina base calls for the cell barcode sequence
+    // that are greater than 30, across molecules
     "cell_barcode_fraction_bases_above_30_mean",
     "n_genes",
     "genes_detected_multiple_observations",
@@ -218,51 +194,28 @@ private:
     "n_mitochondrial_molecules",
     "pct_mitochondrial_molecules"
   };
-
-public:
-  std::string getHeader() override;
-  void output_metrics_extra(std::ofstream& fmetric_out) override;
-  void parse_extra_fields(const std::string& first_tag,
-                          const std::string& second_tag,
-                          const std::string& third_tag,
-                          char** record) override;
-
-  void finalize(std::unordered_set<std::string>& mitochondrial_genes);
-
-  void clear();
 };
 
 
-class GeneMetrics: public Metrics
+class GeneMetricGatherer: public MetricGatherer
 {
-private:
-  int number_cells_detected_multiple;
-  int number_cells_expressing;
+public:
+  GeneMetricGatherer(std::string metric_output_file);
 
-  std::unordered_map<std::string, int> _cells_histogram;
+  void ingestLine(std::string const& str) override;
+
+  void outputMetricsLine() override;
+
+protected:
+  void clear() override;
+
+private:
+  std::unordered_map<std::string, int> cells_histogram_;
   std::string gene_specific_headers[2] =
   {
     "number_cells_detected_multiple",
     "number_cells_expressing"
   };
-
-public:
-  GeneMetrics()
-  {
-    number_cells_detected_multiple = 0;
-    number_cells_expressing = 0;
-  }
-
-public:
-  std::string getHeader() override;
-  void output_metrics_extra(std::ofstream& fmetric_out) override;
-  void parse_extra_fields(std::string const& first_tag,
-                          std::string const& second_tag,
-                          std::string const& third_tag,
-                          char** record) override;
-
-  void finalize(std::unordered_set<std::string>& mitochondrial_genes);
-  void clear();
 };
 
 #endif

--- a/fastqpreprocessing/src/mitochondrial_gene_selector.cpp
+++ b/fastqpreprocessing/src/mitochondrial_gene_selector.cpp
@@ -1,0 +1,135 @@
+#include "mitochondrial_gene_selector.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "tagsort_input_options.h"
+
+std::vector<std::string> splitStringToFields(std::string const& str, char delim)
+{
+  std::stringstream splitter(str);
+  std::vector<std::string> ret;
+  for (std::string field; std::getline(splitter, field, delim); )
+    ret.push_back(field);
+  return ret;
+}
+
+inline std::string ltrim(std::string& s)
+{
+  auto it = std::find_if_not(s.begin(), s.end(), [](int c) { return isspace(c); });
+  s.erase(s.begin(), it);
+  return s;
+}
+
+// remove the " (quotes) from the beginning and end of the string (TODO also
+// removes from the middle; hopefully nobody is trying to use escaped quotes).
+std::string removeQuotes(std::string& s)
+{
+  s.erase(std::remove_if(s.begin(), s.end(), [](unsigned char c)
+  {
+    return c=='\"';
+  }), s.end());
+  return s;
+}
+
+class MitochondrialGeneSelector
+{
+public:
+  MitochondrialGeneSelector(std::string const& mitochondrial_gene_names_filename)
+  {
+    if (mitochondrial_gene_names_filename.empty())
+    {
+      default_old_behavior_ = true;
+      return;
+    }
+
+    std::ifstream input_file(mitochondrial_gene_names_filename);
+    if (!input_file)
+    {
+      crash("ERROR failed to open the mitochondrial gene names file named: " +
+            mitochondrial_gene_names_filename);
+    }
+    for (std::string line; std::getline(input_file, line);)
+    {
+      if (line.empty() || line[0] == '#') // skip comment lines
+        continue;
+      mito_genes_.insert(line);
+    }
+  }
+
+  bool interestedInGeneName(std::string const& gene_name)
+  {
+    if (default_old_behavior_)
+    {
+      return (gene_name.size() >= 3 && tolower(gene_name[0]) == 'm' &&
+              tolower(gene_name[1]) == 't' && gene_name[2] == '-');
+    }
+    return mito_genes_.find(gene_name) != mito_genes_.end();
+  }
+
+private:
+  bool default_old_behavior_ = false;
+  std::unordered_set<std::string> mito_genes_;
+};
+
+// The file at gtf_filename should be unzipped.
+std::unordered_set<std::string> getInterestingMitochondrialGenes(
+    std::string const& gtf_filename,
+    std::string const& mitochondrial_gene_names_filename)
+{
+  std::unordered_set<std::string> mitochondrial_gene_ids;
+
+  MitochondrialGeneSelector gene_selector(mitochondrial_gene_names_filename);
+
+  std::ifstream input_file(gtf_filename);
+  if (!input_file)
+    crash("ERROR failed to open the GTF file named: " + gtf_filename);
+
+  for (std::string line; std::getline(input_file, line);)
+  {
+    if (line.empty() || line[0] == '#') // skip comment lines
+      continue;
+
+    std::vector<std::string> tabbed_fields = splitStringToFields(line, '\t');
+    if (tabbed_fields.size() <= 8)
+      crash("Expected at least 9 tabbed fields, got " + std::to_string(tabbed_fields.size()));
+    if (tabbed_fields[2] != "gene") // skip the line unless it is a gene
+      continue;
+    // split the semicolon-separated attributes field
+    std::vector<std::string> attribs = splitStringToFields(tabbed_fields[8], ';');
+
+    std::string gene_name;
+    std::string gene_id;
+    // now examine each of the attribute name-value pairs
+    for (std::string attrib : attribs)
+    {
+      // each attribute is a space-separated key-value pair
+      std::vector<std::string> key_and_val = splitStringToFields(ltrim(attrib), ' ');
+      if (key_and_val.size() != 2)
+        crash("Expected 2 fields, found " + std::to_string(key_and_val.size()) + " fields");
+
+      // the second element in the pair is the value string
+      std::string& key = key_and_val[0];
+      std::string value = removeQuotes(key_and_val[1]);
+
+      if (key == "gene_id")
+        gene_id = value;
+      if (key == "gene_name")
+        gene_name = value;
+    }
+    if (gene_name.empty())
+    {
+      crash("Malformed GTF file detected. Record is of type gene but does not "
+            "have a gene_name in line:\n" + line);
+    }
+
+    if (gene_selector.interestedInGeneName(gene_name))
+      mitochondrial_gene_ids.insert(gene_id); // TODO what if gene_id is empty?
+  }
+  std::cout << "Number of mitochondrial genes found " << mitochondrial_gene_ids.size() << std::endl;
+  return mitochondrial_gene_ids;
+}

--- a/fastqpreprocessing/src/mitochondrial_gene_selector.h
+++ b/fastqpreprocessing/src/mitochondrial_gene_selector.h
@@ -1,0 +1,12 @@
+#ifndef FASTQPREPROCESSING_MITOCHONDRIAL_GENE_SELECTOR_H_
+#define FASTQPREPROCESSING_MITOCHONDRIAL_GENE_SELECTOR_H_
+
+#include <string>
+#include <unordered_set>
+
+// The file at gtf_filename should be unzipped.
+std::unordered_set<std::string> getInterestingMitochondrialGenes(
+    std::string const& gtf_filename,
+    std::string const& mitochondrial_gene_names_filename);
+
+#endif // FASTQPREPROCESSING_MITOCHONDRIAL_GENE_SELECTOR_H_

--- a/fastqpreprocessing/src/tagsort.cpp
+++ b/fastqpreprocessing/src/tagsort.cpp
@@ -1,435 +1,171 @@
 #include <algorithm>
-#include <cassert>
-#include <cctype>
-#include <chrono>
 #include <fstream>
 #include <queue>
-#include <regex>
 #include <string>
-#include <sstream>
-#include <unordered_set>
 
 #include "htslib_tagsort.h"
 #include "metricgatherer.h"
 
-constexpr int kDataBufferSize = 1000;
+constexpr int kLinesToReadInAChunk = 1000;
 
-struct Context
-{
-  std::vector<std::vector<std::string>> data;
-
-  std::vector<long int> file_offset;
-  std::vector<int> data_size;
-  std::vector<int> ptrs;
-  std::vector<bool> isempty;
-  int index_ = -1;
-  int num_active_files = 0;
-  const int num_parts_;
-
-  Context(unsigned int num_parts) : num_parts_(num_parts)
-  {
-    // set the file offsets to 0
-    for (int i=0; i < num_parts_; i++)
-      file_offset.push_back(0);
-
-    // set the isempty for each file to false
-    for (int i=0; i < num_parts_; i++)
-      isempty.push_back(false);
-
-    // set a vector of vectors of data for each file
-    for (int i=0; i < num_parts_; i++)
-      data.push_back(std::vector<std::string>());
-
-    // set the data_size of the buffer for each file to 0
-    for (int i=0; i < num_parts_; i++)
-      data_size.push_back(0);
-
-    // set the pointer to f each buffer to kDataBufferSize
-    for (int i=0; i < num_parts_; i++)
-      ptrs.push_back(kDataBufferSize);
-  }
-
-  void print_status()
-  {
-    std::cout << "Contx status " << std::endl;
-    for (int i=0; i < num_parts_; i++)
-    {
-      index_ = i;
-      std::cout << "\t" << index_ << "\t" << data[index_].size() << "\t"
-                << data_size[index_] << "\t" << ptrs[index_] << std::endl;
-    }
-  }
-
-  void clear()
-  {
-    data_size.clear();
-    ptrs.clear();
-    isempty.clear();
-  }
-};
-
-using QUEUETUPLE = std::tuple<std::string, int, int>;
-
-inline std::string ltrim(std::string& s)
-{
-  auto it = find_if_not(s.begin(), s.end(), [](int c) { return isspace(c); });
-  s.erase(s.begin(), it);
-  return s;
-}
-
-// remove the " (quotes) from the beginning and end of the string
-// (TODO and the middle; hopefully nobody is trying to use escaped quotes).
-std::string removeQuotes(std::string& s)
-{
-  s.erase(std::remove_if(s.begin(), s.end(), [](unsigned char c)
-  {
-    return c=='\"';
-  }), s.end());
-  return s;
-}
-
-std::vector<std::string> splitStringToFields(std::string const& str, char delim)
-{
-  std::stringstream splitter(str);
-  std::vector<std::string> ret;
-  for (std::string field; std::getline(splitter, field, delim); )
-    ret.push_back(field);
-  return ret;
-}
-
-class MitochondrialGeneSelector
+// Hands you lines one at a time from a file, reading in nice big efficient
+// chunks whenever necessary.
+class PartialFile
 {
 public:
-  MitochondrialGeneSelector(std::string const& mitochondrial_gene_names_filename)
+  PartialFile(std::string const& filename) : file_(filename)
   {
-    if (mitochondrial_gene_names_filename.empty())
-    {
-      default_old_behavior_ = true;
-      return;
-    }
-
-    std::ifstream input_file(mitochondrial_gene_names_filename);
-    if (!input_file)
-    {
-      crash("ERROR failed to open the mitochondrial gene names file named: " +
-            mitochondrial_gene_names_filename);
-    }
-    for (std::string line; std::getline(input_file, line);)
-    {
-      if (line.empty() || line[0] == '#') // skip comment lines
-        continue;
-      mito_genes_.insert(line);
-    }
+    if (!file_)
+      crash("ERROR failed to open the file " + filename);
+    fillBuffer();
   }
 
-  bool interestedInGeneName(std::string const& gene_name)
+  bool stillHasData()
   {
-    if (default_old_behavior_)
-      return std::regex_search(gene_name, std::regex("^mt-", std::regex_constants::icase));
-    else
-      return mito_genes_.find(gene_name) != mito_genes_.end();
+    if (sorted_.empty())
+      fillBuffer();
+    return !sorted_.empty();
+  }
+
+  // It is expected that you call stillHasData() immediately before every call
+  // of takeNext(), to keep PartialFile's internal buffer populated.
+  std::string takeNext()
+  {
+    std::string ret = sorted_.front();
+    sorted_.pop();
+    return ret;
   }
 
 private:
-  bool default_old_behavior_ = false;
-  std::unordered_set<std::string> mito_genes_;
+  void fillBuffer()
+  {
+    int alignments_filled = 0;
+    std::string line;
+    while (std::getline(file_, line))
+    {
+      sorted_.push(line);
+      if (++alignments_filled >= kLinesToReadInAChunk)
+        break;
+    }
+  }
+
+  std::ifstream file_;
+  std::queue<std::string> sorted_;
 };
 
-// TODO function is named "get gene names", and there is something in there called
-//      "gene name", but it instead returns a set of "gene id"s. correct?
-//
-// The file at gtf_filename should be unzipped.
-std::unordered_set<std::string> get_mitochondrial_gene_names(
-    std::string const& gtf_filename, std::string const& mitochondrial_gene_names_filename)
+// Helper class for merging several sorted lists into one, using
+// std::priority_queue to keep track of which item to merge next.
+class Merger
 {
-  std::unordered_set<std::string> mitochondrial_gene_ids;
+public:
+  Merger() : heap_(greater_than_) {}
 
-  MitochondrialGeneSelector gene_selector(mitochondrial_gene_names_filename);
-
-  std::ifstream input_file(gtf_filename);
-  if (!input_file)
-    crash("ERROR failed to open the GTF file named: " + gtf_filename);
-
-  for (std::string line; std::getline(input_file, line);)
+  // returns the appropriate next item, and an index into your PartialFile
+  // array, from which you should giveInput() the next item into this Merger.
+  // (If that PartialFile is now out of data, then you don't have to call
+  //  giveInput() this time).
+  std::pair<std::string, int> receiveNextOutput()
   {
-    if (line.empty() || line[0] == '#') // skip comment lines
-      continue;
-
-    std::vector<std::string> tabbed_fields = splitStringToFields(line, '\t');
-    assert(tabbed_fields.size() > 8);
-    if (tabbed_fields[2] != "gene") // skip the line unless it is a gene
-      continue;
-    // split the semicolon-separated attributes field
-    std::vector<std::string> attribs = splitStringToFields(tabbed_fields[8], ';');
-
-    std::string gene_name;
-    std::string gene_id;
-    // now examine each of the attribute name-value pairs
-    for (std::string attrib : attribs)
-    {
-      // each attribute is a space-separated key-value pair
-      std::vector<std::string> key_and_val = splitStringToFields(ltrim(attrib), ' ');
-      if (key_and_val.size() != 2)
-        crash("Expected 2 fields, found " + std::to_string(key_and_val.size()) + " fields");
-
-      // the second element in the pair is the value string
-      std::string& key = key_and_val[0];
-      std::string value = removeQuotes(key_and_val[1]);
-
-      if (key == "gene_id")
-        gene_id = value;
-      if (key == "gene_name")
-        gene_name = value;
-    }
-    if (gene_name.empty())
-    {
-      crash("Malformed GTF file detected. Record is of type gene but does not "
-            "have a gene_name in line:\n" + line);
-    }
-
-    if (gene_selector.interestedInGeneName(gene_name))
-      mitochondrial_gene_ids.insert(gene_id); // TODO what if gene_id is empty?
+    auto ret = heap_.top();
+    heap_.pop();
+    return ret;
   }
-  std::cout << "Number of mitochondrial genes found " << mitochondrial_gene_ids.size() << std::endl;
-  return mitochondrial_gene_ids;
-}
 
+  void giveInput(std::string input, int src_file_ind)
+  {
+    heap_.emplace(input, src_file_ind);
+  }
 
-/*
- * @brief fills the buffer for the files
- *
- * @param contx is the context of the file
- * @return int number of alignments processed
-*/
-int fill_buffer(Context& contx, std::vector<std::string> const& partial_files)
+  bool empty() const { return heap_.empty(); }
+
+private:
+  std::function<bool(std::pair<std::string, int> const&,
+                     std::pair<std::string, int> const&)>
+      greater_than_ =
+          [](std::pair<std::string, int> const& a,
+             std::pair<std::string, int> const& b)
+          {
+            return a.first > b.first;
+          };
+
+  std::priority_queue<std::pair<std::string, int>,
+                      std::vector<std::pair<std::string, int>>,
+                      decltype(greater_than_) > heap_;
+};
+
+std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT const& options)
 {
-  contx.data[contx.index_].clear();
-  int k = 0;
-  int filling_counter = 0;
+  if (!options.compute_metric)
+    return nullptr;
 
-  std::ifstream input_file(partial_files[contx.index_]);
-  if (!input_file)
-    crash("ERROR failed to open the file " + partial_files[contx.index_]);
-
-  input_file.seekg(contx.file_offset[contx.index_]);
-
-  // the order of the loop condition is iportant first make sure if you can accomodate then try to read,
-  // otherwise it might create a read but never processed
-  for (std::string line; k < kDataBufferSize && std::getline(input_file, line); k++)
+  if (options.metric_type == MetricType::Cell)
   {
-    contx.data[contx.index_].push_back(line);
-    filling_counter++;
+    return std::make_unique<CellMetricGatherer>(
+        options.metric_output_file, options.gtf_file,
+        options.mitochondrial_gene_names_filename);
   }
-  assert(contx.data[contx.index_].size() <= kDataBufferSize);
-
-  contx.file_offset[contx.index_] = input_file.tellg();
-
-  contx.data_size[contx.index_] = contx.data[contx.index_].size();
-
-  if (contx.data_size[contx.index_] != 0)
-  {
-    contx.ptrs[contx.index_] = 0;
-    contx.isempty[contx.index_] = false;
-  }
+  else if (options.metric_type == MetricType::Gene)
+    return std::make_unique<GeneMetricGatherer>(options.metric_output_file);
   else
-  {
-    contx.ptrs[contx.index_] = kDataBufferSize;
-    contx.isempty[contx.index_] = true;
-  }
-
-#ifdef DEBUG
-  std::cout << "-->" << std::endl;
-  for (int m = 0; m < contx.num_parts_; m++)
-    std::cout << "\t" << m << " : " << contx.data_size[m] << " : " << contx.ptrs[m] << std::endl;
-#endif
-
-  return filling_counter;
-}
-
-// TODO if after other refactoring this ends up being the only regex use, then
-//      probably would be worth switching away from regex here.
-// From e.g. "A\tB\tC\tD\tE", extract "A\tB\tC"
-std::string extractCompTag(std::string& s)
-{
-  const std::regex rgx("\t");
-  const std::sregex_token_iterator end;
-  std::sregex_token_iterator iter(s.begin(), s.end(), rgx, -1);
-  std::stringstream comp_tag;
-  for (auto k = 0; k < 3 && iter != end; ++iter, k++)
-  {
-    if (k > 0)
-      comp_tag << "\t";
-    comp_tag << *iter;
-  }
-  return comp_tag.str();
+    crash("new MetricType enum value is not yet handled by MetricGatherer!");
+  return nullptr;
 }
 
 // returns number of alignments processed
-int mergeSortedPartialFiles(INPUT_OPTIONS_TAGSORT const& options,
-                            std::vector<std::string> const& partial_files)
+int mergePartialFiles(INPUT_OPTIONS_TAGSORT const& options,
+                      std::vector<std::string> const& partial_files)
 {
-  const std::string& sorted_output_file = options.sorted_output_file;
-  const std::string& metric_type  = options.metric_type;
-  const std::string& metric_output_file = options.metric_output_file;
-  int filling_counter = 0;
-
-  std::unordered_set<std::string> mitochondrial_genes;
-  if (!options.gtf_file.empty())
-  {
-    mitochondrial_genes = get_mitochondrial_gene_names(
-        options.gtf_file, options.mitochondrial_gene_names_filename);
-  }
-
-  // input the buffer size and partial files
-  Context contx(partial_files.size());
-  auto cmp = [](const QUEUETUPLE &a, const  QUEUETUPLE &b)
-  {
-    return std::get<0>(a) > std::get<0>(b);
-  };
-  std::priority_queue<QUEUETUPLE, std::vector<QUEUETUPLE>,  decltype(cmp) > heap(cmp);
-
-  for (int i=0; i < contx.num_parts_; i++)
-  {
-    contx.index_ = i;
-    filling_counter += fill_buffer(contx, partial_files);
-  }
-
-  // create the heap from the first batch loaded data
-  contx.num_active_files = 0;
-  for (int i=0; i< contx.num_parts_; i++)
-  {
-    contx.index_ = i;
-    if (contx.ptrs[i] != kDataBufferSize)
-    {
-      heap.push(QUEUETUPLE(extractCompTag(contx.data[i][contx.ptrs[i]]), i, contx.ptrs[i]));
-      contx.ptrs[i]++;
-      contx.num_active_files += 1;
-    }
-  }
-
-  //  now merge by pop an push
-  std::ofstream fout;
-  if (options.compute_metric) // TODO i think this is a mistake, and should actually be options.output_sorted_info
-    fout.open(sorted_output_file);
-
-  // pop and push from the heap
   int num_alignments = 0;
-  int i, j;
 
-  Metrics* metric_gatherer = nullptr;
-  MetricType metric_type_enum = MetricType::Cell;
-  if (metric_type.compare("cell")==0)
-  {
-    metric_gatherer = new CellMetrics;
-    metric_type_enum = MetricType::Cell;
-  }
-  else if (metric_type.compare("gene")==0)
-  {
-    metric_gatherer = new GeneMetrics;
-    metric_type_enum = MetricType::Gene;
-  }
-  else
-    crash("Expected metric_type 'cell' or 'gene', got: " + metric_type);
+  std::unique_ptr<MetricGatherer> metric_gatherer = maybeMakeMetricGatherer(options);
 
-  metric_gatherer->clear();
-
-  std::ofstream fmetric_out;
-  if (options.compute_metric)
+  std::ofstream sorted_outfile;
+  if (options.output_sorted_info)
   {
-    fmetric_out.open(metric_output_file.c_str());
-    fmetric_out << metric_gatherer->getHeader() << std::endl;
+    sorted_outfile.open(options.sorted_output_file);
+    if (!sorted_outfile)
+      crash("Failed to open for writing " + options.sorted_output_file);
   }
 
-  // TODO just write directly to fout... don't think the 'binary' is significant,
-  //      but not 100% sure
-  std::stringstream str(std::stringstream::out | std::stringstream::binary);
-  std::string prev_comp_tag = "";
-  while (!heap.empty())
+  // We are going to merge the contents of each of these into a single sorted file.
+  std::vector<PartialFile> sorted_partial_files;
+  for (std::string const& fname : partial_files)
+    sorted_partial_files.emplace_back(fname);
+
+  // We use a heap to track which item to put into the final sorted file next:
+  // we start it with one item from each input file.
+  Merger merger;
+  for (int i = 0; i < sorted_partial_files.size(); i++)
+    if (sorted_partial_files[i].stillHasData())
+      merger.giveInput(sorted_partial_files[i].takeNext(), i);
+
+  while (!merger.empty())
   {
-    // read the top
-    QUEUETUPLE qtuple = heap.top();
-    std::string curr_comp_tag = std::get<0>(qtuple);
-    assert(prev_comp_tag.compare(curr_comp_tag) <= 0);
+    // 'line' is the next item to go to the sorted file.
+    auto [line, i] = merger.receiveNextOutput();
 
-#ifdef DEBUG
-    contx.print_status();
-    if (prev_comp_tag.compare(curr_comp_tag) <= 0)
-      std::cout << "Expected " << prev_comp_tag << "\n\t\t" << curr_comp_tag << std::endl;
-    else
-      crash("Anomaly " + prev_comp_tag + "\n\t\t" + curr_comp_tag);
-#endif
-    i = std::get<1>(qtuple);  //buffer no
-    j = std::get<2>(qtuple);  //the pointer into the ith buffer array
-
-    heap.pop();
-
-    // start writing in chunks from the stream buffer
-    if (num_alignments%kDataBufferSize==0)
-    {
-      if (options.output_sorted_info)
-      {
-        fout.write(str.str().c_str(), str.str().length());
-        str.clear();
-        str.str("");
-      }
-    }
-
-    // load into stream buffer
-    std::string field  = contx.data[i][j];
     if (options.output_sorted_info)
-      str << field << std::endl;
+      sorted_outfile << line << "\n";
+    if (metric_gatherer)
+      metric_gatherer->ingestLine(line);
+    num_alignments++;
 
-    if (options.compute_metric)
-      metric_gatherer->parse_line(field, fmetric_out, mitochondrial_genes, metric_type_enum);
-    num_alignments += 1;
-
-    // if ismpty is true means the file has been fully read
-    if (!contx.isempty[i] && contx.ptrs[i] == contx.data_size[i])
-    {
-      contx.index_ = i;
-      filling_counter += fill_buffer(contx, partial_files);
-    }
-
-    // make sure it is not empty
-    if (contx.data_size[i] > 0)
-    {
-      heap.push(QUEUETUPLE(extractCompTag(contx.data[i][contx.ptrs[i]]), i, contx.ptrs[i]));
-      contx.ptrs[i]++;
-    }
-    else     // one more file is fully read
-      contx.num_active_files -= 1;
-
-    if (num_alignments % 1000000 == 0)
-      std::cout << "num alns read " << num_alignments << std::endl;
-
-    prev_comp_tag = curr_comp_tag;
+    // Now that 'line' has been removed from the heap, it needs to be replaced
+    // with another item from the same file (i) that it came from.
+    // (If file i is out of data, then we don't need to replace).
+    if (sorted_partial_files[i].stillHasData())
+      merger.giveInput(sorted_partial_files[i].takeNext(), i);
   }
 
-  // process the final line
-  metric_gatherer->finalize(mitochondrial_genes);
-  metric_gatherer->output_metrics(fmetric_out);
-  metric_gatherer->output_metrics_extra(fmetric_out);
-  delete metric_gatherer;
+  if (metric_gatherer)
+    metric_gatherer->outputMetricsLine(); // will have a final line of output waiting
 
-  // close the metric file
-  if (options.compute_metric)
-    fmetric_out.close();
-
-  // write out the remaining data
   if (options.output_sorted_info)
   {
-    fout.write(str.str().c_str(), str.str().length());
-    str.str("");
-    str.clear();
+    std::cout << "Wrote "<< num_alignments << " alignments in sorted order to "
+              << options.sorted_output_file << std::endl;
   }
-
-  // close output files as there is no more to write
-  if (options.output_sorted_info)
-    fout.close();
-
-  std::cout << "Written "<< num_alignments << " alignments in total" << std::endl;
-  contx.clear();
-  return filling_counter;
+  return num_alignments;
 }
 
 void warnIfNo_mitochondrial_gene_names_filename(INPUT_OPTIONS_TAGSORT const& options)
@@ -446,7 +182,6 @@ void warnIfNo_mitochondrial_gene_names_filename(INPUT_OPTIONS_TAGSORT const& opt
   }
 }
 
-/* Flag set by ‘--verbose’. */
 int main(int argc, char** argv)
 {
   INPUT_OPTIONS_TAGSORT options = readOptionsTagsort(argc, argv);
@@ -454,30 +189,25 @@ int main(int argc, char** argv)
 
   std::cout << "bam input " << options.bam_input << std::endl;
   std::cout << "temp folder " << options.temp_folder << std::endl;
-  std::cout << "sorted output file " <<  options.sorted_output_file << std::endl;
-  std::cout << "metric output file " <<  options.metric_output_file << std::endl;
+  std::cout << "sorted output file " << options.sorted_output_file << std::endl;
+  std::cout << "metric output file " << options.metric_output_file << std::endl;
   std::cout << "temp folder " << options.alignments_per_batch << std::endl;
   std::cout << "tags:" << std::endl;
 
   for (auto const& [tag, tag_order_num] : options.tag_order)
     std::cout << "\t" << tag << "\t" << tag_order_num << std::endl;
 
-  /* first create a list of sorted, and simplified sorted files */
-  std::vector<std::string> partial_files = create_sorted_file_splits_htslib(options);
-
-  /* now merge the sorted files to create one giant sorted file by using
-    a head to compare the values based on the tags used  */
-  std::cout << "Merging " <<  partial_files.size() << " sorted files!"<< std::endl;
-
-  int filling_counter = mergeSortedPartialFiles(options, partial_files);
+  // We first sort (by tag) several chunks of the data in parallel, written to
+  // temporary files, then merge them to one big final sorted file.
+  std::vector<std::string> partial_files = splitAndPartialSortToFiles(options);
+  std::cout << "Merging " << partial_files.size() << " sorted files!"<< std::endl;
+  int num_alignments = mergePartialFiles(options, partial_files);
+  std::cout << "Processed " << num_alignments << " alignments." << std::endl;
 
   // we no longer need the partial files
   for (unsigned int i=0; i < partial_files.size(); i++)
     if (remove(partial_files[i].c_str()) != 0)
       std::cerr << "Warning: error deleting file " << partial_files[i] << std::endl;
-
-  partial_files.clear();
-  std::cout << "Aligments " << filling_counter << " loaded to buffer " << std::endl;
 
   warnIfNo_mitochondrial_gene_names_filename(options);
   return 0;

--- a/fastqpreprocessing/src/tagsort_input_options.cpp
+++ b/fastqpreprocessing/src/tagsort_input_options.cpp
@@ -1,0 +1,220 @@
+#include "tagsort_input_options.h"
+
+#include <filesystem>
+#include <getopt.h>
+#include <iostream>
+#include <string>
+
+using std::string;
+
+void crash(string msg)
+{
+  std::cout << msg << std::endl;
+  std::cerr << msg << std::endl;
+  exit(1);
+}
+
+INPUT_OPTIONS_TAGSORT readOptionsTagsort(int argc, char** argv)
+{
+  INPUT_OPTIONS_TAGSORT options;
+  int c;
+  int i;
+
+  static struct option long_options[] =
+  {
+    /* These options set a flag. */
+    {"compute-metric",             no_argument,       0, 'm'},
+    {"output-sorted-info",         no_argument,       0, 'n'},
+    /* These options don’t set a flag.
+       We distinguish them by their indices. */
+    {"bam-input",                  required_argument, 0, 'b'},
+    {"gtf-file",                   required_argument, 0, 'a'},
+    {"temp-folder",                required_argument, 0, 't'},
+    {"sorted-output",              required_argument, 0, 'o'},
+    {"metric-output",              required_argument, 0, 'M'},
+    {"alignments-per-thread",      required_argument, 0, 'p'},
+    {"nthreads",                   required_argument, 0, 'T'},
+    {"barcode-tag",                required_argument, 0, 'C'},
+    {"umi-tag",                    required_argument, 0, 'U'},
+    {"gene-tag",                   required_argument, 0, 'G'},
+    {"metric-type",                required_argument, 0, 'K'},
+    {"mitochondrial-gene-names-filename", required_argument, 0, 'g'},
+    {0, 0, 0, 0}
+  };
+
+  // help messages when the user types -h
+  const char* help_messages[] =
+  {
+    "compute metric, metrics are computed if this option is provided [optional]",
+    "sorted output file is produced if this option is provided [optional]",
+    "input bam file [required]",
+    "gtf file (unzipped) required then metric type is cell [required with metric cell]",
+    "temp folder for disk sorting [options: default /tmp]",
+    "sorted output file [optional]",
+    "metric file, the metrics are output in this file  [optional]",
+    "number of alignments per thread [optional: default 1000000], if this number is increased then more RAM is required but reduces the number of file splits",
+    "number of threads [optional: default 1]",
+    "barcode-tag the call barcode tag [required]",
+    "umi-tag the umi tag [required]: the tsv file output is sorted according the tags in the options barcode-tag, umi-tag or gene-tag",
+    "gene-tag the gene tag [required]",
+    "metric type, either \"cell\" or \"gene\" [required]",
+    "file listing gene names, one per line, that the program should care about. [required, may omit if you want mouse or human]"
+  };
+
+  string metric_type_str;
+
+  /* getopt_long stores the option index here. */
+  int option_index = 0;
+  int curr_size = 0;
+  while ((c = getopt_long(argc, argv,
+                          "b:a:t:no:mM:p:T:C:U:G:K:",
+                          long_options,
+                          &option_index)) !=- 1)
+  {
+    // process the option or arguments
+    switch (c)
+    {
+    case 'm':
+      options.compute_metric = true;
+      break;
+    case 'n':
+      options.output_sorted_info = true;
+      break;
+    case 0:
+      /* If this option set a flag, do nothing else now. */
+      if (long_options[option_index].flag != 0)
+        break;
+      printf("option %s", long_options[option_index].name);
+      if (optarg)
+        printf(" with arg %s", optarg);
+      printf("\n");
+      break;
+    case 'b':
+      options.bam_input = string(optarg);
+      break;
+    case 'a':
+      options.gtf_file = string(optarg);
+      break;
+    case 't':
+      options.temp_folder = string(optarg);
+      break;
+    case 'o':
+      options.sorted_output_file = string(optarg);
+      break;
+    case 'M':
+      options.metric_output_file = string(optarg);
+      break;
+    case 'p':
+      options.alignments_per_batch = atoi(optarg);
+      break;
+    case 'T':
+      options.nthreads = atoi(optarg);
+      break;
+    case 'C':
+      options.barcode_tag = string(optarg);
+      curr_size = options.tag_order.size();
+      options.tag_order[string(optarg)] = curr_size;
+      break;
+    case 'U':
+      options.umi_tag = string(optarg);
+      curr_size = options.tag_order.size();
+      options.tag_order[string(optarg)] = curr_size;
+      break;
+    case 'G':
+      options.gene_tag = string(optarg);
+      curr_size = options.tag_order.size();
+      options.tag_order[string(optarg)] = curr_size;
+      break;
+    case 'K':
+      metric_type_str = string(optarg);
+      break;
+    case 'g':
+      options.mitochondrial_gene_names_filename = string(optarg);
+      break;
+    case '?':
+    case 'h':
+      i = 0;
+      printf("Usage: %s [options] \n", argv[0]);
+      while (long_options[i].name != 0)
+      {
+        printf("\t--%-20s  %-25s  %-35s\n", long_options[i].name,
+               long_options[i].has_arg == no_argument?
+               "no argument" : "required_argument",
+               help_messages[i]);
+        i = i + 1;
+      }
+      /* getopt_long already printed an error message. */
+      exit(0);
+      break;
+    default:
+      abort();
+    }
+  }
+
+  // Check the options
+  // either metric computation or the sorted tsv file must be produced
+  if (!options.output_sorted_info && !options.compute_metric)
+    crash("ERROR: The choice of either the sorted alignment info or metric computation must be specified");
+
+  if (options.compute_metric && options.metric_output_file.empty())
+    crash("ERROR: Must specify --metric-output when specifying --compute-metric");
+
+  if (options.output_sorted_info && options.sorted_output_file.empty())
+    crash("ERROR: Must specify --sorted-output when specifying --output-sorted-info");
+
+  if (metric_type_str == "cell")
+    options.metric_type = MetricType::Cell;
+  else if (metric_type_str == "gene")
+    options.metric_type = MetricType::Gene;
+  else
+    crash("ERROR: --metric-type must be \"cell\", \"gene\", or \"umi\"");
+
+  // if metric type is cell then the gtf file must be provided
+  if (options.metric_type == MetricType::Cell && options.gtf_file.empty())
+    crash("ERROR: The gtf file name must be provided with metric_type \"cell\"");
+
+  // the gtf file should not be gzipped
+  if (options.gtf_file.length() > 3)
+  {
+    int len = options.gtf_file.length();
+    string const& fname = options.gtf_file;
+    if (fname[len-3] == '.' && tolower(fname[len-2]) == 'g' && tolower(fname[len-1]) == 'z')
+      crash("ERROR: The gtf file must not be gzipped");
+  }
+
+  // bam input file must be there
+  if (options.bam_input.empty())
+    crash("ERROR: Must specify a input file name");
+
+  // check for input file
+  if (!std::filesystem::exists(options.bam_input.c_str()))
+    crash("ERROR: bam_input " + options.bam_input + " is missing!");
+
+  // check for the temp folder
+  if (!std::filesystem::exists(options.temp_folder.c_str()))
+    crash("ERROR: temp folder " + options.temp_folder + " is missing!");
+
+  // check for three distinct tags, barcode, umi and gene_id tags
+  if (options.tag_order.size() != 3)
+    crash("ERROR:  Must have three distinct tags");
+  bool seen_tag_index[3] = { false, false, false };
+  for (auto [tag, index] : options.tag_order)
+  {
+    if (index < 0 || index > 2)
+      crash("Invalid tag index " + std::to_string(index) + "; must be 0 1 or 2");
+    else
+      seen_tag_index[index] = true;
+  }
+  if (!(seen_tag_index[0] && seen_tag_index[1] && seen_tag_index[2]))
+    crash("Need tag indices 0 1 and 2");
+
+  // The size of a set of aligments for in-memory sorting must be positive
+  if (options.alignments_per_batch < 1000)
+    crash("ERROR: The number of alignments per thread must be at least 1000");
+
+  // The number of threads must be between 1 and kMaxTagsortThreads
+  if (options.nthreads > kMaxTagsortThreads || options.nthreads < 1)
+    crash("ERROR: The number of threads must be between 1 and " + std::to_string(kMaxTagsortThreads));
+
+  return options;
+}

--- a/fastqpreprocessing/src/tagsort_input_options.h
+++ b/fastqpreprocessing/src/tagsort_input_options.h
@@ -1,0 +1,46 @@
+#ifndef TAGSORT_INPUT_OPTIONS_H_
+#define TAGSORT_INPUT_OPTIONS_H_
+
+#include <string>
+#include <unordered_map>
+
+constexpr unsigned int kMaxTagsortThreads = 30;
+constexpr unsigned int kDefaultNumAlignsPerThread = 1000000;
+
+void crash(std::string msg);
+
+// Structure to hold input options for tagsort
+enum class MetricType { Cell, Gene };
+struct INPUT_OPTIONS_TAGSORT
+{
+  MetricType metric_type;
+  bool output_sorted_info = false;
+  bool compute_metric = false;
+  // name of the bam file
+  std::string bam_input;
+  // name of the gtf file
+  std::string gtf_file;
+  // temp folder for disk sorting
+  std::string temp_folder = "/tmp/";
+
+  std::string metric_output_file;
+  // sorted tsv output file
+  std::string sorted_output_file;
+
+  // Size (in number of alignments) of individual chunks to sort in a batch and
+  // write to a partial file. Approximately 20 million alignments makes 1 GB bam file.
+  unsigned int alignments_per_batch = kDefaultNumAlignsPerThread;
+  unsigned int nthreads = 1;
+  std::string barcode_tag;
+  std::string umi_tag;
+  std::string gene_tag;
+
+  // order of the tags to sort by
+  std::unordered_map<std::string, unsigned int> tag_order;
+
+  std::string mitochondrial_gene_names_filename;
+};
+
+INPUT_OPTIONS_TAGSORT readOptionsTagsort(int argc, char** argv);
+
+#endif // TAGSORT_INPUT_OPTIONS_H_

--- a/fastqpreprocessing/src/whitelist_data.cpp
+++ b/fastqpreprocessing/src/whitelist_data.cpp
@@ -1,4 +1,4 @@
-#include "utilities.h"
+#include "whitelist_data.h"
 
 #include <fstream>
 #include <iostream>
@@ -42,11 +42,4 @@ WhiteListData readWhiteList(std::string const& white_list_file)
   }
 
   return white_list_data;
-}
-
-void crash(std::string msg)
-{
-  std::cout << msg << std::endl;
-  std::cerr << msg << std::endl;
-  exit(1);
 }

--- a/fastqpreprocessing/src/whitelist_data.h
+++ b/fastqpreprocessing/src/whitelist_data.h
@@ -1,10 +1,15 @@
-#ifndef __OPTIMUS_UTILITES__
-#define __OPTIMUS_UTILITES__
+#ifndef FASTQ_PREPROCESSING_WHITELIST_DATA_H_
+#define FASTQ_PREPROCESSING_WHITELIST_DATA_H_
 
 #include <string>
 #include <vector>
 #include <unordered_map>
 
+#include "input_options.h"
+
+// TODO this would ideally be a class, with a single public method
+// optional<string> getCorrectedBarcode(string uncorrected)
+//
 // structure for correcting the barcodes
 struct WhiteListData
 {
@@ -23,6 +28,4 @@ struct WhiteListData
 // 1 mutation away from a whitelisted barcode.
 WhiteListData readWhiteList(std::string const& white_list_file);
 
-void crash(std::string msg);
-
-#endif
+#endif // FASTQ_PREPROCESSING_WHITELIST_DATA_H_


### PR DESCRIPTION
This is a huge overhaul of the TagSort program, which was how I figured out how to cleanly add the new UMI metrics output feature. The major points:

* Split out some code into the new files alignment_datatype.cpp, mitochondrial_gene_selector.cpp and tagsort_input_options.cpp

* Renamed utilities.cpp to whitelist_data.cpp

* Cleaned up the partial sorted file merging in tagsort.cpp - should now be much more obvious what is going on there

* Cleaned up metricgatherer.cpp. Users no longer need to get the fragile sequence of finalize(), output_metrics(), output_metrics_extra() right.

* Unified htslib_tagsort.cpp and metricgatherer.cpp's understanding of the data format into the LineFields struct

Various parts of the cleanup appear to speed things up, too - my test run on my laptop vs an older version took ~55 seconds for this one vs ~85 seconds for the older version. Not yet sure how that will scale, though.