### PR TITLE
PD2396 Added "number of output files" as a parameter to fastqprocess

### DIFF
--- a/tools/fastqpreprocessing/src/fastqprocess.cpp
+++ b/tools/fastqpreprocessing/src/fastqprocess.cpp
@@ -6,8 +6,8 @@ int main(int argc, char** argv)
   InputOptionsFastqProcess options = readOptionsFastqProcess(argc, argv);
   
   int num_writer_threads = 1;
-  if (options.num_output_files != -1) {
-    std::cout<<"options.num_output_file != -1\n";
+  if (options.num_output_files != 0) {
+    std::cout<<"options.num_output_file != 0\n";
     num_writer_threads = options.num_output_files;
   }
   else {

--- a/tools/fastqpreprocessing/src/fastqprocess.cpp
+++ b/tools/fastqpreprocessing/src/fastqprocess.cpp
@@ -4,10 +4,13 @@
 int main(int argc, char** argv)
 {
   InputOptionsFastqProcess options = readOptionsFastqProcess(argc, argv);
+  
   // number of output bam files, and one writer thread per bam file
   int num_writer_threads = get_num_blocks(options);
   // hardcoded this to 1000 in case of large files
   num_writer_threads =  (num_writer_threads > 1000) ? 1000 : num_writer_threads;
+
+  num_writer_threads= (options.num_output_files != -1) ? options.num_output_files : num_writer_threads;
 
   // added this for consistency with other code
   std::vector<std::pair<char, int>> g_parsed_read_structure = parseReadStructure(options.read_structure);

--- a/tools/fastqpreprocessing/src/fastqprocess.cpp
+++ b/tools/fastqpreprocessing/src/fastqprocess.cpp
@@ -7,20 +7,16 @@ int main(int argc, char** argv)
   
   int num_writer_threads = 1;
   if (options.num_output_files != 0) {
-    std::cout<<"options.num_output_file != 0\n";
+    std::cout<<"Number of output files is set. Bam size ignored.";
     num_writer_threads = options.num_output_files;
   }
   else {
-    std::cout<<"ELSE\n";
+    std::cout<<"Number of output files is not set. Bam size is not ignored.";
     // number of output bam files, and one writer thread per bam file
     num_writer_threads = get_num_blocks(options);
     // hardcoded this to 1000 in case of large files
     num_writer_threads =  (num_writer_threads > 1000) ? 1000 : num_writer_threads;
   }
-
-  std::cout<<num_writer_threads<<"\n";
-  // num_writer_threads= (options.num_output_files != -1) ? options.num_output_files : num_writer_threads;
-  std::cout<<options.num_output_files<<"\n";
 
   // added this for consistency with other code
   std::vector<std::pair<char, int>> g_parsed_read_structure = parseReadStructure(options.read_structure);

--- a/tools/fastqpreprocessing/src/fastqprocess.cpp
+++ b/tools/fastqpreprocessing/src/fastqprocess.cpp
@@ -7,11 +7,11 @@ int main(int argc, char** argv)
   
   int num_writer_threads = 1;
   if (options.num_output_files != 0) {
-    std::cout<<"Number of output files is set. Bam size ignored.";
+    std::cout<<"Number of output files is set. Bam size ignored.\n";
     num_writer_threads = options.num_output_files;
   }
   else {
-    std::cout<<"Number of output files is not set. Bam size is not ignored.";
+    std::cout<<"Number of output files is not set. Bam size is not ignored.\n";
     // number of output bam files, and one writer thread per bam file
     num_writer_threads = get_num_blocks(options);
     // hardcoded this to 1000 in case of large files

--- a/tools/fastqpreprocessing/src/fastqprocess.cpp
+++ b/tools/fastqpreprocessing/src/fastqprocess.cpp
@@ -5,12 +5,22 @@ int main(int argc, char** argv)
 {
   InputOptionsFastqProcess options = readOptionsFastqProcess(argc, argv);
   
-  // number of output bam files, and one writer thread per bam file
-  int num_writer_threads = get_num_blocks(options);
-  // hardcoded this to 1000 in case of large files
-  num_writer_threads =  (num_writer_threads > 1000) ? 1000 : num_writer_threads;
+  int num_writer_threads = 1;
+  if (options.num_output_file != -1) {
+    std::cout<<"options.num_output_file != -1\n";
+    num_writer_threads = options.num_output_file;
+  }
+  else {
+    std::cout<<"ELSE\n";
+    // number of output bam files, and one writer thread per bam file
+    num_writer_threads = get_num_blocks(options);
+    // hardcoded this to 1000 in case of large files
+    num_writer_threads =  (num_writer_threads > 1000) ? 1000 : num_writer_threads;
+  }
 
-  num_writer_threads= (options.num_output_files != -1) ? options.num_output_files : num_writer_threads;
+  std::cout<<num_writer_threads<<"\n";
+  // num_writer_threads= (options.num_output_files != -1) ? options.num_output_files : num_writer_threads;
+  std::cout<<options.num_output_files<<"\n";
 
   // added this for consistency with other code
   std::vector<std::pair<char, int>> g_parsed_read_structure = parseReadStructure(options.read_structure);

--- a/tools/fastqpreprocessing/src/fastqprocess.cpp
+++ b/tools/fastqpreprocessing/src/fastqprocess.cpp
@@ -6,9 +6,9 @@ int main(int argc, char** argv)
   InputOptionsFastqProcess options = readOptionsFastqProcess(argc, argv);
   
   int num_writer_threads = 1;
-  if (options.num_output_file != -1) {
+  if (options.num_output_files != -1) {
     std::cout<<"options.num_output_file != -1\n";
-    num_writer_threads = options.num_output_file;
+    num_writer_threads = options.num_output_files;
   }
   else {
     std::cout<<"ELSE\n";

--- a/tools/fastqpreprocessing/src/input_options.cpp
+++ b/tools/fastqpreprocessing/src/input_options.cpp
@@ -102,6 +102,7 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
     /* These options don’t set a flag.
        We distinguish them by their indices. */
     {"bam-size",            required_argument, 0, 'B'},
+    {"num-output-files",    required_argument, 0, 'OF'},
     {"read-structure",      required_argument, 0, 'S'},
     {"sample-id",           required_argument, 0, 's'},
     {"I1",                  required_argument, 0, 'I'},
@@ -120,6 +121,7 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
   {
     "verbose messages  ",
     "output BAM file in GB [optional: default 1 GB]",
+    "num_output_files [optional: default -1 (it will take bam_size as default)]",
     "read structure [required]",
     "sample id [required]",
     "I1 [optional]",
@@ -159,6 +161,9 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
     case 'B':
       options.bam_size = atof(optarg);
       break;
+    case 'OF':
+      options.num_output_files = atof(optarg);
+      break;    
     case 's':
       options.sample_id = string(optarg);
       break;
@@ -224,7 +229,10 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
     crash("ERROR: Must provide as many R3 input files as R1 input files.");
 
   if (options.bam_size <= 0)
-    crash("ERROR: Size of a bam file (in GB) cannot be negative or 0");
+    crash("ERROR: Size of a bam file (in GB) cannot be negative or 0.");
+
+  if (options.num_output_files < 0)
+    crash("ERROR: Number of output files cannot be negative.");
 
   if (options.sample_id.empty())
     crash("ERROR: Must provide a sample id or name");
@@ -264,6 +272,7 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
     /* These options don’t set a flag.
        We distinguish them by their indices. */
     {"bam-size",            required_argument, 0, 'B'},
+    {"num-output-files",    required_argument, 0, 'OF'},
     {"read-structure",      required_argument, 0, 'S'},
     {"sample-id",           required_argument, 0, 's'},
     {"I1",                  required_argument, 0, 'I'},
@@ -282,6 +291,7 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
   {
     "verbose messages  ",
     "output BAM file in GB [optional: default 1 GB]",
+    "num_output_files [optional: default -1 (it will take bam_size as default)]",
     "read structure [required]",
     "sample id [required]",
     "I1 [optional]",
@@ -320,6 +330,9 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
     case 'B':
       options.bam_size = atof(optarg);
       break;
+    case 'OF':
+      options.num_output_files = atof(optarg);
+      break;  
     case 'S':
       options.read_structure = string(optarg);
       break;
@@ -385,7 +398,10 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
     crash("ERROR: Must provide as many R3 input files as R1 input files.");
 
   if (options.bam_size <= 0)
-    crash("ERROR: Size of a bam file (in GB) cannot be negative or 0");
+    crash("ERROR: Size of a bam file (in GB) cannot be negative or 0.");
+ 
+  if (options.num_output_files < 0)
+    crash("ERROR: Number of output files cannot be negative.");
 
   if (options.sample_id.empty())
     crash("ERROR: Must provide a sample id or name");

--- a/tools/fastqpreprocessing/src/input_options.cpp
+++ b/tools/fastqpreprocessing/src/input_options.cpp
@@ -121,7 +121,7 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
   {
     "verbose messages  ",
     "output BAM file in GB [optional: default 1 GB]",
-    "num_output_files [optional: default -1 (it will take bam_size as default)]",
+    "num_output_files [optional: default 0 (it will take bam_size as default)]",
     "read structure [required]",
     "sample id [required]",
     "I1 [optional]",
@@ -291,7 +291,7 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
   {
     "verbose messages  ",
     "output BAM file in GB [optional: default 1 GB]",
-    "num_output_files [optional: default -1 (it will take bam_size as default)]",
+    "num_output_files [optional: default 0 (it will take bam_size as default)]",
     "read structure [required]",
     "sample id [required]",
     "I1 [optional]",

--- a/tools/fastqpreprocessing/src/input_options.cpp
+++ b/tools/fastqpreprocessing/src/input_options.cpp
@@ -102,7 +102,7 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
     /* These options don’t set a flag.
        We distinguish them by their indices. */
     {"bam-size",            required_argument, 0, 'B'},
-    {"num-output-files",    required_argument, 0, 'OF'},
+    {"num-output-files",    required_argument, 0, 'nF'},
     {"read-structure",      required_argument, 0, 'S'},
     {"sample-id",           required_argument, 0, 's'},
     {"I1",                  required_argument, 0, 'I'},
@@ -161,7 +161,7 @@ InputOptionsFastqProcess readOptionsFastqProcess(int argc, char** argv)
     case 'B':
       options.bam_size = atof(optarg);
       break;
-    case 'OF':
+    case 'nF':
       options.num_output_files = atof(optarg);
       break;    
     case 's':
@@ -272,7 +272,7 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
     /* These options don’t set a flag.
        We distinguish them by their indices. */
     {"bam-size",            required_argument, 0, 'B'},
-    {"num-output-files",    required_argument, 0, 'OF'},
+    {"num-output-files",    required_argument, 0, 'nF'},
     {"read-structure",      required_argument, 0, 'S'},
     {"sample-id",           required_argument, 0, 's'},
     {"I1",                  required_argument, 0, 'I'},
@@ -330,7 +330,7 @@ INPUT_OPTIONS_FASTQ_READ_STRUCTURE readOptionsFastqSlideseq(int argc, char** arg
     case 'B':
       options.bam_size = atof(optarg);
       break;
-    case 'OF':
+    case 'nF':
       options.num_output_files = atof(optarg);
       break;  
     case 'S':

--- a/tools/fastqpreprocessing/src/input_options.h
+++ b/tools/fastqpreprocessing/src/input_options.h
@@ -23,7 +23,7 @@ struct INPUT_OPTIONS_FASTQ_READ_STRUCTURE
   double bam_size = 1.0;
 
   // Number of output files
-  int num_output_files = -1
+  int num_output_files = -1;
 
   std::string read_structure;
 
@@ -51,7 +51,7 @@ struct InputOptionsFastqProcess
   double bam_size = 1.0;
 
   // Number of output files
-  int num_output_files = -1
+  int num_output_files = -1;
 
   std::string read_structure;
 

--- a/tools/fastqpreprocessing/src/input_options.h
+++ b/tools/fastqpreprocessing/src/input_options.h
@@ -23,7 +23,7 @@ struct INPUT_OPTIONS_FASTQ_READ_STRUCTURE
   double bam_size = 1.0;
 
   // Number of output files
-  int num_output_files = -1;
+  int num_output_files = 0;
 
   std::string read_structure;
 
@@ -51,7 +51,7 @@ struct InputOptionsFastqProcess
   double bam_size = 1.0;
 
   // Number of output files
-  int num_output_files = -1;
+  int num_output_files = 0;
 
   std::string read_structure;
 

--- a/tools/fastqpreprocessing/src/input_options.h
+++ b/tools/fastqpreprocessing/src/input_options.h
@@ -22,6 +22,9 @@ struct INPUT_OPTIONS_FASTQ_READ_STRUCTURE
   // Bam file size to split by (in GB)
   double bam_size = 1.0;
 
+  // Number of output files
+  int num_output_files = -1
+
   std::string read_structure;
 
   std::string sample_id;
@@ -46,6 +49,9 @@ struct InputOptionsFastqProcess
 
   // Bam file size to split by (in GB)
   double bam_size = 1.0;
+
+  // Number of output files
+  int num_output_files = -1
 
   std::string read_structure;
 


### PR DESCRIPTION
This corresponds to ticket https://broadworkbench.atlassian.net/browse/PD-2396. 

Here, were adding an additional parameter, `num-output-files`. This parameter is optional. The default is set to 0 -- meaning that it will be ignored if set to 0. 

If this parameter is set to any number more than 0, `bam-size` is ignored. This will allow the user to define the number of output files (shards) that we want fastqprocess to produce. 