### PR TITLE
Update mitochondrial_gene_selector.cpp

### DIFF
--- a/tools/TagSort/src/mitochondrial_gene_selector.cpp
+++ b/tools/TagSort/src/mitochondrial_gene_selector.cpp
@@ -26,14 +26,6 @@ inline std::string ltrim(std::string& s)
   return s;
 }
 
-// trim from right end (in place) -- https://stackoverflow.com/questions/216823/how-to-trim-an-stdstring
-inline std::string rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }).base(), s.end());
-    return s;
-}
-
 // remove the " (quotes) from the beginning and end of the string (TODO also
 // removes from the middle; hopefully nobody is trying to use escaped quotes).
 std::string removeQuotes(std::string& s)
@@ -109,7 +101,7 @@ std::unordered_set<std::string> getInterestingMitochondrialGenes(
     if (tabbed_fields[2] != "gene") // skip the line unless it is a gene
       continue;
     // split the semicolon-separated attributes field
-    std::vector<std::string> attribs = splitStringToFields(rtrim(tabbed_fields[8]), ';');
+    std::vector<std::string> attribs = splitStringToFields(tabbed_fields[8], ';');
 
     std::string gene_name;
     std::string gene_id;
@@ -117,17 +109,14 @@ std::unordered_set<std::string> getInterestingMitochondrialGenes(
     for (std::string attrib : attribs)
     {
       // each attribute is a space-separated key-value pair
-      std::string key = ltrim(attrib).substr(0,ltrim(attrib).find_first_of(" "));
-      std::string value = ltrim(attrib).substr(ltrim(attrib).find_first_of(" ") +1);
-
       // removed the lines below b/c we found a different way to split strings
-      // std::vector<std::string> key_and_val = splitStringToFields(ltrim(attrib), ' ');
-      // if (key_and_val.size() != 2)
-      //   crash("Expected 2 fields, found " + std::to_string(key_and_val.size()) + " fields");
+      std::vector<std::string> key_and_val = splitStringToFields(ltrim(attrib), ' ');
+      if (key_and_val.size() != 2)
+        crash("Expected 2 fields, found " + std::to_string(key_and_val.size()) + " fields");
 
       // the second element in the pair is the value string
-      // std::string& key = key_and_val[0];
-      // std::string value = removeQuotes(key_and_val[1]);
+      std::string& key = key_and_val[0];
+      std::string value = removeQuotes(key_and_val[1]);
 
       if (key == "gene_id")
         gene_id = value;

--- a/tools/docker_build.sh
+++ b/tools/docker_build.sh
@@ -3,7 +3,7 @@
 set -e -x
 
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.0.5
+DOCKER_IMAGE_VERSION=1.0.6
 TIMESTAMP=$(date +"%s")
 DIR=$(cd "$(dirname "$0")" && pwd)
 TAG=$1

--- a/tools/docker_versions.tsv
+++ b/tools/docker_versions.tsv
@@ -14,3 +14,4 @@ us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686572906
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686577614
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.1-1686671920
 us.gcr.io/broad-gotc-prod/warp-tools:1.0.5-1692706846
+us.gcr.io/broad-gotc-prod/warp-tools:1.0.6-1692962087


### PR DESCRIPTION
This PR reverts changes related to this PR: https://github.com/broadinstitute/warp-tools/pull/56/files#diff-0a611aa94dbf7400455e13ec79aaf57967c90abd311b0049c63cd66b37ba7bc4

The changes in PR 56 were related to this JIRA ticket: https://broadworkbench.atlassian.net/browse/PD-2265

We had to undo them because we realized that mitochondrial genes were no longer being calculated in our Cell Metrics. 

Future work will fix the TagSort Mitochondrial Gene Selector to require a gene list for any Refseq GTF inputs: https://broadworkbench.atlassian.net/jira/software/projects/PD/boards/167?selectedIssue=PD-2355