### PR TITLE
Update samplefastq

### DIFF
--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -111,19 +111,36 @@ void releaseReaderThreadMemory(int reader_thread_index, SamRecord* samRecord)
   g_read_arenas[reader_thread_index]->releaseSamRecordMemory(samRecord);
 }
 
+void outputHandler(WriteQueue* cur_write_queue, SamRecord* samrec, int reader_thread_index)
+{
+  cur_write_queue->enqueueWrite(std::make_pair(samrec, reader_thread_index));
+}
 // ---------------------------------------------------
 // Write to output BAM OR FASTQ
 // ----------------------------------------------------
-void writeFastqRecord(ogzstream& r1_out, ogzstream& r2_out, SamRecord* sam)
+void writeFastqRecord(ogzstream& r1_out, ogzstream& r2_out, SamRecord* sam, bool sample_bool)
 {
-  r1_out << "@" << sam->getReadName() << "\n" << sam->getString("CR").c_str()
-         << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
-  r2_out << "@" << sam->getReadName() << "\n" << sam->getSequence() << "\n+\n"
-         << sam->getQuality() << "\n";
+  // if sample_bool set to true, write reads with only corrected/correct barcodes 
+  // probably would need to change how this is done
+  if(sample_bool && sam->getStringTag("CB"))
+  {
+    r1_out << "@" << sam->getReadName() << "\n" << sam->getString("CR").c_str()
+           << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
+    r2_out << "@" << sam->getReadName() << "\n" << sam->getSequence() << "\n+\n"
+           << sam->getQuality() << "\n";    
+  }
+  // else print everything -- valid and invalid 
+  else
+  {
+    r1_out << "@" << sam->getReadName() << "\n" << sam->getString("CR").c_str()
+           << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
+    r2_out << "@" << sam->getReadName() << "\n" << sam->getSequence() << "\n+\n"
+           << sam->getQuality() << "\n"; 
+  }
 }
 
 void writeFastqRecordATAC(ogzstream& r1_out, ogzstream& r2_out, ogzstream& r3_out, 
-                          SamRecord* sam)
+                          SamRecord* sam, bool sample_bool)
 {
   std::string cb_barcode = sam->getString("CB").c_str();
   std::string cr_barcode = sam->getString("CR").c_str();
@@ -132,25 +149,48 @@ void writeFastqRecordATAC(ogzstream& r1_out, ogzstream& r2_out, ogzstream& r3_ou
   if (!cb_barcode.empty())
     write_cb_barcode = cb_barcode + ":CB:"; 
   
-  //R1
-  r2_out << "@" << write_cb_barcode
-          << sam->getReadName() << ":CR:" << cr_barcode
-          << "\n" << cr_barcode
-          << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
-  //R2
-  r1_out << "@" << write_cb_barcode
-          << sam->getReadName() << ":CR:" << cr_barcode
-          << "\n" << sam->getSequence() << "\n+\n"
-          << sam->getQuality() << "\n";
-  //R3
-  r3_out << "@" << write_cb_barcode
-          << sam->getReadName() << ":CR:" << cr_barcode
-          << "\n" << sam->getString("RS").c_str() << "\n+\n"
-          << sam->getString("RQ").c_str() <<  "\n";
+  // if sample_bool set to true, write reads with only corrected/correct barcodes 
+  if(sample_bool && sam->getStringTag("CB"))
+  {
+    //R1
+    r2_out << "@" << write_cb_barcode
+            << sam->getReadName() << ":CR:" << cr_barcode
+            << "\n" << cr_barcode
+            << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
+    //R2
+    r1_out << "@" << write_cb_barcode
+            << sam->getReadName() << ":CR:" << cr_barcode
+            << "\n" << sam->getSequence() << "\n+\n"
+            << sam->getQuality() << "\n";
+    //R3
+    r3_out << "@" << write_cb_barcode
+            << sam->getReadName() << ":CR:" << cr_barcode
+            << "\n" << sam->getString("RS").c_str() << "\n+\n"
+            << sam->getString("RQ").c_str() <<  "\n";
+  }
+  // else print everything -- valid and invalid 
+  else
+  {
+    //R1
+    r2_out << "@" << write_cb_barcode
+            << sam->getReadName() << ":CR:" << cr_barcode
+            << "\n" << cr_barcode
+            << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
+    //R2
+    r1_out << "@" << write_cb_barcode
+            << sam->getReadName() << ":CR:" << cr_barcode
+            << "\n" << sam->getSequence() << "\n+\n"
+            << sam->getQuality() << "\n";
+    //R3
+    r3_out << "@" << write_cb_barcode
+            << sam->getReadName() << ":CR:" << cr_barcode
+            << "\n" << sam->getString("RS").c_str() << "\n+\n"
+            << sam->getString("RQ").c_str() <<  "\n";
+  }
   
 }
 
-void fastqWriterThread(int write_thread_index)
+void fastqWriterThread(int write_thread_index, bool sample_bool)
 {
   std::string r1_output_fname = "fastq_R1_" + std::to_string(write_thread_index) + ".fastq.gz";
   ogzstream r1_out(r1_output_fname.c_str());
@@ -168,7 +208,7 @@ void fastqWriterThread(int write_thread_index)
     if (source_reader_index == WriteQueue::kShutdown)
       break;
 
-    writeFastqRecord(r1_out, r2_out, sam);
+    writeFastqRecord(r1_out, r2_out, sam, sample_bool);
     g_read_arenas[source_reader_index]->releaseSamRecordMemory(sam);
   }
 
@@ -177,8 +217,8 @@ void fastqWriterThread(int write_thread_index)
   r2_out.close();
 }
 
-//overload fastqWriterThread function for atac
-void fastqWriterThreadATAC(int write_thread_index)
+// write fastq for atac
+void fastqWriterThreadATAC(int write_thread_index, bool sample_bool)
 {
   std::string r1_output_fname = "fastq_R1_" + std::to_string(write_thread_index) + ".fastq.gz";
   ogzstream r1_out(r1_output_fname.c_str());
@@ -201,7 +241,7 @@ void fastqWriterThreadATAC(int write_thread_index)
     if (source_reader_index == WriteQueue::kShutdown)
       break;
 
-    writeFastqRecordATAC(r1_out, r2_out, r3_out, sam);    
+    writeFastqRecordATAC(r1_out, r2_out, r3_out, sam, sample_bool);    
     g_read_arenas[source_reader_index]->releaseSamRecordMemory(sam);
   }
 
@@ -481,8 +521,7 @@ bool readOneItem(FastQFile& fastQFileI1, bool has_I1_file_list,
 void fastQFileReaderThread(
     int reader_thread_index, std::string filenameI1, String filenameR1,
     String filenameR2, std::string filenameR3, const WhiteListCorrector* corrector, std::string barcode_orientation,
-    std::vector<std::pair<char, int>> g_parsed_read_structure,
-    std::function<void(WriteQueue*, SamRecord*, int)> output_handler)
+    std::vector<std::pair<char, int>> g_parsed_read_structure)
 {
   /// setting the shortest sequence allowed to be read
   FastQFile fastQFileI1(4, 4);
@@ -597,7 +636,7 @@ void mainCommon(
     std::vector<std::string> I1s, std::vector<std::string> R1s, 
     std::vector<std::string> R2s, std::vector<std::string> R3s,
     std::string sample_id,  std::vector<std::pair<char, int>> g_parsed_read_structure,
-    std::function<void(WriteQueue*, SamRecord*, int)> output_handler)
+    bool sample_bool)
 {
   std::cout << "reading whitelist file " << white_list_file << "...";
   // stores barcode correction map and vector of correct barcodes
@@ -617,9 +656,9 @@ void mainCommon(
   else if (output_format == "FASTQ")
     for (int i = 0; i < num_writer_threads; i++)
       if (R3s.empty())
-          writers.emplace_back(fastqWriterThread, i);
+          writers.emplace_back(fastqWriterThread, i, sample_bool);
       else
-          writers.emplace_back(fastqWriterThreadATAC, i);
+          writers.emplace_back(fastqWriterThreadATAC, i, sample_bool);
   else
     crash("ERROR: Output-format must be either FASTQ or BAM");
 
@@ -633,9 +672,7 @@ void mainCommon(
     readers.emplace_back(fastQFileReaderThread, i, I1s.empty() ? "" : I1s[i], R1s[i].c_str(),
                          R2s[i].c_str(), R3s.empty() ? "" : R3s[i].c_str(), 
                          &corrector, barcode_orientation,
-                         g_parsed_read_structure,
-                         //sam_record_filler, barcode_getter, 
-                         output_handler);
+                         g_parsed_read_structure);
   }
 
   for (auto& reader : readers)

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -173,8 +173,8 @@ void writeFastqRecordATAC(ogzstream& r1_out, ogzstream& r2_out, ogzstream& r3_ou
       //R3
       r3_out << "@" 
             << sam->getReadName() 
-            << "\n" << sam->getString("RS").c_str() << "\n+\n"
-            << sam->getString("RQ").c_str() <<  "\n";
+            << "\n" << sam->getString("S3").c_str() << "\n+\n"
+            << sam->getString("Q3").c_str() <<  "\n";
     }
   }
   // else print everything -- valid and invalid 
@@ -193,8 +193,8 @@ void writeFastqRecordATAC(ogzstream& r1_out, ogzstream& r2_out, ogzstream& r3_ou
     //R3
     r3_out << "@" << write_cb_barcode
             << sam->getReadName() << ":CR:" << cr_barcode
-            << "\n" << sam->getString("RS").c_str() << "\n+\n"
-            << sam->getString("RQ").c_str() <<  "\n";
+            << "\n" << sam->getString("S3").c_str() << "\n+\n"
+            << sam->getString("Q3").c_str() <<  "\n";
   }
   
 }
@@ -376,8 +376,8 @@ void fillSamRecordCommon(SamRecord* samRecord, FastQFile* fastQFileI1,
   // add raw sequence and quality sequence for the R3 atac fastq file 
   if (has_R3_file_list)
   { 
-    samRecord->addTag("RS", 'Z', fastQFileR3->myRawSequence.c_str());
-    samRecord->addTag("RQ", 'Z', fastQFileR3->myQualityString.c_str());
+    samRecord->addTag("S3", 'Z', fastQFileR3->myRawSequence.c_str());
+    samRecord->addTag("Q3", 'Z', fastQFileR3->myQualityString.c_str());
   }
 }
 

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -122,15 +122,18 @@ void writeFastqRecord(ogzstream& r1_out, ogzstream& r2_out, SamRecord* sam, bool
 {
   // if sample_bool set to true, write reads with only corrected/correct barcodes 
   // probably would need to change how this is done
-  if(sample_bool && sam->getStringTag("CB"))
+  if(sample_bool)
   {
-    //R1 -- S1 for read + Q1 for quality 
-    r1_out << "@" << sam->getReadName() << "\n" 
-          << sam->getString("S1")
-          <<"\n+\n" 
-          << sam->getString("Q1") << "\n";
-    r2_out << "@" << sam->getReadName() << "\n" << sam->getSequence() << "\n+\n"
-           << sam->getQuality() << "\n";    
+    if (sam->getStringTag("CB"))
+    {
+      //R1 -- S1 for read + Q1 for quality 
+      r1_out << "@" << sam->getReadName() << "\n" 
+            << sam->getString("S1")
+            <<"\n+\n" 
+            << sam->getString("Q1") << "\n";
+      r2_out << "@" << sam->getReadName() << "\n" << sam->getSequence() << "\n+\n"
+            << sam->getQuality() << "\n";    
+    }
   }
   // else print everything -- valid and invalid 
   else
@@ -153,23 +156,26 @@ void writeFastqRecordATAC(ogzstream& r1_out, ogzstream& r2_out, ogzstream& r3_ou
     write_cb_barcode = cb_barcode + ":CB:"; 
   
   // if sample_bool set to true, write reads with only corrected/correct barcodes 
-  if(sample_bool && sam->getStringTag("CB"))
+  if(sample_bool) 
   {
-    //R1 -- S1 for read + Q1 for quality 
-    r2_out << "@" << write_cb_barcode
+    if (sam->getStringTag("CB"))
+    {
+      //R1 -- S1 for read + Q1 for quality 
+      r2_out << "@" << write_cb_barcode
             << sam->getReadName() << ":CR:" << cr_barcode
             << "\n" << sam->getString("S1")
             << "\n+\n" << sam->getString("Q1") << "\n";
-    //R2
-    r1_out << "@" << write_cb_barcode
+      //R2
+      r1_out << "@" << write_cb_barcode
             << sam->getReadName() << ":CR:" << cr_barcode
             << "\n" << sam->getSequence() << "\n+\n"
             << sam->getQuality() << "\n";
-    //R3
-    r3_out << "@" << write_cb_barcode
+      //R3
+      r3_out << "@" << write_cb_barcode
             << sam->getReadName() << ":CR:" << cr_barcode
             << "\n" << sam->getString("RS").c_str() << "\n+\n"
             << sam->getString("RQ").c_str() <<  "\n";
+    }
   }
   // else print everything -- valid and invalid 
   else

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -124,8 +124,11 @@ void writeFastqRecord(ogzstream& r1_out, ogzstream& r2_out, SamRecord* sam, bool
   // probably would need to change how this is done
   if(sample_bool && sam->getStringTag("CB"))
   {
-    r1_out << "@" << sam->getReadName() << "\n" << sam->getString("CR").c_str()
-           << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
+    //R1 -- S1 for read + Q1 for quality 
+    r1_out << "@" << sam->getReadName() << "\n" 
+          << sam->getString("S1")
+          <<"\n+\n" 
+          << sam->getString("Q1") << "\n";
     r2_out << "@" << sam->getReadName() << "\n" << sam->getSequence() << "\n+\n"
            << sam->getQuality() << "\n";    
   }
@@ -152,11 +155,11 @@ void writeFastqRecordATAC(ogzstream& r1_out, ogzstream& r2_out, ogzstream& r3_ou
   // if sample_bool set to true, write reads with only corrected/correct barcodes 
   if(sample_bool && sam->getStringTag("CB"))
   {
-    //R1
+    //R1 -- S1 for read + Q1 for quality 
     r2_out << "@" << write_cb_barcode
             << sam->getReadName() << ":CR:" << cr_barcode
-            << "\n" << cr_barcode
-            << sam->getString("UR") << "\n+\n" << sam->getString("CY") << sam->getString("UY") << "\n";
+            << "\n" << sam->getString("S1")
+            << "\n+\n" << sam->getString("Q1") << "\n";
     //R2
     r1_out << "@" << write_cb_barcode
             << sam->getReadName() << ":CR:" << cr_barcode
@@ -347,6 +350,11 @@ void fillSamRecordCommon(SamRecord* samRecord, FastQFile* fastQFileI1,
   samRecord->setReadName(fastQFileR2->mySequenceIdentifier.c_str());
   samRecord->setSequence(fastQFileR2->myRawSequence.c_str());
   samRecord->setQuality(fastQFileR2->myQualityString.c_str());
+  
+  // add raw sequence from R1 -- this is for the downsampling
+  samRecord->addTag("S1", 'Z', fastQFileR1->myRawSequence.c_str());
+  samRecord->addTag("Q1", 'Z', fastQFileR1->myQualityString.c_str());
+  
   // add barcode and quality
   samRecord->addTag("CR", 'Z', barcode_seq.c_str());
   samRecord->addTag("CY", 'Z', barcode_quality.c_str());

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -597,7 +597,7 @@ void fastQFileReaderThread(
           barcode, samrec, corrector, &n_barcode_corrected, 
           &n_barcode_correct, &n_barcode_errors, g_write_queues.size());
 
-      output_handler(g_write_queues[bam_bucket].get(), samrec, reader_thread_index);
+      outputHandler(g_write_queues[bam_bucket].get(), samrec, reader_thread_index);
 
       if (total_reads % 10000000 == 0)
       {

--- a/fastqpreprocessing/src/fastq_common.cpp
+++ b/fastqpreprocessing/src/fastq_common.cpp
@@ -161,18 +161,18 @@ void writeFastqRecordATAC(ogzstream& r1_out, ogzstream& r2_out, ogzstream& r3_ou
     if (sam->getStringTag("CB"))
     {
       //R1 -- S1 for read + Q1 for quality 
-      r2_out << "@" << write_cb_barcode
-            << sam->getReadName() << ":CR:" << cr_barcode
+      r2_out << "@" 
+            << sam->getReadName()
             << "\n" << sam->getString("S1")
             << "\n+\n" << sam->getString("Q1") << "\n";
       //R2
-      r1_out << "@" << write_cb_barcode
-            << sam->getReadName() << ":CR:" << cr_barcode
+      r1_out << "@" 
+            << sam->getReadName()
             << "\n" << sam->getSequence() << "\n+\n"
             << sam->getQuality() << "\n";
       //R3
-      r3_out << "@" << write_cb_barcode
-            << sam->getReadName() << ":CR:" << cr_barcode
+      r3_out << "@" 
+            << sam->getReadName() 
             << "\n" << sam->getString("RS").c_str() << "\n+\n"
             << sam->getString("RQ").c_str() <<  "\n";
     }

--- a/fastqpreprocessing/src/fastq_common.h
+++ b/fastqpreprocessing/src/fastq_common.h
@@ -39,6 +39,6 @@ void mainCommon(
     std::string white_list_file, std::string barcode_orientation, int num_writer_threads, std::string output_format,
     std::vector<std::string> I1s, std::vector<std::string> R1s, std::vector<std::string> R2s, std::vector<std::string> R3s,
     std::string sample_id, std::vector<std::pair<char, int>> g_parsed_read_structure,
-    std::function<void(WriteQueue*, SamRecord*, int)> output_handler);
+    bool sample_bool);
 
 #endif // __SCTOOLS_FASTQPREPROCESSING_FASTQ_COMMON_H_

--- a/fastqpreprocessing/src/fastq_slideseq.cpp
+++ b/fastqpreprocessing/src/fastq_slideseq.cpp
@@ -1,11 +1,6 @@
 #include "fastq_common.h"
 #include "input_options.h"
 
-void outputHandler(WriteQueue* cur_write_queue, SamRecord* samrec, int reader_thread_index)
-{
-  cur_write_queue->enqueueWrite(std::make_pair(samrec, reader_thread_index));
-}
-
 int main(int argc, char** argv)
 {
   INPUT_OPTIONS_FASTQ_READ_STRUCTURE options = readOptionsFastqSlideseq(argc, argv);
@@ -18,7 +13,7 @@ int main(int argc, char** argv)
 
   mainCommon(options.white_list_file, options.barcode_orientation, num_writer_threads, options.output_format,
              options.I1s, options.R1s, options.R2s, options.R3s, options.sample_id, g_parsed_read_structure,
-             outputHandler);
+             options.sample_bool);
 
   return 0;
 }

--- a/fastqpreprocessing/src/fastqprocess.cpp
+++ b/fastqpreprocessing/src/fastqprocess.cpp
@@ -1,11 +1,6 @@
 #include "fastq_common.h"
 #include "input_options.h"
 
-void outputHandler(WriteQueue* cur_write_queue, SamRecord* samrec, int reader_thread_index)
-{
-  cur_write_queue->enqueueWrite(std::make_pair(samrec, reader_thread_index));
-}
-
 int main(int argc, char** argv)
 {
   InputOptionsFastqProcess options = readOptionsFastqProcess(argc, argv);
@@ -19,7 +14,7 @@ int main(int argc, char** argv)
 
   mainCommon(options.white_list_file, options.barcode_orientation, num_writer_threads, options.output_format,
              options.I1s, options.R1s, options.R2s, options.R3s, options.sample_id, g_parsed_read_structure,
-             outputHandler);
+             options.sample_bool);
 
   return 0;
 }

--- a/fastqpreprocessing/src/input_options.cpp
+++ b/fastqpreprocessing/src/input_options.cpp
@@ -109,6 +109,7 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
     {"R2",                  required_argument, 0, 'r'},
     {"R3",                  required_argument, 0, 'A'},
     {"barcode-orientation", required_argument, 0, 'O'},
+    {"sample_bool",         required_argument, 0, 'D'},
     {"white-list",          required_argument, 0, 'w'},
     {"output-format",       required_argument, 0, 'F'},
     {0, 0, 0, 0}
@@ -126,6 +127,7 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
     "R2 [required -- File that contains the reads. This corresponds to R2 for v2/v3/multiome GEX/slideseq. However, it corresponds to R1 in scATAC.]",
     "R3 [optional -- This file is needed for scATAC and corresponds to R2.]",
     "barcode-orientation [optional: default FIRST_BP. Other options include LAST_BP, FIRST_BP_RC or LAST_BP_RC.]",
+    "sample_bool [optional: default false. When set to false, all barcodes (valid + invalid) are printed. If set to true, only valid barcodes are printed.]",
     "whitelist (from cellranger) of barcodes [required]",
     "output-format : either FASTQ or BAM [required]",
   };
@@ -177,6 +179,9 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
       break;
     case 'O':
       options.barcode_orientation = string(optarg);
+      break;
+    case 'D':
+      options.sample_bool = bool(optarg);
       break;
     case 'w':
       options.white_list_file = string(optarg);
@@ -266,6 +271,7 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
     {"R2",                  required_argument, 0, 'r'},
     {"R3",                  required_argument, 0, 'A'},
     {"barcode-orientation", required_argument, 0, 'O'},
+    {"sample_bool",         required_argument, 0, 'D'},
     {"white-list",          required_argument, 0, 'w'},
     {"output-format",       required_argument, 0, 'F'},
     {0, 0, 0, 0}
@@ -283,6 +289,7 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
     "R2 [required -- File that contains the reads. This corresponds to R2 for v2/v3/multiome GEX/slideseq. However, it corresponds to R1 in scATAC.]",
     "R3 [optional -- This file is needed for scATAC and corresponds to R2.]", 
     "barcode-orientation [optional: default FIRST_BP. Other options include LAST_BP, FIRST_BP_RC or LAST_BP_RC.]",
+    "sample_bool [optional: default false. When set to false, all barcodes (valid + invalid) are printed. If set to true, only valid barcodes are printed.]",
     "whitelist (from cellranger) of barcodes [required]",
     "output-format : either FASTQ or BAM [required]",
   };
@@ -333,6 +340,9 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
       break;
     case 'O':
       options.barcode_orientation = string(optarg);
+      break;
+    case 'D':
+      options.sample_bool = bool(optarg);
       break;
     case 'w':
       options.white_list_file = string(optarg);

--- a/fastqpreprocessing/src/input_options.h
+++ b/fastqpreprocessing/src/input_options.h
@@ -25,6 +25,9 @@ struct INPUT_OPTIONS_FASTQ_READ_STRUCTURE
   std::string read_structure;
 
   std::string sample_id;
+
+  // if set to false we print out all valid/invalid barcodes.
+  bool sample_bool = false;
 };
 
 // Structure to hold input options for fastqprocess
@@ -47,6 +50,9 @@ struct InputOptionsFastqProcess
   std::string read_structure;
 
   std::string sample_id;
+
+  // if set to false we print out all valid/invalid barcodes.
+  bool sample_bool = false; 
 };
 
 InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv);

--- a/fastqpreprocessing/src/samplefastq.cpp
+++ b/fastqpreprocessing/src/samplefastq.cpp
@@ -17,6 +17,6 @@ int main(int argc, char** argv)
 
   mainCommon(options.white_list_file, options.barcode_orientation, /*num_writer_threads=*/1, options.output_format,
              options.I1s, options.R1s, options.R2s, options.R3s, options.sample_id, g_parsed_read_structure,
-             options.sample_bool);
+             true);
   return 0;
 }

--- a/fastqpreprocessing/src/samplefastq.cpp
+++ b/fastqpreprocessing/src/samplefastq.cpp
@@ -1,20 +1,10 @@
 #include "fastq_common.h"
 #include "input_options.h"
-#include <fstream>
 
 // ---------------------------------------------------
-// Global Variable
+// Global Variables
 // ----------------------------------------------------
 std::vector<std::pair<char, int>> g_parsed_read_structure;
-
-// ---------------------------------------------------
-// Used to write files -- needs to be merged 
-// test this
-// ----------------------------------------------------
-void outputHandler(WriteQueue* cur_write_queue, SamRecord* samrec, int reader_thread_index)
-{
-  cur_write_queue->enqueueWrite(std::make_pair(samrec, reader_thread_index));
-}
 
 // ---------------------------------------------------
 // Main
@@ -22,68 +12,11 @@ void outputHandler(WriteQueue* cur_write_queue, SamRecord* samrec, int reader_th
 int main(int argc, char** argv)
 {
   INPUT_OPTIONS_FASTQ_READ_STRUCTURE options = readOptionsFastqSlideseq(argc, argv);
-
-  std::ofstream outfile_r1("sampled_down.R1");
-  if (!outfile_r1)
-    crash("Failed to open output file sampled_down.R1");
-    
-  std::ofstream outfile_r2("sampled_down.R2");
-  if (!outfile_r2)
-    crash("Failed to open output file sampled_down.R2");
-
-
-
+  
   g_parsed_read_structure = parseReadStructure(options.read_structure);
 
   mainCommon(options.white_list_file, options.barcode_orientation, /*num_writer_threads=*/1, options.output_format,
              options.I1s, options.R1s, options.R2s, options.R3s, options.sample_id, g_parsed_read_structure,
-             [&outfile_r1, &outfile_r2](WriteQueue* ignored1, SamRecord* sam, int reader_thread_index)
-             {
-               if (sam->getStringTag("CB"))
-               {
-                   // Read structure can be 8C18X6C9M1X, 16C10M or 16C12M 
-                   const char* barcode = sam->getString("CR").c_str();
-                   const char* quality_score = sam->getString("CY").c_str();
-                  
-                   // Barcode 
-                   int barcode_index = 0;        
-                   outfile_r1 << "@" <<  sam->getReadName() << "\n";
-                   for (auto [tag, length] : g_parsed_read_structure)
-                   {
-                      if (tag == 'C')
-                      {
-                            outfile_r1 << std::string_view(barcode + barcode_index, length);
-                            barcode_index = length;
-                      }
-                      else if (tag == 'M')
-                            outfile_r1 << sam->getString("UR");
-                      else if (tag == 'X')
-                            outfile_r1 << std::string_view("CTTCAGCGTTCCCGAGAG", length);        
-                   } 
-                   outfile_r1 << "\n" << "+\n";
-                   
-                   // Quality 
-                   barcode_index = 0;
-                   for (auto [tag, length] : g_parsed_read_structure)
-                   {
-                      if (tag == 'C')
-                      {
-                            outfile_r1 << std::string_view(quality_score + barcode_index, length);
-                            barcode_index = length;
-                      }
-                      else if (tag == 'M')
-                            outfile_r1 << sam->getString("UY");
-                      else if (tag == 'X')
-                            outfile_r1 << std::string_view("FFFFFFFFFFFFFFFFFF", length);
-                   }       
-                   outfile_r1 << "\n";
-                 
-                   outfile_r2 << "@" << sam->getReadName() << "\n"
-                          << sam->getSequence() << "\n"
-                          << "+\n"
-                          << sam->getQuality() << "\n";
-               }
-               releaseReaderThreadMemory(reader_thread_index,sam);
-             });
+             options.sample_bool);
   return 0;
 }

--- a/fastqpreprocessing/src/samplefastq.cpp
+++ b/fastqpreprocessing/src/samplefastq.cpp
@@ -9,6 +9,7 @@ std::vector<std::pair<char, int>> g_parsed_read_structure;
 
 // ---------------------------------------------------
 // Used to write files -- needs to be merged 
+// test this
 // ----------------------------------------------------
 void outputHandler(WriteQueue* cur_write_queue, SamRecord* samrec, int reader_thread_index)
 {


### PR DESCRIPTION
Updated samplefastq to account for scATAC-seq. 

Previously samplefastq was initially set to deal with only GEX data that takes only 2 files (R1 and R2) as input. This is now updated to also take ATAC-seq data as input with the 3 files: R1, R2 and R3. 

Moreover, to avoid code redundancy, an additional parameter `sample_bool` is now taken as input. 

`sample_bool` is set to `False` by default -- meaning it will print out all reads with valid and invalid barcodes. Valid reads will have both the CB and CR tags, while invalid barcodes will only have the CR tags. This is equivalent to `fastqprocess`. 

If `sample_bool` is set to `True`, `samplefastq` is called -- where only reads with valid barcodes are written to the fastq files. 
