### PR TITLE
TagSort can now produce cell x gene x UMI 3d count matrix

### DIFF
--- a/fastqpreprocessing/src/alignment_datatype.cpp
+++ b/fastqpreprocessing/src/alignment_datatype.cpp
@@ -41,6 +41,20 @@ TagOrder getTagOrder(INPUT_OPTIONS_TAGSORT options)
   return TagOrder::BUG;
 }
 
+std::string tagOrderToString(TagOrder tag_order)
+{
+  switch (tag_order)
+  {
+    case TagOrder::BUG: return "barcode,umi,gene_id";
+    case TagOrder::BGU: return "barcode,gene_id,umi";
+    case TagOrder::UBG: return "umi,barcode,gene_id";
+    case TagOrder::UGB: return "umi,gene_id,barcode";
+    case TagOrder::GUB: return "gene_id,umi,barcode";
+    case TagOrder::GBU: return "gene_id,barcode,umi";
+    default: crash("no such TagOrder"); return "";
+  }
+}
+
 TagTriple makeTriplet(std::string barcode, std::string umi, std::string gene_id,
                       TagOrder tag_order)
 {

--- a/fastqpreprocessing/src/alignment_datatype.h
+++ b/fastqpreprocessing/src/alignment_datatype.h
@@ -60,6 +60,7 @@ private:
 
 enum class TagOrder { BUG, BGU, UBG, UGB, GUB, GBU };
 TagOrder getTagOrder(INPUT_OPTIONS_TAGSORT options);
+std::string tagOrderToString(TagOrder tag_order);
 
 TagTriple makeTriplet(std::string barcode, std::string umi, std::string gene_id,
                       TagOrder tag_order);

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -373,8 +373,6 @@ void mainCommon(
   std::cout << "done" << std::endl;
 
 
-  for (int i = 0; i < R1s.size(); i++)
-    g_read_arenas.push_back(std::make_unique<SamRecordArena>());
   for (int i = 0; i < num_writer_threads; i++)
     g_write_queues.push_back(std::make_unique<WriteQueue>());
 
@@ -396,7 +394,10 @@ void mainCommon(
   {
     assert(I1s.empty() || I1s.size() == R1s.size());
     // if there is no I1 file then send an empty file name
-    readers.emplace_back(fastQFileReaderThread, i, I1s.empty() ? "" : I1s[i], R1s[i].c_str(),
+    std::string I1 = I1s.empty() ? "" : I1s[i];
+
+    g_read_arenas.push_back(std::make_unique<SamRecordArena>());
+    readers.emplace_back(fastQFileReaderThread, i, I1.c_str(), R1s[i].c_str(),
                          R2s[i].c_str(), &white_list_data, sam_record_filler, barcode_getter, output_handler);
   }
 
@@ -409,5 +410,5 @@ void mainCommon(
     write_queue->enqueueShutdownSignal();
 
   for (auto& writer : writers)
-    writer.join();
+writer.join();
 }

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -373,7 +373,7 @@ void mainCommon(
   std::cout << "done" << std::endl;
 
 
-  for (unsigned int i = 0; i < R1s.size(); i++)
+  for (int i = 0; i < R1s.size(); i++)
     g_read_arenas.push_back(std::make_unique<SamRecordArena>());
   for (int i = 0; i < num_writer_threads; i++)
     g_write_queues.push_back(std::make_unique<WriteQueue>());
@@ -391,6 +391,7 @@ void mainCommon(
 
   // execute the fastq readers threads
   std::vector<std::thread> readers;
+
   for (unsigned int i = 0; i < R1s.size(); i++)
   {
     assert(I1s.empty() || I1s.size() == R1s.size());

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -373,6 +373,8 @@ void mainCommon(
   std::cout << "done" << std::endl;
 
 
+  for (unsigned int i = 0; i < R1s.size(); i++)
+    g_read_arenas.push_back(std::make_unique<SamRecordArena>());
   for (int i = 0; i < num_writer_threads; i++)
     g_write_queues.push_back(std::make_unique<WriteQueue>());
 
@@ -389,15 +391,11 @@ void mainCommon(
 
   // execute the fastq readers threads
   std::vector<std::thread> readers;
-
   for (unsigned int i = 0; i < R1s.size(); i++)
   {
     assert(I1s.empty() || I1s.size() == R1s.size());
     // if there is no I1 file then send an empty file name
-    std::string I1 = I1s.empty() ? "" : I1s[i];
-
-    g_read_arenas.push_back(std::make_unique<SamRecordArena>());
-    readers.emplace_back(fastQFileReaderThread, i, I1.c_str(), R1s[i].c_str(),
+    readers.emplace_back(fastQFileReaderThread, i, I1s.empty() ? "" : I1s[i], R1s[i].c_str(),
                          R2s[i].c_str(), &white_list_data, sam_record_filler, barcode_getter, output_handler);
   }
 
@@ -410,5 +408,5 @@ void mainCommon(
     write_queue->enqueueShutdownSignal();
 
   for (auto& writer : writers)
-writer.join();
+    writer.join();
 }

--- a/fastqpreprocessing/src/metricgatherer.h
+++ b/fastqpreprocessing/src/metricgatherer.h
@@ -109,7 +109,7 @@ protected:
   void parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags);
 
   std::unordered_map<std::string, int> molecule_histogram_;
-  std::ofstream metrics_outfile_;
+  std::ofstream metrics_csv_outfile_;
 
   std::string prev_tag_;
 
@@ -200,7 +200,7 @@ private:
 class GeneMetricGatherer: public MetricGatherer
 {
 public:
-  GeneMetricGatherer(std::string metric_output_file);
+  explicit GeneMetricGatherer(std::string metric_output_file);
 
   void ingestLine(std::string const& str) override;
 
@@ -216,6 +216,21 @@ private:
     "number_cells_detected_multiple",
     "number_cells_expressing"
   };
+};
+
+class UmiMetricGatherer: public MetricGatherer
+{
+public:
+  UmiMetricGatherer(std::string metric_output_file, TagOrder tag_order);
+  void ingestLine(std::string const& str) override;
+  void outputMetricsLine() override;
+
+protected:
+  void clear() override;
+
+private:
+  std::string cur_histogram_triple_{};
+  int cur_histogram_count_ = 0;
 };
 
 #endif

--- a/fastqpreprocessing/src/tagsort.cpp
+++ b/fastqpreprocessing/src/tagsort.cpp
@@ -106,6 +106,8 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
   }
   else if (options.metric_type == MetricType::Gene)
     return std::make_unique<GeneMetricGatherer>(options.metric_output_file);
+  else if (options.metric_type == MetricType::Umi)
+    return std::make_unique<UmiMetricGatherer>(options.metric_output_file, getTagOrder(options));
   else
     crash("new MetricType enum value is not yet handled by MetricGatherer!");
   return nullptr;

--- a/fastqpreprocessing/src/tagsort.cpp
+++ b/fastqpreprocessing/src/tagsort.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <fstream>
+#include <functional>
 #include <queue>
 #include <string>
 

--- a/fastqpreprocessing/src/tagsort_input_options.cpp
+++ b/fastqpreprocessing/src/tagsort_input_options.cpp
@@ -57,7 +57,7 @@ INPUT_OPTIONS_TAGSORT readOptionsTagsort(int argc, char** argv)
     "barcode-tag the call barcode tag [required]",
     "umi-tag the umi tag [required]: the tsv file output is sorted according the tags in the options barcode-tag, umi-tag or gene-tag",
     "gene-tag the gene tag [required]",
-    "metric type, either \"cell\" or \"gene\" [required]",
+    "metric type, one of \"cell\", \"gene\", or \"umi\" [required]",
     "file listing gene names, one per line, that the program should care about. [required, may omit if you want mouse or human]"
   };
 

--- a/fastqpreprocessing/src/tagsort_input_options.cpp
+++ b/fastqpreprocessing/src/tagsort_input_options.cpp
@@ -166,6 +166,8 @@ INPUT_OPTIONS_TAGSORT readOptionsTagsort(int argc, char** argv)
     options.metric_type = MetricType::Cell;
   else if (metric_type_str == "gene")
     options.metric_type = MetricType::Gene;
+  else if (metric_type_str == "umi")
+    options.metric_type = MetricType::Umi;
   else
     crash("ERROR: --metric-type must be \"cell\", \"gene\", or \"umi\"");
 

--- a/fastqpreprocessing/src/tagsort_input_options.h
+++ b/fastqpreprocessing/src/tagsort_input_options.h
@@ -10,7 +10,7 @@ constexpr unsigned int kDefaultNumAlignsPerThread = 1000000;
 void crash(std::string msg);
 
 // Structure to hold input options for tagsort
-enum class MetricType { Cell, Gene };
+enum class MetricType { Cell, Gene, Umi };
 struct INPUT_OPTIONS_TAGSORT
 {
   MetricType metric_type;


### PR DESCRIPTION
Input is a BAM file, output is a .csv with 4 columns: cell, gene, UMI, and count of reads in the BAM file matching those three tags.

This new feature can be called by specifying `--metric-type umi` and `--compute-metric` in the TagSort command line invocation.