### PR TITLE
Move snM3C Dockerfiles from warp to warp-tools

### DIFF
--- a/.github/workflows/build-m3C-yap-hisat.yml
+++ b/.github/workflows/build-m3C-yap-hisat.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ "develop", "master" ]
     paths:
-      - '3rd-party-tools/m3C-yap-hisat/**'
+      - '3rd-party-tools/m3c-yap-hisat/**'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -19,7 +19,7 @@ env:
   REPOSITORY_NAME: ${{ github.event.repository.name }}
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
-  GCR_PATH: broad-gotc-prod/m3C-yap-hisat
+  GCR_PATH: broad-gotc-prod/m3c-yap-hisat
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: 3rd-party-tools/m3C-yap-hisat
+        working-directory: 3rd-party-tools/m3c-yap-hisat
     # Map a step output to a job output
     outputs:
       imagePath: ${{ steps.saveImagePath.outputs.url }}

--- a/.github/workflows/build-m3C-yap-hisat.yml
+++ b/.github/workflows/build-m3C-yap-hisat.yml
@@ -1,0 +1,59 @@
+name: M3C YAP Hisat CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "develop" and "master" branch
+  pull_request:
+    branches: [ "develop", "master" ]
+    paths:
+      - '3rd-party-tools/m3C-yap-hisat/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker Image Tag (default: branch_name)' 
+
+env:
+  PROJECT_NAME: WARP 3rd Party Tools
+  # Github repo name
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
+  # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
+  DOCKER_REGISTRY: us.gcr.io
+  GCR_PATH: broad-gotc-prod/m3C-yap-hisat
+  TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
+
+  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # The job that builds our container
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 3rd-party-tools/m3C-yap-hisat
+    # Map a step output to a job output
+    outputs:
+      imagePath: ${{ steps.saveImagePath.outputs.url }}
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}
+    - name: Check working directory'
+      run: |
+        echo "Current directory: "
+        pwd
+        ls -lht
+    # Save the image path to an output
+    - id: 'saveImagePath'
+      run: echo "url=${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}" >> $GITHUB_OUTPUT
+    # Log into the Google Docker registry
+    - id: 'Auth'
+      name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.DOCKER_REGISTRY }}
+        username: _json_key
+        password: ${{ secrets.GCR_CI_KEY }}
+    # Push the image to the Google Docker registry
+    - name: Push image
+      run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"

--- a/3rd-party-tools/m3C-yap-hisat/Dockerfile
+++ b/3rd-party-tools/m3C-yap-hisat/Dockerfile
@@ -1,0 +1,47 @@
+FROM mambaorg/micromamba:0.23.0
+
+WORKDIR /usr/gitc
+RUN echo $PATH
+ENV PATH="$PATH:/opt/conda/bin:/root/pkg/hisat-3n"
+RUN echo $PATH
+
+
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER hisat3n_env.yml /tmp/hisat3n_env.yml
+RUN micromamba install -y -f /tmp/hisat3n_env.yml && \
+    micromamba clean --all --yes
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+RUN yap --version
+RUN allcools --version
+
+USER root
+# default argument when not provided in the --build-arg
+# to build the image with gcp, use
+# docker build --build-arg gcp=true -t mapping-gcp:tag .
+ARG gcp
+RUN if [ "$gcp" = "true" ] ; then \
+        apt-get update && \
+        apt-get install -y curl gnupg && \
+        echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+        tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+        curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+        apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+        apt-get update -y && \
+        apt-get install google-cloud-sdk -y;  \
+      else echo 'no gcp install';  \
+    fi
+
+RUN apt-get update; \
+    apt-get install; -y make; \
+    apt-get install -y git-all; \
+    apt-get install -y build-essential; \
+    mkdir -p ~/pkg; \
+    cd ~/pkg; \
+    git clone https://github.com/DaehwanKimLab/hisat2.git hisat-3n; \
+    cd hisat-3n; \
+    git checkout -b hisat-3n origin/hisat-3n; \
+    make; \
+    echo 'export PATH=$HOME/pkg/hisat-3n:$PATH' >> ~/.bashrc; \
+    source ~/.bashrc

--- a/3rd-party-tools/m3C-yap-hisat/Dockerfile
+++ b/3rd-party-tools/m3C-yap-hisat/Dockerfile
@@ -1,4 +1,5 @@
-FROM mambaorg/micromamba:0.23.0
+# Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
+FROM --platform="linux/amd64" mambaorg/micromamba:0.23.0
 
 WORKDIR /usr/gitc
 RUN echo $PATH

--- a/3rd-party-tools/m3C-yap-hisat/Dockerfile
+++ b/3rd-party-tools/m3C-yap-hisat/Dockerfile
@@ -1,4 +1,4 @@
-# Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
+# Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines.
 FROM --platform="linux/amd64" mambaorg/micromamba:0.23.0
 
 WORKDIR /usr/gitc

--- a/3rd-party-tools/m3C-yap-hisat/README.md
+++ b/3rd-party-tools/m3C-yap-hisat/README.md
@@ -1,0 +1,35 @@
+# HISAT2-3N
+
+## Quick reference
+
+Copy and paste to pull this image
+
+#### `docker pull us.gcr.io/broad-gotc-prod/hisat3n:1.0.0-1.11-1624651616`
+
+- __What is this image:__ This image is a lightweight alpine-based image for running SAMTOOLS.
+- __What is HISAT2-3N:__ HISAT2 is a fast and sensitive alignment program for mapping next-generation sequencing reads to the human genome. See [here](https://github.com/DaehwanKimLab/hisat2) more information.
+- __How to see HISAT2-3N version used in image:__ Please see below.
+
+## Versioning
+
+The HISAT2-3N image uses the following convention for versioning:
+
+#### `us.gcr.io/broad-gotc-prod/hisat3n:<image-version>-<hisat3n-version>-<unix-timestamp>` 
+
+We keep track of all past versions in [docker_versions](docker_versions.tsv) with the last image listed being the currently used version in WARP.
+
+You can see more information about the image, including the tool versions, by running the following command:
+
+```bash
+$ docker pull us.gcr.io/broad-gotc-prod/hisat3n:1.0.0-1.11-1624651616
+$ docker inspect us.gcr.io/broad-gotc-prod/hisat3n:1.0.0-1.11-1624651616
+```
+
+## Usage
+
+### Display default menu
+
+```bash
+$ docker run --rm -it \
+    us.gcr.io/broad-gotc-prod/hisat3n:1.0.0-1.11-1624651616 hisat3n(?) 
+```

--- a/3rd-party-tools/m3C-yap-hisat/docker_build.sh
+++ b/3rd-party-tools/m3C-yap-hisat/docker_build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -e
+
+# Update version when changes to Dockerfile are made
+DOCKER_IMAGE_VERSION=1.0.0
+TIMESTAMP=$(date +"%s")
+DIR=$(cd $(dirname $0) && pwd)
+
+# Registries and tags
+GCR_URL="us.gcr.io/broad-gotc-prod/hisat3n"
+QUAY_URL="quay.io/broadinstitute/gotc-prod-hisat3n"
+
+# Hisat3n version
+HISAT_VERSION="2.2.1"
+
+# Necessary tools and help text
+TOOLS=(docker gcloud)
+HELP="$(basename "$0") [-h|--help] [-v|--version] [-t|tools] -- script to build the hisat-3n image and push to GCR & Quay
+
+where:
+    -h|--help Show help text
+    -v|--version Version of hisat-3n to use (default: $HISAT_VERSION)
+    -t|--tools Show tools needed to run script
+    "
+
+function main(){
+    for t in "${TOOLS[@]}"; do which "$t" >/dev/null || ok=no; done
+        if [[ $ok == no ]]; then
+            echo "Missing one of the following tools: "
+            for t in "${TOOLS[@]}"; do echo "$t"; done
+            exit 1
+        fi
+
+    while [[ $# -gt 0 ]]
+    do 
+    key="$1"
+    case $key in
+        -v|--version)
+        HISAT_VERSION="$2"
+        shift
+        shift
+        ;;
+        -h|--help)
+        echo "$HELP"
+        exit 0
+        ;;
+        -t|--tools)
+        for t in "${TOOLS[@]}"; do echo "$t"; done
+        exit 0
+        ;;
+        *)
+        shift
+        ;;
+    esac
+    done
+    
+    IMAGE_TAG="$DOCKER_IMAGE_VERSION-$HISAT_VERSION-$TIMESTAMP"
+
+    echo "building and pushing GCR Image - $GCR_URL:$IMAGE_TAG"
+    docker build --no-cache -t "$GCR_URL:$IMAGE_TAG" \
+        --build-arg HISAT_VERSION="$HISAT_VERSION" "$DIR" 
+    docker push "$GCR_URL:$IMAGE_TAG"
+
+    echo "tagging and pushing Quay Image"
+    docker tag "$GCR_URL:$IMAGE_TAG" "$QUAY_URL:$IMAGE_TAG"
+    docker push "$QUAY_URL:$IMAGE_TAG"
+
+    echo -e "$GCR_URL:$IMAGE_TAG" >> "$DIR/docker_versions.tsv"
+    echo "done"
+}
+
+main "$@"

--- a/3rd-party-tools/m3C-yap-hisat/hisat3n_env.yml
+++ b/3rd-party-tools/m3C-yap-hisat/hisat3n_env.yml
@@ -1,0 +1,25 @@
+name: base
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+ - python=3.9
+ - pip
+ - jupyter
+ - snakemake
+ - pytables
+ - seaborn
+ - yaml
+ - cutadapt
+ - samtools
+ - picard
+ - bedtools
+ - htslib=1.15
+ - pysam
+ - pybedtools
+ - pyBigWig
+ - pip:
+    - papermill
+    - allcools
+    - cemba_data


### PR DESCRIPTION
Dockerfiles and build scripts for the snM3C workflow need to be moved to warp-tools from warp. 