### PR TITLE
This creates automation (CI) for all the 3rd party tools containers for WARP

### DIFF
--- a/.github/workflows/build-3rd-party-tools.yml
+++ b/.github/workflows/build-3rd-party-tools.yml
@@ -1,4 +1,4 @@
-name: Warp Tools CI
+name: Warp 3rd Party Tools CI
 
 # Controls when the workflow will run
 on:

--- a/.github/workflows/build-3rd-party-tools.yml
+++ b/.github/workflows/build-3rd-party-tools.yml
@@ -1,0 +1,62 @@
+name: Warp Tools CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "develop" and "master" branch
+  pull_request:
+    branches: [ "develop", "master" ]
+    paths:
+      - '3rd-party-tools/**'
+    paths-ignore:
+      - '**/README.md'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker Image Tag (default: branch_name)' 
+
+env:
+  PROJECT_NAME: WARP 3rd Party Tools
+  # Github repo name
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
+  # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
+  DOCKER_REGISTRY: us.gcr.io
+  GCR_PATH: broad-gotc-prod/warp-tools
+  TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
+
+  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # The job that builds our container
+  build-arrays-picard-private:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 3rd-party-tools/arrays_picard_private
+    # Map a step output to a job output
+    outputs:
+      imagePath: ${{ steps.saveImagePath.outputs.url }}
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}
+    - name: Check working directory'
+      run: |
+        echo "Current directory: "
+        pwd
+        ls -lht
+    # Save the image path to an output
+    - id: 'saveImagePath'
+      run: echo "url=${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}" >> $GITHUB_OUTPUT
+    # Log into the Google Docker registry
+    - id: 'Auth'
+      name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.DOCKER_REGISTRY }}
+        username: _json_key
+        password: ${{ secrets.GCR_CI_KEY }}
+    # Push the image to the Google Docker registry
+    - name: Push image
+      run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"

--- a/.github/workflows/build-3rd-party-tools.yml
+++ b/.github/workflows/build-3rd-party-tools.yml
@@ -7,8 +7,6 @@ on:
     branches: [ "develop", "master" ]
     paths:
       - '3rd-party-tools/**'
-    paths-ignore:
-      - '**/README.md'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-arrays-picard-private.yml
+++ b/.github/workflows/build-arrays-picard-private.yml
@@ -19,7 +19,7 @@ env:
   REPOSITORY_NAME: ${{ github.event.repository.name }}
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
-  GCR_PATH: broad-gotc-prod/warp-tools
+  GCR_PATH: broad-arrays-prod/arrays-picard-private
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/build-arrays-picard-private.yml
+++ b/.github/workflows/build-arrays-picard-private.yml
@@ -19,7 +19,7 @@ env:
   REPOSITORY_NAME: ${{ github.event.repository.name }}
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
-  GCR_PATH: broad-arrays-prod/arrays-picard-private
+  GCR_PATH: broad-gotc-prod/arrays-picard-private
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/build-arrays-picard-private.yml
+++ b/.github/workflows/build-arrays-picard-private.yml
@@ -1,4 +1,4 @@
-name: Warp 3rd Party Tools CI
+name: Arrays Picard Private CI
 
 # Controls when the workflow will run
 on:
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ "develop", "master" ]
     paths:
-      - '3rd-party-tools/**'
+      - '3rd-party-tools/arrays_picard_private/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:

--- a/.github/workflows/build-atac-barcodes.yml
+++ b/.github/workflows/build-atac-barcodes.yml
@@ -1,4 +1,4 @@
-name: Arrays Picard Private CI
+name: ATAC Barcodes CI
 
 # Controls when the workflow will run
 on:
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ "develop", "master" ]
     paths:
-      - '3rd-party-tools/arrays_picard_private/**'
+      - '3rd-party-tools/atac_barcodes/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -19,18 +19,17 @@ env:
   REPOSITORY_NAME: ${{ github.event.repository.name }}
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
-  GCR_PATH: broad-gotc-prod/arrays-picard-private
+  GCR_PATH: broad-gotc-prod/atac-barcodes
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # The job that builds our container
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: 3rd-party-tools/arrays_picard_private
+        working-directory: 3rd-party-tools/atac_barcodes
     # Map a step output to a job output
     outputs:
       imagePath: ${{ steps.saveImagePath.outputs.url }}

--- a/.github/workflows/build-warp-tools.yml
+++ b/.github/workflows/build-warp-tools.yml
@@ -11,8 +11,8 @@ on:
     #  - '**/README.md'
   pull_request:
     branches: [ "develop", "master" ]
-    paths-ignore:
-      - '**/README.md'
+    paths:
+      - 'tools/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -65,7 +65,7 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-  
+  #Runs pytest on all python code in warp-tools/tools
   test-python:
     needs: build
     runs-on: ubuntu-latest

--- a/3rd-party-tools/arrays_picard_private/Dockerfile
+++ b/3rd-party-tools/arrays_picard_private/Dockerfile
@@ -1,4 +1,5 @@
-FROM adoptopenjdk/openjdk8:debian-slim
+# Adding a platform tag to ensure that images built on ARM-based machines
+FROM --platform="linux/amd64" adoptopenjdk/openjdk8:debian-slim
 
 ARG PICARD_PRIVATE_VERSION=c24d8e2dfd6de9c663416278040a9f91b6a5e3eb
 

--- a/3rd-party-tools/arrays_picard_private/Dockerfile
+++ b/3rd-party-tools/arrays_picard_private/Dockerfile
@@ -1,4 +1,4 @@
-# Adding a platform tag to ensure that images built on ARM-based machines
+# Adding a platform tag to ensure that images built on ARM-based machines.
 FROM --platform="linux/amd64" adoptopenjdk/openjdk8:debian-slim
 
 ARG PICARD_PRIVATE_VERSION=c24d8e2dfd6de9c663416278040a9f91b6a5e3eb

--- a/3rd-party-tools/arrays_picard_private/Dockerfile
+++ b/3rd-party-tools/arrays_picard_private/Dockerfile
@@ -1,4 +1,4 @@
-# Adding a platform tag to ensure that images built on ARM-based machines.
+# Adding a platform tag to ensure that images built on ARM-based machines
 FROM --platform="linux/amd64" adoptopenjdk/openjdk8:debian-slim
 
 ARG PICARD_PRIVATE_VERSION=c24d8e2dfd6de9c663416278040a9f91b6a5e3eb

--- a/3rd-party-tools/atac_barcodes/Dockerfile
+++ b/3rd-party-tools/atac_barcodes/Dockerfile
@@ -1,3 +1,4 @@
+# Adding a platform tag to ensure that images built on ARM-based machines.
 FROM --platform=linux/amd64 python:3.9.2
 
 ENV TERM=xterm-256color \


### PR DESCRIPTION
- We have about 30 (and growing) 3rd-party tools containers in warp-tools
- This will automatically build every one of them with the following rules:
   - If only a file inside container A has been modified, trigger the docker build automation just for container A.
   - Run tests only for container A, if there are any (unit tests or functional tests).
   - If the build succeeds, push to our docker registry (GCR)
- A manual trigger will also be provided for developers to make sure their containers build properly before merging to develop or master