### PR TITLE
Update optimus_output_schema_version

### DIFF
--- a/scripts/create_loom_optimus.py
+++ b/scripts/create_loom_optimus.py
@@ -329,7 +329,7 @@ def create_loom_files(args):
     Args:
         args (argparse.Namespace): input arguments for the run
     """
-    version = "1.0.0"
+    version = "1.0.1"
 
 
     # generate a dictionary of row attributes

--- a/scripts/create_snrna_optimus.py
+++ b/scripts/create_snrna_optimus.py
@@ -273,7 +273,7 @@ def create_loom_files(args):
     Args:
         args (argparse.Namespace): input arguments for the run
     """
-    version = "1.0.0"
+    version = "1.0.1"
 
 
     # generate a dictionary of row attributes

--- a/scripts/create_snrna_optimus_counts.py
+++ b/scripts/create_snrna_optimus_counts.py
@@ -281,7 +281,7 @@ def create_loom_files(args):
     Args:
         args (argparse.Namespace): input arguments for the run
     """
-    version = "1.0.0"
+    version = "1.0.1"
 
 
     # generate a dictionary of row attributes


### PR DESCRIPTION
Updating the optimus_output_schema_version to reflect the changes made to remove some columns from cell metrics (https://github.com/broadinstitute/warp-tools/pull/27)