### PR TITLE
Convert loom to h5ad. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN cd /sctools/fastqpreprocessing && ./fetch_and_make_dep_libs.sh && make && cp
 
 RUN cd /sctools/TagSort && ./fetch_and_make_dep_libs.sh && make && cp /sctools/TagSort/bin/* /usr/local/bin/
 
+RUN pip install loompy anndata
+
 WORKDIR usr/local/bin/sctools
 
 # Set tini as default entrypoint

--- a/scripts/loom_to_h5ad.py
+++ b/scripts/loom_to_h5ad.py
@@ -1,7 +1,6 @@
 import argparse
 import anndata as ad
 import loompy
-import scipy 
 import os
 
 def convertloomtoh5ad(args):
@@ -16,19 +15,8 @@ def convertloomtoh5ad(args):
     file_name = os.path.basename(args.loom_file)
     file_name = file_name.split(".")[0] 
 
-    #establish connection to loom file 
-    ds = loompy.connect(args.loom_file)
-
-    #adata.sparse() ouputs coo then convert to csr
-    coo = ds.sparse()
-    csr = coo.tocsr()
-
-    #save as h5ad
-    adata = ad.AnnData(csr)
+    adata = ad.read_loom(args.loom_file, sparse=True)
     adata.write(os.path.join(args.output_path, file_name + ".h5ad"))
-
-    #close loompy connection
-    ds.close()
 
 def main():
     description = """This script converts a loom file (http://linnarssonlab.org/loompy/index.html) into h5ad (https://anndata.readthedocs.io/en/latest/) format."""

--- a/scripts/loom_to_h5ad.py
+++ b/scripts/loom_to_h5ad.py
@@ -12,8 +12,7 @@ def convertloomtoh5ad(args):
     
     """
 
-    file_name = os.path.basename(args.loom_file)
-    file_name = file_name.split(".")[0] 
+    file_name = os.path.basename(args.loom_file).split(".")[0] 
 
     #reads loom file as sparse csr matrix
     adata = ad.read_loom(args.loom_file, sparse=True)

--- a/scripts/loom_to_h5ad.py
+++ b/scripts/loom_to_h5ad.py
@@ -15,7 +15,17 @@ def convertloomtoh5ad(args):
     file_name = os.path.basename(args.loom_file)
     file_name = file_name.split(".")[0] 
 
+    #reads loom file as sparse csr matrix
     adata = ad.read_loom(args.loom_file, sparse=True)
+    
+    #connect to loom file to save the global attributes in the h5ad file
+    ds = loompy.connect(args.loom_file)
+    
+    #loop through global attributes and save in adata
+    for global_attr, value in ds.attrs.items():
+        adata.uns[global_attr] = value
+    ds.close()
+    
     adata.write(os.path.join(args.output_path, file_name + ".h5ad"))
 
 def main():

--- a/scripts/loom_to_h5ad.py
+++ b/scripts/loom_to_h5ad.py
@@ -1,0 +1,56 @@
+import argparse
+import anndata as ad
+import loompy
+import scipy 
+import os
+
+def convertloomtoh5ad(args):
+    """ Converts loom file format to h5ad. 
+
+    Args:
+        loom_path (str): path to loom file.  
+        output_path (str): output path directory to save h5ad file in. 
+    
+    """
+
+    file_name = os.path.basename(args.loom_file)
+    file_name = file_name.split(".")[0] 
+
+    #establish connection to loom file 
+    ds = loompy.connect(args.loom_file)
+
+    #adata.sparse() ouputs coo then convert to csr
+    coo = ds.sparse()
+    csr = coo.tocsr()
+
+    #save as h5ad
+    adata = ad.AnnData(csr)
+    adata.write(os.path.join(args.output_path, file_name + ".h5ad"))
+
+    #close loompy connection
+    ds.close()
+
+def main():
+    description = """This script converts a loom file (http://linnarssonlab.org/loompy/index.html) into h5ad (https://anndata.readthedocs.io/en/latest/) format."""
+
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument(
+        "--loom_file",
+        dest="loom_file",
+        required=True,
+        help="A loom file is needed as input.",
+    )
+
+    parser.add_argument(
+        "--output_path",
+        dest="output_path",
+        required=True,
+        help="Output path to save the h5ad file in.",
+    )
+
+    args = parser.parse_args()
+    convertloomtoh5ad(args)   
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This script converts a loom file into h5ad (the matrix is in csr format) -- it saves the h5ad file in the given output directory. 

It takes the loom file and the h5ad output directory as input.