### PR TITLE
Decode fragChrom column in fragment matrix

### DIFF
--- a/tools/scripts/breakoutSnap.py
+++ b/tools/scripts/breakoutSnap.py
@@ -40,7 +40,9 @@ def main():
             'fragStart': FM['fragStart'][:]
         }
     )
-    fragments_DF.to_csv(args.output_prefix + 'fragments.csv')
+
+    fragments_DF['fragChrom_decoded'] = fragments_DF.fragChrom.str.decode(encoding = 'UTF-8')
+    fragments_DF[['fragChrom_decoded','fragStart', 'fragLen']].to_csv(args.output_prefix + 'fragments.csv')
 
     ###################################
     # Export the cell x bin accessibility matrices (AM)


### PR DESCRIPTION
The fragChrom column needs to be decoded before sorting. Sorting the files prior wasnt working because of this encoded column. 