### PR TITLE
Update TagSort to work with RefSeq gtf

### DIFF
--- a/tools/TagSort/src/mitochondrial_gene_selector.cpp
+++ b/tools/TagSort/src/mitochondrial_gene_selector.cpp
@@ -120,7 +120,7 @@ std::unordered_set<std::string> getInterestingMitochondrialGenes(
       std::string key = ltrim(attrib).substr(0,ltrim(attrib).find_first_of(" "));
       std::string value = ltrim(attrib).substr(ltrim(attrib).find_first_of(" ") +1);
 
-      // removed lines below b/c we found a different way to split strings
+      // removed the lines below b/c we found a different way to split strings
       // std::vector<std::string> key_and_val = splitStringToFields(ltrim(attrib), ' ');
       // if (key_and_val.size() != 2)
       //   crash("Expected 2 fields, found " + std::to_string(key_and_val.size()) + " fields");

--- a/tools/TagSort/src/mitochondrial_gene_selector.cpp
+++ b/tools/TagSort/src/mitochondrial_gene_selector.cpp
@@ -18,11 +18,20 @@ std::vector<std::string> splitStringToFields(std::string const& str, char delim)
   return ret;
 }
 
+// trim from left end
 inline std::string ltrim(std::string& s)
 {
   auto it = std::find_if_not(s.begin(), s.end(), [](int c) { return isspace(c); });
   s.erase(s.begin(), it);
   return s;
+}
+
+// trim from right end (in place) -- https://stackoverflow.com/questions/216823/how-to-trim-an-stdstring
+inline std::string rtrim(std::string &s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+    return s;
 }
 
 // remove the " (quotes) from the beginning and end of the string (TODO also
@@ -100,7 +109,7 @@ std::unordered_set<std::string> getInterestingMitochondrialGenes(
     if (tabbed_fields[2] != "gene") // skip the line unless it is a gene
       continue;
     // split the semicolon-separated attributes field
-    std::vector<std::string> attribs = splitStringToFields(tabbed_fields[8], ';');
+    std::vector<std::string> attribs = splitStringToFields(rtrim(tabbed_fields[8]), ';');
 
     std::string gene_name;
     std::string gene_id;
@@ -108,13 +117,17 @@ std::unordered_set<std::string> getInterestingMitochondrialGenes(
     for (std::string attrib : attribs)
     {
       // each attribute is a space-separated key-value pair
-      std::vector<std::string> key_and_val = splitStringToFields(ltrim(attrib), ' ');
-      if (key_and_val.size() != 2)
-        crash("Expected 2 fields, found " + std::to_string(key_and_val.size()) + " fields");
+      std::string key = ltrim(attrib).substr(0,ltrim(attrib).find_first_of(" "));
+      std::string value = ltrim(attrib).substr(ltrim(attrib).find_first_of(" ") +1);
+
+      // removed lines below b/c we found a different way to split strings
+      // std::vector<std::string> key_and_val = splitStringToFields(ltrim(attrib), ' ');
+      // if (key_and_val.size() != 2)
+      //   crash("Expected 2 fields, found " + std::to_string(key_and_val.size()) + " fields");
 
       // the second element in the pair is the value string
-      std::string& key = key_and_val[0];
-      std::string value = removeQuotes(key_and_val[1]);
+      // std::string& key = key_and_val[0];
+      // std::string value = removeQuotes(key_and_val[1]);
 
       if (key == "gene_id")
         gene_id = value;


### PR DESCRIPTION
We updated TagSort to work with the RefSeq gtf.

We updated it by:
- removing trailing white spaces at the right of the string. This was causing issues when we were splitting on semi-colons.
- splitting attributes in a different way. We are now splitting on the first space occurrence -- as we want to split the string into key and value pairs. Splitting on all spaces is problematic as the value may contain spaces as well. 
