### PR TITLE
add partial_file_merge_test.cpp

### DIFF
--- a/TagSort/Makefile
+++ b/TagSort/Makefile
@@ -4,7 +4,7 @@ all: bin/TagSort
 # All tests produced by this Makefile. Add new tests you create to this list.
 # UNIT TESTS MUST BE NAMED foo_test, with a corresponding foo_test.cpp in the
 # test directory.
-test: bin/alignment_datatype_test
+test: bin/alignment_datatype_test bin/partial_file_merge_test
 
 CC = g++ -std=c++17 -Wall -Wno-sign-compare -O4
 

--- a/TagSort/src/alignment_datatype.cpp
+++ b/TagSort/src/alignment_datatype.cpp
@@ -70,6 +70,18 @@ TagTriple makeTriplet(std::string barcode, std::string umi, std::string gene_id,
   }
 }
 
+bool sortAlignmentsByTagTriple(std::unique_ptr<LineFields> const& a,
+                               std::unique_ptr<LineFields> const& b)
+{
+  int comp0 = a->tag_triple.first .compare( b->tag_triple.first);
+  if (comp0 != 0)
+    return comp0 < 0;
+  int comp1 = a->tag_triple.second .compare( b->tag_triple.second);
+  if (comp1 != 0)
+    return comp1 < 0;
+  return a->tag_triple.third .compare( b->tag_triple.third) < 0;
+}
+
 LineFields::LineFields(
     TagTriple _tag_triple, std::string _reference, std::string _alignment_location,
     int _position, int _is_strand,

--- a/TagSort/src/alignment_datatype.h
+++ b/TagSort/src/alignment_datatype.h
@@ -2,6 +2,7 @@
 #define TAGSORT_ALIGNMENT_DATATYPE_H_
 
 #include <fstream>
+#include <memory>
 #include <string>
 
 #include "tagsort_input_options.h"
@@ -34,6 +35,8 @@ public:
       int _read_is_duplicate, int _cell_barcode_perfect,
       float _molecule_barcode_base_above_30);
 
+  LineFields() {}
+
   void writeTabbedToFile(std::ofstream& outfile);
 
   TagTriple tag_triple; // (0,1,2) barcode umi and gene_id, not necessarily in that order
@@ -53,6 +56,9 @@ public:
   int cell_barcode_perfect; // (15) 1 for yes, 0 for no
   float molecule_barcode_base_above_30; // (16) fraction of umi qual score > 30
 };
+
+bool sortAlignmentsByTagTriple(std::unique_ptr<LineFields> const& a,
+                               std::unique_ptr<LineFields> const& b);
 
 // Parses tab-separated fields from a line (std::string s).
 class LineFieldsParser

--- a/TagSort/src/partial_file_merge.cpp
+++ b/TagSort/src/partial_file_merge.cpp
@@ -79,6 +79,11 @@ public:
   bool empty() const { return heap_.empty(); }
 
 private:
+  // A custom comparator to tell our priority_queue how to deal with our std::pairs.
+  // It is correct that this comparator is a > rather than <, because priority_queue
+  // is a max-heap, and so wants to return the "largest" (i.e. having the comparator
+  // seeing it as "before" no other item) first. So if you want 'A' to be returned
+  // before 'B', your comparator needs to report 'B' as being "before" 'A'.
   std::function<bool(std::pair<std::string, int> const&,
                      std::pair<std::string, int> const&)>
       greater_than_ =

--- a/TagSort/src/partial_sort.cpp
+++ b/TagSort/src/partial_sort.cpp
@@ -157,18 +157,6 @@ std::unique_ptr<LineFields> parseOneAlignment(
       frac_umi_qual_above_threshold);
 }
 
-inline bool sortAlignmentsByTagTriple(std::unique_ptr<LineFields> const& a,
-                                      std::unique_ptr<LineFields> const& b)
-{
-  int comp0 = a->tag_triple.first .compare( b->tag_triple.first);
-  if (comp0 != 0)
-    return comp0 < 0;
-  int comp1 = a->tag_triple.second .compare( b->tag_triple.second);
-  if (comp1 != 0)
-    return comp1 < 0;
-  return a->tag_triple.third .compare( b->tag_triple.third) < 0;
-}
-
 // Generates a random alphanumeric string (AZaz09) of a fixed length.
 constexpr int kStringLen = 40;
 std::string randomString()

--- a/TagSort/test/partial_file_merge_test.cpp
+++ b/TagSort/test/partial_file_merge_test.cpp
@@ -1,0 +1,76 @@
+#include "../src/alignment_datatype.h"
+#include "../src/partial_file_merge.h"
+
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
+
+TEST(PartialFileMergeTest, BasicMerge)
+{
+  INPUT_OPTIONS_TAGSORT options;
+  options.compute_metric = false;
+  options.output_sorted_info = true;
+  options.sorted_output_file = "/tmp/TagSort_gtest_partial_file_merge_test_sorted_output_file";
+
+  options.barcode_tag = "barcode";
+  options.umi_tag = "umi";
+  options.gene_tag = "gene";
+  options.tag_order["barcode"] = 0;
+  options.tag_order["umi"] = 1;
+  options.tag_order["gene"] = 2;
+
+  options.alignments_per_batch = 2;
+  options.nthreads = 2;
+
+  std::vector<std::string> my_partial_filenames;
+  {
+    std::vector<std::unique_ptr<LineFields>> alignment_batch;
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("A", "A", "A");
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("B", "B", "B");
+
+    std::sort(alignment_batch.begin(), alignment_batch.end(),
+              sortAlignmentsByTagTriple);
+
+    std::string partialfile_name = "/tmp/TagSort_gtest_partial_file_merge_test_temp_file_0";
+    std::ofstream outfile(partialfile_name);
+    my_partial_filenames.push_back(partialfile_name);
+    for (int i = 0; i < alignment_batch.size(); i++)
+      alignment_batch[i]->writeTabbedToFile(outfile);
+  }
+  {
+    std::vector<std::unique_ptr<LineFields>> alignment_batch;
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("C", "C", "C");
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("B", "B", "B");
+
+    std::sort(alignment_batch.begin(), alignment_batch.end(),
+              sortAlignmentsByTagTriple);
+
+    std::string partialfile_name = "/tmp/TagSort_gtest_partial_file_merge_test_temp_file_1";
+    std::ofstream outfile(partialfile_name);
+    my_partial_filenames.push_back(partialfile_name);
+    for (int i = 0; i < alignment_batch.size(); i++)
+      alignment_batch[i]->writeTabbedToFile(outfile);
+  }
+
+  int num_alignments_merged = mergePartialFiles(options, my_partial_filenames);
+  EXPECT_EQ(num_alignments_merged, 4);
+
+  std::ifstream sorted_file(options.sorted_output_file);
+  std::string line;
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'A');
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'B');
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'B');
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'C');
+
+
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_sorted_output_file");
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_0");
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_1");
+}

--- a/TagSort/test/partial_file_merge_test.cpp
+++ b/TagSort/test/partial_file_merge_test.cpp
@@ -74,3 +74,153 @@ TEST(PartialFileMergeTest, BasicMerge)
   unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_0");
   unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_1");
 }
+
+TEST(PartialFileMergeTest, EmptyTagsOk)
+{
+  INPUT_OPTIONS_TAGSORT options;
+  options.compute_metric = false;
+  options.output_sorted_info = true;
+  options.sorted_output_file = "/tmp/TagSort_gtest_partial_file_merge_test_sorted_output_file";
+
+  options.barcode_tag = "barcode";
+  options.umi_tag = "umi";
+  options.gene_tag = "gene";
+  options.tag_order["barcode"] = 0;
+  options.tag_order["umi"] = 1;
+  options.tag_order["gene"] = 2;
+
+  options.alignments_per_batch = 2;
+  options.nthreads = 2;
+
+  std::vector<std::string> my_partial_filenames;
+  {
+    std::vector<std::unique_ptr<LineFields>> alignment_batch;
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("A", "A", "A");
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("B", "B", "B");
+    alignment_batch.emplace_back(std::make_unique<LineFields>()); // empty
+
+    std::sort(alignment_batch.begin(), alignment_batch.end(),
+              sortAlignmentsByTagTriple);
+
+    std::string partialfile_name = "/tmp/TagSort_gtest_partial_file_merge_test_temp_file_0";
+    std::ofstream outfile(partialfile_name);
+    my_partial_filenames.push_back(partialfile_name);
+    for (int i = 0; i < alignment_batch.size(); i++)
+      alignment_batch[i]->writeTabbedToFile(outfile);
+  }
+  {
+    std::vector<std::unique_ptr<LineFields>> alignment_batch;
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("C", "C", "C");
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("B", "B", "B");
+
+    std::sort(alignment_batch.begin(), alignment_batch.end(),
+              sortAlignmentsByTagTriple);
+
+    std::string partialfile_name = "/tmp/TagSort_gtest_partial_file_merge_test_temp_file_1";
+    std::ofstream outfile(partialfile_name);
+    my_partial_filenames.push_back(partialfile_name);
+    for (int i = 0; i < alignment_batch.size(); i++)
+      alignment_batch[i]->writeTabbedToFile(outfile);
+  }
+
+  int num_alignments_merged = mergePartialFiles(options, my_partial_filenames);
+  EXPECT_EQ(num_alignments_merged, 5);
+
+  std::ifstream sorted_file(options.sorted_output_file);
+  std::string line;
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], '\t'); // empty tag, so first char is the tab delim
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'A');
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'B');
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'B');
+  std::getline(sorted_file, line);
+  EXPECT_EQ(line[0], 'C');
+
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_sorted_output_file");
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_0");
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_1");
+}
+
+// Exercises comparing tags beyond the first field.
+// Tests that the sorting gives AAA -> AAB -> ABB -> BAA -> BBB
+TEST(PartialFileMergeTest, TagTiebreaking)
+{
+  INPUT_OPTIONS_TAGSORT options;
+  options.compute_metric = false;
+  options.output_sorted_info = true;
+  options.sorted_output_file = "/tmp/TagSort_gtest_partial_file_merge_test_sorted_output_file";
+
+  options.barcode_tag = "barcode";
+  options.umi_tag = "umi";
+  options.gene_tag = "gene";
+  options.tag_order["barcode"] = 0;
+  options.tag_order["umi"] = 1;
+  options.tag_order["gene"] = 2;
+
+  options.alignments_per_batch = 2;
+  options.nthreads = 2;
+
+  std::vector<std::string> my_partial_filenames;
+  {
+    std::vector<std::unique_ptr<LineFields>> alignment_batch;
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("A", "A", "A");
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("A", "A", "B");
+
+    std::sort(alignment_batch.begin(), alignment_batch.end(),
+              sortAlignmentsByTagTriple);
+
+    std::string partialfile_name = "/tmp/TagSort_gtest_partial_file_merge_test_temp_file_0";
+    std::ofstream outfile(partialfile_name);
+    my_partial_filenames.push_back(partialfile_name);
+    for (int i = 0; i < alignment_batch.size(); i++)
+      alignment_batch[i]->writeTabbedToFile(outfile);
+  }
+  {
+    std::vector<std::unique_ptr<LineFields>> alignment_batch;
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("A", "B", "B");
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("B", "A", "A");
+    alignment_batch.emplace_back(std::make_unique<LineFields>());
+    alignment_batch.back()->tag_triple = TagTriple("B", "B", "B");
+
+    std::sort(alignment_batch.begin(), alignment_batch.end(),
+              sortAlignmentsByTagTriple);
+
+    std::string partialfile_name = "/tmp/TagSort_gtest_partial_file_merge_test_temp_file_1";
+    std::ofstream outfile(partialfile_name);
+    my_partial_filenames.push_back(partialfile_name);
+    for (int i = 0; i < alignment_batch.size(); i++)
+      alignment_batch[i]->writeTabbedToFile(outfile);
+  }
+
+  int num_alignments_merged = mergePartialFiles(options, my_partial_filenames);
+  EXPECT_EQ(num_alignments_merged, 5);
+
+  std::ifstream sorted_file(options.sorted_output_file);
+  std::string line;
+  std::getline(sorted_file, line);
+  EXPECT_THAT(line, testing::StartsWith("A\tA\tA"));
+  std::getline(sorted_file, line);
+  EXPECT_THAT(line, testing::StartsWith("A\tA\tB"));
+  std::getline(sorted_file, line);
+  EXPECT_THAT(line, testing::StartsWith("A\tB\tB"));
+  std::getline(sorted_file, line);
+  EXPECT_THAT(line, testing::StartsWith("B\tA\tA"));
+  std::getline(sorted_file, line);
+  EXPECT_THAT(line, testing::StartsWith("B\tB\tB"));
+
+
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_sorted_output_file");
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_0");
+  unlink("/tmp/TagSort_gtest_partial_file_merge_test_temp_file_1");
+}


### PR DESCRIPTION
Added a test of TagSort's sorted-partial-file merging (partial_file_merge.cpp). This test demonstrates that TagSort does indeed sort correctly. Somewhat of an integration test with partial_sort.cpp: although the inputs are basically fake, the partial sort is done with the actual sortAlignmentsByTagTriple comparator that the real partial_sort.cpp uses.

Also tests that the sorting is ok with empty tags.

Also added documentation to the use of std::priority_queue with a "greater than" comparator despite the partial sorting being a standard "less than", which had me worried that there would be mis-sorted alignments at the partial file boundaries (about one in a million with default params). The test demonstrated that giving std::priority_queue a "greater than" comparator is correct here.