### PR TITLE
updated STAR docker to 2.7.11a

### DIFF
--- a/3rd-party-tools/star/Dockerfile
+++ b/3rd-party-tools/star/Dockerfile
@@ -1,10 +1,10 @@
 # Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
 FROM --platform="linux/amd64" alpine:latest
 
-ARG STAR_VERSION=2.7.10b
+ARG STAR_VERSION=2.7.11a
 
 ENV TERM=xterm-256color \
-        STAR_URL=https://github.com/alexdobin/STAR/archive/${STAR_VERSION}.tar.gz
+        STAR_URL=https://github.com/alexdobin/STAR/archive/refs/tags/${STAR_VERSION}.tar.gz
 
 LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org" \
         STAR_VERSION=${STAR_VERSION}

--- a/3rd-party-tools/star/docker_build.sh
+++ b/3rd-party-tools/star/docker_build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.0.0
+DOCKER_IMAGE_VERSION=1.0.1
 TIMESTAMP=$(date +"%s")
 DIR=$(cd "$(dirname "$0")" && pwd)
 
@@ -11,7 +11,7 @@ GCR_URL="us.gcr.io/broad-gotc-prod/star"
 #QUAY_URL="quay.io/broadinstitute/gotc-prod-star" # Update and uncomment push block below after setting up quay repo
 
 # STAR version
-STAR_VERSION="2.7.10b"
+STAR_VERSION="2.7.11a"
 
 # Necessary tools and help text
 TOOLS=(docker gcloud)

--- a/3rd-party-tools/star/docker_versions.tsv
+++ b/3rd-party-tools/star/docker_versions.tsv
@@ -2,3 +2,4 @@ DOCKER_VERSION
 us.gcr.io/broad-gotc-prod/star:1.0.0-2.7.9a-1658781884
 us.gcr.io/broad-gotc-prod/star:1.0.0-2.7.9a-1685556119
 us.gcr.io/broad-gotc-prod/star:1.0.0-2.7.10b-1685556218
+us.gcr.io/broad-gotc-prod/star:1.0.1-2.7.11a-1692706072


### PR DESCRIPTION
Created a new STAR docker for the 2.7.11a release. This release includes a new sF BAM tag that we can use to generate intronic and exonic metrics. 