### PR TITLE
TagSort can now produce cell x gene x UMI 3d count matrix

### DIFF
--- a/fastqpreprocessing/src/alignment_datatype.cpp
+++ b/fastqpreprocessing/src/alignment_datatype.cpp
@@ -41,6 +41,20 @@ TagOrder getTagOrder(INPUT_OPTIONS_TAGSORT options)
   return TagOrder::BUG;
 }
 
+std::string tagOrderToString(TagOrder tag_order)
+{
+  switch (tag_order)
+  {
+    case TagOrder::BUG: return "barcode,umi,gene_id";
+    case TagOrder::BGU: return "barcode,gene_id,umi";
+    case TagOrder::UBG: return "umi,barcode,gene_id";
+    case TagOrder::UGB: return "umi,gene_id,barcode";
+    case TagOrder::GUB: return "gene_id,umi,barcode";
+    case TagOrder::GBU: return "gene_id,barcode,umi";
+    default: crash("no such TagOrder"); return "";
+  }
+}
+
 TagTriple makeTriplet(std::string barcode, std::string umi, std::string gene_id,
                       TagOrder tag_order)
 {

--- a/fastqpreprocessing/src/alignment_datatype.h
+++ b/fastqpreprocessing/src/alignment_datatype.h
@@ -60,6 +60,7 @@ private:
 
 enum class TagOrder { BUG, BGU, UBG, UGB, GUB, GBU };
 TagOrder getTagOrder(INPUT_OPTIONS_TAGSORT options);
+std::string tagOrderToString(TagOrder tag_order);
 
 TagTriple makeTriplet(std::string barcode, std::string umi, std::string gene_id,
                       TagOrder tag_order);

--- a/fastqpreprocessing/src/metricgatherer.cpp
+++ b/fastqpreprocessing/src/metricgatherer.cpp
@@ -13,10 +13,10 @@ std::string to_nan(float x)
 
 MetricGatherer::MetricGatherer(std::string metric_output_file)
 {
-  metrics_outfile_.open(metric_output_file);
-  if (!metrics_outfile_)
+  metrics_csv_outfile_.open(metric_output_file);
+  if (!metrics_csv_outfile_)
     crash("Failed to open for writing " + metric_output_file);
-  metrics_outfile_ << std::setprecision(kMetricsFloatPrintPrecision);
+  metrics_csv_outfile_ << std::setprecision(kMetricsFloatPrintPrecision);
 }
 
 MetricGatherer::~MetricGatherer() {}
@@ -119,7 +119,7 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
     if (val == 1)
       molecules_with_single_read_evidence++;
 
-  metrics_outfile_
+  metrics_csv_outfile_
       << prev_tag_ << ","
       << n_reads_ << ","
       << noise_reads << ","
@@ -167,10 +167,10 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
   // write metrics csv header
   std::string s;
   for (int i=0; i<24; i++)
-    metrics_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
+    metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<11; i++)
-    metrics_outfile_ << "," << cell_specific_headers[i];
-  metrics_outfile_ << "\n";
+    metrics_csv_outfile_ << "," << cell_specific_headers[i];
+  metrics_csv_outfile_ << "\n";
 }
 
 bool MetricGatherer::cellAndGeneIsItTimeToOutput(std::string const& first_tag)
@@ -257,7 +257,7 @@ void CellMetricGatherer::outputMetricsLine()
   else
     pct_mitochondrial_molecules = 0.0f;
 
-  metrics_outfile_
+  metrics_csv_outfile_
       << "," << perfect_cell_barcodes_
       << "," << reads_mapped_intergenic_
       << "," << reads_unmapped_
@@ -291,10 +291,10 @@ GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file)
   // write metrics csv header
   std::string s;
   for (int i=0; i<24; i++)
-    metrics_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
+    metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<2; i++)
-    metrics_outfile_ << "," << gene_specific_headers[i];
-  metrics_outfile_ << "\n";
+    metrics_csv_outfile_ << "," << gene_specific_headers[i];
+  metrics_csv_outfile_ << "\n";
 }
 
 void GeneMetricGatherer::ingestLine(std::string const& str)
@@ -336,9 +336,9 @@ void GeneMetricGatherer::outputMetricsLine()
     if (count > 1)
       number_cells_detected_multiple++;
 
-  metrics_outfile_ <<  ","  << number_cells_detected_multiple
-              <<  ","  << cells_histogram_.size()
-              << "\n";
+  metrics_csv_outfile_ <<  ","  << number_cells_detected_multiple
+                       <<  ","  << cells_histogram_.size()
+                       << "\n";
 }
 
 void GeneMetricGatherer::clear()
@@ -350,18 +350,15 @@ void GeneMetricGatherer::clear()
 
 
 ////////////////  UmiMetricGatherer ////////////////////////
-UmiMetricGatherer::UmiMetricGatherer(std::string metric_output_file)
+UmiMetricGatherer::UmiMetricGatherer(std::string metric_output_file, TagOrder tag_order)
   : MetricGatherer(metric_output_file)
 {
-  // TODO in theory we should be able to know which order to write umi/barcode/gene
-  //      here, but for now we'll just do tag1 tag2 tag3 and the user should be
-  //      able to figure out which is which
-  metrics_outfile_ << "tag1,tag2,tag3,count\n";
+  metrics_csv_outfile_ << tagOrderToString(tag_order) << ",count\n";
 }
 
 void UmiMetricGatherer::outputMetricsLine()
 {
-  metrics_outfile_ << cur_histogram_triple_ << "," << cur_histogram_count_ << "\n";
+  metrics_csv_outfile_ << cur_histogram_triple_ << "," << cur_histogram_count_ << "\n";
 }
 
 void UmiMetricGatherer::ingestLine(std::string const& str)

--- a/fastqpreprocessing/src/metricgatherer.cpp
+++ b/fastqpreprocessing/src/metricgatherer.cpp
@@ -346,3 +346,44 @@ void GeneMetricGatherer::clear()
   clearCellAndGeneCommon();
   cells_histogram_.clear();
 }
+
+
+
+////////////////  UmiMetricGatherer ////////////////////////
+UmiMetricGatherer::UmiMetricGatherer(std::string metric_output_file)
+  : MetricGatherer(metric_output_file)
+{
+  // TODO in theory we should be able to know which order to write umi/barcode/gene
+  //      here, but for now we'll just do tag1 tag2 tag3 and the user should be
+  //      able to figure out which is which
+  metrics_outfile_ << "tag1,tag2,tag3,count\n";
+}
+
+void UmiMetricGatherer::outputMetricsLine()
+{
+  metrics_outfile_ << cur_histogram_triple_ << "," << cur_histogram_count_ << "\n";
+}
+
+void UmiMetricGatherer::ingestLine(std::string const& str)
+{
+  LineFields fields(str);
+
+  std::string comma_separated_tags = fields.tag_triple.first + "," +
+                                     fields.tag_triple.second + "," +
+                                     fields.tag_triple.third;
+
+  if (comma_separated_tags == cur_histogram_triple_)
+    cur_histogram_count_++;
+  else
+  {
+    outputMetricsLine();
+    cur_histogram_triple_ = comma_separated_tags;
+    cur_histogram_count_ = 1;
+  }
+}
+
+void UmiMetricGatherer::clear()
+{
+  // (clear is not relevant, since UmiMetricGatherer::ingestLine handles its own state reset,
+  //  and needs the value of comma_separated_tags to do so)
+}

--- a/fastqpreprocessing/src/metricgatherer.h
+++ b/fastqpreprocessing/src/metricgatherer.h
@@ -109,7 +109,7 @@ protected:
   void parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags);
 
   std::unordered_map<std::string, int> molecule_histogram_;
-  std::ofstream metrics_outfile_;
+  std::ofstream metrics_csv_outfile_;
 
   std::string prev_tag_;
 
@@ -200,7 +200,7 @@ private:
 class GeneMetricGatherer: public MetricGatherer
 {
 public:
-  GeneMetricGatherer(std::string metric_output_file);
+  explicit GeneMetricGatherer(std::string metric_output_file);
 
   void ingestLine(std::string const& str) override;
 
@@ -221,7 +221,7 @@ private:
 class UmiMetricGatherer: public MetricGatherer
 {
 public:
-  UmiMetricGatherer(std::string metric_output_file);
+  UmiMetricGatherer(std::string metric_output_file, TagOrder tag_order);
   void ingestLine(std::string const& str) override;
   void outputMetricsLine() override;
 

--- a/fastqpreprocessing/src/metricgatherer.h
+++ b/fastqpreprocessing/src/metricgatherer.h
@@ -218,4 +218,19 @@ private:
   };
 };
 
+class UmiMetricGatherer: public MetricGatherer
+{
+public:
+  UmiMetricGatherer(std::string metric_output_file);
+  void ingestLine(std::string const& str) override;
+  void outputMetricsLine() override;
+
+protected:
+  void clear() override;
+
+private:
+  std::string cur_histogram_triple_{};
+  int cur_histogram_count_ = 0;
+};
+
 #endif

--- a/fastqpreprocessing/src/tagsort.cpp
+++ b/fastqpreprocessing/src/tagsort.cpp
@@ -107,7 +107,7 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
   else if (options.metric_type == MetricType::Gene)
     return std::make_unique<GeneMetricGatherer>(options.metric_output_file);
   else if (options.metric_type == MetricType::Umi)
-    return std::make_unique<UmiMetricGatherer>(options.metric_output_file);
+    return std::make_unique<UmiMetricGatherer>(options.metric_output_file, getTagOrder(options));
   else
     crash("new MetricType enum value is not yet handled by MetricGatherer!");
   return nullptr;

--- a/fastqpreprocessing/src/tagsort.cpp
+++ b/fastqpreprocessing/src/tagsort.cpp
@@ -106,6 +106,8 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
   }
   else if (options.metric_type == MetricType::Gene)
     return std::make_unique<GeneMetricGatherer>(options.metric_output_file);
+  else if (options.metric_type == MetricType::Umi)
+    return std::make_unique<UmiMetricGatherer>(options.metric_output_file);
   else
     crash("new MetricType enum value is not yet handled by MetricGatherer!");
   return nullptr;

--- a/fastqpreprocessing/src/tagsort_input_options.cpp
+++ b/fastqpreprocessing/src/tagsort_input_options.cpp
@@ -166,6 +166,8 @@ INPUT_OPTIONS_TAGSORT readOptionsTagsort(int argc, char** argv)
     options.metric_type = MetricType::Cell;
   else if (metric_type_str == "gene")
     options.metric_type = MetricType::Gene;
+  else if (metric_type_str == "umi")
+    options.metric_type = MetricType::Umi;
   else
     crash("ERROR: --metric-type must be \"cell\", \"gene\", or \"umi\"");
 

--- a/fastqpreprocessing/src/tagsort_input_options.h
+++ b/fastqpreprocessing/src/tagsort_input_options.h
@@ -10,7 +10,7 @@ constexpr unsigned int kDefaultNumAlignsPerThread = 1000000;
 void crash(std::string msg);
 
 // Structure to hold input options for tagsort
-enum class MetricType { Cell, Gene };
+enum class MetricType { Cell, Gene, Umi };
 struct INPUT_OPTIONS_TAGSORT
 {
   MetricType metric_type;


### PR DESCRIPTION
Input is a BAM file, output is a .csv with 4 columns: cell, gene, UMI, and count of reads in the BAM file matching those three tags.

This new feature can be called by specifying `--metric-type umi` and `--compute-metric` in the TagSort command line invocation.