### PR TITLE
Np remove some columns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux && \
     mkdir -p /warptools && \
     apt-get update && apt-get upgrade -y && apt-get install -y libhdf5-dev vim apt-utils liblzma-dev libbz2-dev && \
     pip install --upgrade pip && \
-    pip install loompy anndata numpy scipy h5py
+    pip install loompy==3.0.6 anndata numpy scipy h5py==2.10.0
 
 COPY . /warptools
 #build C/C++ code and add binaries to usr's bin

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -48,10 +48,10 @@ function main(){
         ;;
     esac
     done
-    if [ -z $1 ]; 
+    if [ -n "$TAG" ]; 
     then
         IMAGE_TAG="$TAG"
-        echo "Tag is set. Overriding default."
+        echo "Tag is set to $TAG. Overriding default."
     else
         echo "Tag is unset. Using default."
         IMAGE_TAG="$DOCKER_IMAGE_VERSION-$TIMESTAMP"

--- a/docker_versions.tsv
+++ b/docker_versions.tsv
@@ -1,3 +1,5 @@
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1669859121
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1669865645
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1669902462
+us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1674487316
+us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1678734726

--- a/docker_versions.tsv
+++ b/docker_versions.tsv
@@ -3,3 +3,4 @@ us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1669865645
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1669902462
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-1678805190
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-1678808309
+us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1678990890

--- a/scripts/create_loom_optimus.py
+++ b/scripts/create_loom_optimus.py
@@ -135,7 +135,7 @@ def generate_col_attr(args):
     if metrics_df.shape[0] == 0 or metrics_df.shape[1] == 0:
         logging.error("Cell metrics table is not valid")
         raise ValueError()
-    metrics_df = metrics_df.rename(columns={"barcode": "cell_id"})
+    metrics_df = metrics_df.rename(columns={"CellID": "cell_id"})
 
     add_emptydrops_results = args.add_emptydrops_results
     if add_emptydrops_results == 'yes':
@@ -325,7 +325,7 @@ def generate_matrix(args):
 def create_loom_files(args):
     """This function creates the loom file or folder structure in output_loom_path in format file_format,
        with input_id from the input folder analysis_output_path
-    
+
     Args:
         args (argparse.Namespace): input arguments for the run
     """
@@ -356,7 +356,7 @@ def create_loom_files(args):
     if args.input_name_metadata_field is not None:
         attrDict['input_name_metadata_field'] = args.input_name_metadata_field
     attrDict['pipeline_version'] = args.pipeline_version
-    #generate loom file 
+    #generate loom file
     loompy.create(args.output_loom_path, expr_sp_t, row_attrs, col_attrs, file_attrs=attrDict)
 
 def main():

--- a/scripts/create_loom_optimus.py
+++ b/scripts/create_loom_optimus.py
@@ -23,7 +23,7 @@ def create_gene_id_name_map(gtf_file):
 
     # loop through the lines and find the gene_id and gene_name pairs
     with gzip.open(gtf_file, "rt") if gtf_file.endswith(".gz") else open(
-        gtf_file, "r"
+            gtf_file, "r"
     ) as fpin:
         for _line in fpin:
             line = _line.strip()
@@ -135,16 +135,16 @@ def generate_col_attr(args):
     if metrics_df.shape[0] == 0 or metrics_df.shape[1] == 0:
         logging.error("Cell metrics table is not valid")
         raise ValueError()
-    metrics_df = metrics_df.rename(columns={"Unnamed: 0": "cell_id"})
+    metrics_df = metrics_df.rename(columns={"barcode": "cell_id"})
 
     add_emptydrops_results = args.add_emptydrops_results
     if add_emptydrops_results == 'yes':
-       emptydrops_df = pd.read_csv(args.empty_drops_file, dtype=str)
-       if emptydrops_df.shape[0] == 0 or emptydrops_df.shape[1] == 0:
-           logging.error("EmptyDrops table is not valid")
-           raise ValueError()
-      # Rename cell columns for both datasets to cell_id
-       emptydrops_df = emptydrops_df.rename(columns={"CellId": "cell_id"})
+        emptydrops_df = pd.read_csv(args.empty_drops_file, dtype=str)
+        if emptydrops_df.shape[0] == 0 or emptydrops_df.shape[1] == 0:
+            logging.error("EmptyDrops table is not valid")
+            raise ValueError()
+        # Rename cell columns for both datasets to cell_id
+        emptydrops_df = emptydrops_df.rename(columns={"CellId": "cell_id"})
 
     # Order the cells by merging with cell_ids
     cellorder_df = pd.DataFrame(data={"cell_id": cell_ids})
@@ -154,9 +154,6 @@ def generate_col_attr(args):
         "n_reads",
         "noise_reads",
         "perfect_molecule_barcodes",
-        "reads_mapped_exonic",
-        "reads_mapped_intronic",
-        "reads_mapped_utr",
         "reads_mapped_uniquely",
         "reads_mapped_multiple",
         "duplicate_reads",
@@ -167,12 +164,10 @@ def generate_col_attr(args):
         "fragments_with_single_read_evidence",
         "molecules_with_single_read_evidence",
         "perfect_cell_barcodes",
-        "reads_mapped_intergenic",
-        "reads_unmapped",
         "reads_mapped_too_many_loci",
         "n_genes",
         "genes_detected_multiple_observations"
-    ] 
+    ]
 
     FloatColumnNames = [ # Float32
         "molecule_barcode_fraction_bases_above_30_mean",
@@ -202,7 +197,7 @@ def generate_col_attr(args):
 
         emptydrops_df = emptydrops_df.rename(columns=namemap)
 
-    # Confirm that the emptydrops table is a subset of the cell metadata table, fail if not
+        # Confirm that the emptydrops table is a subset of the cell metadata table, fail if not
         if not emptydrops_df.cell_id.isin(metrics_df.cell_id).all():
             logging.error(
                 "Not all emptydrops cells can be found in the metrics table."
@@ -215,12 +210,12 @@ def generate_col_attr(args):
         final_df = cellorder_df.merge(merged_df, on="cell_id", how="left")
 
         ColumnNames = IntColumnNames + ["emptydrops_Total"] + FloatColumnNames + \
-            [ "emptydrops_LogProb", "emptydrops_PValue", "emptydrops_FDR" ]
+                      [ "emptydrops_LogProb", "emptydrops_PValue", "emptydrops_FDR" ]
         BoolColumnNames = ["emptydrops_Limited", "emptydrops_IsCell"]
-       
+
     else:
         final_df = cellorder_df.merge(metrics_df, on="cell_id", how="left")
-        ColumnNames = IntColumnNames + FloatColumnNames 
+        ColumnNames = IntColumnNames + FloatColumnNames
         BoolColumnNames = []
 
     # Split the dataframe
@@ -238,7 +233,7 @@ def generate_col_attr(args):
                 final_df_bool[index, 0] = False
             else:
                 final_df_bool[index, 0] = np.nan
-    
+
             if row["emptydrops_IsCell"] == "TRUE":
                 final_df_bool[index, 1] = True
             elif row["emptydrops_IsCell"] == "FALSE":
@@ -259,14 +254,14 @@ def generate_col_attr(args):
         name = bool_field_names[i]
         data = final_df_bool[:, i]
         col_attrs[name] = data
-    
+
     # Create metadata tables and their headers for float
     float_field_names = list(final_df_non_boolean.columns)
 
     for i in range(len(float_field_names)):
         name = float_field_names[i]
         data = final_df_non_boolean[name].to_numpy()
-        col_attrs[name] = data 
+        col_attrs[name] = data
 
     if args.verbose:
         logging.info(
@@ -338,14 +333,14 @@ def create_loom_files(args):
 
 
     # generate a dictionary of row attributes
-    row_attrs =  generate_row_attr(args) 
-    
+    row_attrs =  generate_row_attr(args)
+
     # generate a dictionarty of column attributes
-    col_attrs =  generate_col_attr(args) 
+    col_attrs =  generate_col_attr(args)
 
     # add the expression count matrix data
     expr_sp_t = generate_matrix(args)
-    
+
     # add input_id to col_attrs
     col_attrs['input_id'] = np.repeat(args.input_id, expr_sp_t.shape[1])
 
@@ -467,7 +462,7 @@ def main():
         action="store_true",
         help="whether to output verbose debugging messages",
     )
-    
+
     parser.add_argument(
         "--expression_data_type",
         dest="expression_data_type",

--- a/scripts/create_loom_optimus.py
+++ b/scripts/create_loom_optimus.py
@@ -23,7 +23,7 @@ def create_gene_id_name_map(gtf_file):
 
     # loop through the lines and find the gene_id and gene_name pairs
     with gzip.open(gtf_file, "rt") if gtf_file.endswith(".gz") else open(
-            gtf_file, "r"
+        gtf_file, "r"
     ) as fpin:
         for _line in fpin:
             line = _line.strip()
@@ -139,12 +139,12 @@ def generate_col_attr(args):
 
     add_emptydrops_results = args.add_emptydrops_results
     if add_emptydrops_results == 'yes':
-        emptydrops_df = pd.read_csv(args.empty_drops_file, dtype=str)
-        if emptydrops_df.shape[0] == 0 or emptydrops_df.shape[1] == 0:
-            logging.error("EmptyDrops table is not valid")
-            raise ValueError()
-        # Rename cell columns for both datasets to cell_id
-        emptydrops_df = emptydrops_df.rename(columns={"CellId": "cell_id"})
+       emptydrops_df = pd.read_csv(args.empty_drops_file, dtype=str)
+       if emptydrops_df.shape[0] == 0 or emptydrops_df.shape[1] == 0:
+           logging.error("EmptyDrops table is not valid")
+           raise ValueError()
+      # Rename cell columns for both datasets to cell_id
+       emptydrops_df = emptydrops_df.rename(columns={"CellId": "cell_id"})
 
     # Order the cells by merging with cell_ids
     cellorder_df = pd.DataFrame(data={"cell_id": cell_ids})
@@ -197,7 +197,7 @@ def generate_col_attr(args):
 
         emptydrops_df = emptydrops_df.rename(columns=namemap)
 
-        # Confirm that the emptydrops table is a subset of the cell metadata table, fail if not
+    # Confirm that the emptydrops table is a subset of the cell metadata table, fail if not
         if not emptydrops_df.cell_id.isin(metrics_df.cell_id).all():
             logging.error(
                 "Not all emptydrops cells can be found in the metrics table."
@@ -210,7 +210,7 @@ def generate_col_attr(args):
         final_df = cellorder_df.merge(merged_df, on="cell_id", how="left")
 
         ColumnNames = IntColumnNames + ["emptydrops_Total"] + FloatColumnNames + \
-                      [ "emptydrops_LogProb", "emptydrops_PValue", "emptydrops_FDR" ]
+            [ "emptydrops_LogProb", "emptydrops_PValue", "emptydrops_FDR" ]
         BoolColumnNames = ["emptydrops_Limited", "emptydrops_IsCell"]
 
     else:

--- a/scripts/create_snrna_optimus.py
+++ b/scripts/create_snrna_optimus.py
@@ -134,7 +134,7 @@ def generate_col_attr(args):
     if metrics_df.shape[0] == 0 or metrics_df.shape[1] == 0:
         logging.error("Cell metrics table is not valid")
         raise ValueError()
-    metrics_df = metrics_df.rename(columns={"Unnamed: 0": "cell_id"})
+    metrics_df = metrics_df.rename(columns={"CellID: "cell_id"})
 
     # Order the cells by merging with cell_ids
     cellorder_df = pd.DataFrame(data={"cell_id": cell_ids})
@@ -144,9 +144,6 @@ def generate_col_attr(args):
         "n_reads",
         "noise_reads",
         "perfect_molecule_barcodes",
-        "reads_mapped_exonic",
-        "reads_mapped_intronic",
-        "reads_mapped_utr",
         "reads_mapped_uniquely",
         "reads_mapped_multiple",
         "duplicate_reads",
@@ -157,8 +154,6 @@ def generate_col_attr(args):
         "fragments_with_single_read_evidence",
         "molecules_with_single_read_evidence",
         "perfect_cell_barcodes",
-        "reads_mapped_intergenic",
-        "reads_unmapped",
         "reads_mapped_too_many_loci",
         "n_genes",
         "genes_detected_multiple_observations"
@@ -201,16 +196,16 @@ def generate_col_attr(args):
     # Create metadata tables and their headers for bool
     for i in range(0, bool_field_names.shape[0]):
         name = bool_field_names[i]
-        data = final_df_bool[:, i]
-        col_attrs[name] = data
+    data = final_df_bool[:, i]
+    col_attrs[name] = data
 
     # Create metadata tables and their headers for float
     float_field_names = list(final_df_non_boolean.columns)
 
     for i in range(len(float_field_names)):
         name = float_field_names[i]
-        data = final_df_non_boolean[name].to_numpy()
-        col_attrs[name] = data
+    data = final_df_non_boolean[name].to_numpy()
+    col_attrs[name] = data
 
     if args.verbose:
         logging.info(

--- a/scripts/create_snrna_optimus.py
+++ b/scripts/create_snrna_optimus.py
@@ -196,16 +196,16 @@ def generate_col_attr(args):
     # Create metadata tables and their headers for bool
     for i in range(0, bool_field_names.shape[0]):
         name = bool_field_names[i]
-    data = final_df_bool[:, i]
-    col_attrs[name] = data
+        data = final_df_bool[:, i]
+        col_attrs[name] = data
 
     # Create metadata tables and their headers for float
     float_field_names = list(final_df_non_boolean.columns)
 
     for i in range(len(float_field_names)):
         name = float_field_names[i]
-    data = final_df_non_boolean[name].to_numpy()
-    col_attrs[name] = data
+        data = final_df_non_boolean[name].to_numpy()
+        col_attrs[name] = data
 
     if args.verbose:
         logging.info(

--- a/scripts/create_snrna_optimus_counts.py
+++ b/scripts/create_snrna_optimus_counts.py
@@ -137,7 +137,7 @@ def generate_col_attr(barcode_1_path,barcode_2_path,cell_metrics_path):
     if metrics_df.shape[0] == 0 or metrics_df.shape[1] == 0:
         logging.error("Cell metrics table is not valid")
         raise ValueError()
-    metrics_df = metrics_df.rename(columns={"CellId": "cell_id"})
+    metrics_df = metrics_df.rename(columns={"CellID": "cell_id"})
 
     # Order the cells by merging with cell_ids
     cellorder_df = pd.DataFrame(data={"cell_id": cell_ids})

--- a/scripts/create_snrna_optimus_counts.py
+++ b/scripts/create_snrna_optimus_counts.py
@@ -298,7 +298,7 @@ def create_loom_files(args):
     barcode_2 = np.load(args.cell_id_2)
     expr_sp_t, exon_sp_t = changeCoord(sp1,sp2,barcode_1,barcode_2)
 
-    # add input_id to col_attrs
+# add input_id to col_attrs
     col_attrs['input_id'] = np.repeat(args.input_id, expr_sp_t.shape[1])
 
     # generate global attributes

--- a/scripts/create_snrna_optimus_counts.py
+++ b/scripts/create_snrna_optimus_counts.py
@@ -137,7 +137,7 @@ def generate_col_attr(barcode_1_path,barcode_2_path,cell_metrics_path):
     if metrics_df.shape[0] == 0 or metrics_df.shape[1] == 0:
         logging.error("Cell metrics table is not valid")
         raise ValueError()
-    metrics_df = metrics_df.rename(columns={"Unnamed: 0": "cell_id"})
+    metrics_df = metrics_df.rename(columns={"CellId": "cell_id"})
 
     # Order the cells by merging with cell_ids
     cellorder_df = pd.DataFrame(data={"cell_id": cell_ids})
@@ -147,9 +147,6 @@ def generate_col_attr(barcode_1_path,barcode_2_path,cell_metrics_path):
         "n_reads",
         "noise_reads",
         "perfect_molecule_barcodes",
-        "reads_mapped_exonic",
-        "reads_mapped_intronic",
-        "reads_mapped_utr",
         "reads_mapped_uniquely",
         "reads_mapped_multiple",
         "duplicate_reads",
@@ -160,8 +157,6 @@ def generate_col_attr(barcode_1_path,barcode_2_path,cell_metrics_path):
         "fragments_with_single_read_evidence",
         "molecules_with_single_read_evidence",
         "perfect_cell_barcodes",
-        "reads_mapped_intergenic",
-        "reads_unmapped",
         "reads_mapped_too_many_loci",
         "n_genes",
         "genes_detected_multiple_observations"
@@ -303,7 +298,7 @@ def create_loom_files(args):
     barcode_2 = np.load(args.cell_id_2)
     expr_sp_t, exon_sp_t = changeCoord(sp1,sp2,barcode_1,barcode_2)
 
-# add input_id to col_attrs
+    # add input_id to col_attrs
     col_attrs['input_id'] = np.repeat(args.input_id, expr_sp_t.shape[1])
 
     # generate global attributes


### PR DESCRIPTION
BICAN Team (Jeff Goldy) identified that our metrics.csv produced by Optimus has empty or incorrect counts for exonic reads, intronic reads, unmapped reads, and intergenic reads. We need to remove these columns.  This bug is the result of sctools trying to grab these counts from the XF tag of the BAM file produced by STARsolo (the XF tag does not exist).
