### PR TITLE
Np gene metrics remove cols from optimus and slideseq

### DIFF
--- a/docker_versions.tsv
+++ b/docker_versions.tsv
@@ -4,3 +4,4 @@ us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-v0.3.15-1669902462
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-1678805190
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.0-1678808309
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1678990890
+us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1679940173

--- a/scripts/create_loom_optimus.py
+++ b/scripts/create_loom_optimus.py
@@ -156,7 +156,6 @@ def generate_col_attr(args):
         "perfect_molecule_barcodes",
         "reads_mapped_uniquely",
         "reads_mapped_multiple",
-        "duplicate_reads",
         "spliced_reads",
         "antisense_reads",
         "n_molecules",

--- a/scripts/create_snrna_optimus.py
+++ b/scripts/create_snrna_optimus.py
@@ -146,7 +146,6 @@ def generate_col_attr(args):
         "perfect_molecule_barcodes",
         "reads_mapped_uniquely",
         "reads_mapped_multiple",
-        "duplicate_reads",
         "spliced_reads",
         "antisense_reads",
         "n_molecules",

--- a/scripts/create_snrna_optimus_counts.py
+++ b/scripts/create_snrna_optimus_counts.py
@@ -149,7 +149,6 @@ def generate_col_attr(barcode_1_path,barcode_2_path,cell_metrics_path):
         "perfect_molecule_barcodes",
         "reads_mapped_uniquely",
         "reads_mapped_multiple",
-        "duplicate_reads",
         "spliced_reads",
         "antisense_reads",
         "n_molecules",


### PR DESCRIPTION
Our gene metrics.csv produced by Optimus/SlideSeq has empty or incorrect counts for exonic reads, intronic reads, unmapped reads, intergenic reads and duplicate reads. We need to remove these columns. This bug is the result of sctools trying to grab these counts from the XF tag of the BAM file produced by STARsolo (the XF tag does not exist).

