### PR TITLE
Fix memory allocation races

### DIFF
--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -373,6 +373,8 @@ void mainCommon(
   std::cout << "done" << std::endl;
 
 
+  for (int i = 0; i < R1s.size(); i++)
+    g_read_arenas.push_back(std::make_unique<SamRecordArena>());
   for (int i = 0; i < num_writer_threads; i++)
     g_write_queues.push_back(std::make_unique<WriteQueue>());
 
@@ -394,10 +396,7 @@ void mainCommon(
   {
     assert(I1s.empty() || I1s.size() == R1s.size());
     // if there is no I1 file then send an empty file name
-    std::string I1 = I1s.empty() ? "" : I1s[i];
-
-    g_read_arenas.push_back(std::make_unique<SamRecordArena>());
-    readers.emplace_back(fastQFileReaderThread, i, I1.c_str(), R1s[i].c_str(),
+    readers.emplace_back(fastQFileReaderThread, i, I1s.empty() ? "" : I1s[i], R1s[i].c_str(),
                          R2s[i].c_str(), &white_list_data, sam_record_filler, barcode_getter, output_handler);
   }
 
@@ -410,5 +409,5 @@ void mainCommon(
     write_queue->enqueueShutdownSignal();
 
   for (auto& writer : writers)
-writer.join();
+    writer.join();
 }


### PR DESCRIPTION
There was a temporary string getting created and a pointer to that was getting passed to the spawning of a thread. The temp string goes out of the scope shortly after the thread is created. The thread copies early on, but if it doesn't copy fast enough, then it is a use after free.

The global SamRecordArena is also moved up to be created before the threads. It might be get used before they are fully initialized and this way, we make sure they are all initialized before any threads does any work. 