### PR TITLE
PD-2474: Remove reads from MT genes in Tagsort metrics

### DIFF
--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -72,7 +72,7 @@ void MetricGatherer::ingestLineCellAndGeneCommon(LineFields const& fields)
  
   //-----------------------------------------------------------------------
   // Will remove this after
-  std::cout << "TEST -- to increment number of n_mitochondrial_reads -- \n";
+  // std::cout << "TEST -- to increment number of n_mitochondrial_reads -- \n";
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
       {1, fields.tag_triple.second}, 

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -113,9 +113,17 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   // tag_order_str is a combination of BGU so find order of where gene_id is in gene_id,barcode,umi
 
   std::cout << "Fields tag triple\n";
-  std::cout<< tag_order_str << "\n";
-
-  size_t geneIndex = tag_order_str.find('gene_id');
+  std::istringstream ss(tag_order_str);
+  std::string token;
+  int geneIndex;
+ 
+  // Tokenize tag_order_str and check positions
+  for (int i = 0; std::getline(ss, token, ','); ++i) {
+    if (token == "gene_id" && (i == 0 || i == 1 || i == 2)) {
+        geneIndex = i; 
+        std::cout << "'gene_id' is at position: " << geneIndex << std::endl;
+    }
+  }
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
       {1, fields.tag_triple.second}, 
@@ -124,24 +132,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   std::cout << geneIndex << "\n" ;
   std::string GeneID = indexToField_TagOrder[geneIndex]; 
   std::cout << "gene name " << GeneID << "\n";
-
-  std::istringstream ss(tag_order_str);
-  std::string token;
-
-  // Tokenize the string and check positions
-  for (int i = 0; std::getline(ss, token, ','); ++i) {
-    if (token == "gene_id" && (i == 0 || i == 1 || i == 2)) {
-        std::cout << "'gene_id' is at position: " << i << std::endl;
-    }
-  }
-
-  auto it = indexToField_TagOrder.find(geneIndex);
-  if (it != indexToField_TagOrder.end()) {
-      std::string result = it->second;
-      std::cout << "Index of 'G' in the tag_order_str: " << geneIndex << std::endl;
-      std::cout << "Corresponding field: " << result << std::endl;
-  }
-
+  
   // Check if not a mitochondrial gene
   //if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end())) {
   if (!(mitochondrial_genes_.find(GeneID) != mitochondrial_genes_.end())) {

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -147,7 +147,6 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   spliced_reads_ += fields.read_spliced;
 }
 
-
 void MetricGatherer::outputMetricsLineCellAndGeneCommon()
 {
   float reads_per_molecule = -1.0f;   // float("nan")
@@ -201,6 +200,13 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
       << molecules_with_single_read_evidence;
 }
 
+int MetricGatherer::getGeneIdPosition() const{
+    return geneid_position;
+}
+
+std::unordered_set<std::string> MetricGatherer::getMTgenes() const {
+    return mitochondrial_genes_;
+}
 
 ////////////////  CellMetricGatherer ////////////////////////
 
@@ -216,6 +222,10 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
   // // getInterestingMitochondrialGenes() has logic to handle that case.
   // mitochondrial_genes_ = getInterestingMitochondrialGenes(
   //     gtf_file, mitochondrial_gene_names_filename);
+
+  std::unordered_set<std::string> mitochondrial_genes_ = getMTgenes();
+  int geneid_position = getGeneIdPosition();
+
   std::cout << "TEST in Cell class mitochondrial_genes_: ";
   for (const auto& gene : mitochondrial_genes_) {
         std::cout << gene << " ";

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -109,9 +109,9 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
       {1, fields.tag_triple.second}, 
       {2, fields.tag_triple.third}};
 
-  std::cout << "Position of gene_id in TagOrder is :" << geneid_position << "\n" ;
+  //std::cout << "Position of gene_id in TagOrder is :" << geneid_position << "\n" ;
   std::string gene_id = indexToField_TagOrder[geneid_position]; 
-  std::cout << "Gene name " << gene_id << "\n";
+  //std::cout << "Gene name " << gene_id << "\n";
   
   // Check if not a mitochondrial gene
   if (!(mitochondrial_genes_.find(gene_id) != mitochondrial_genes_.end())) {
@@ -129,10 +129,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
       reads_mapped_multiple_ += 1;  // without multi-mapping, this number is zero!
     }
   }
-  else {
-    std::cout<< gene_id << "is a mitochrondrial gene. Skip.\n";
-  }
-
+ 
   // in futher check if read maps outside window (when we add a  gene model)
   // and  create distances from terminate side (needs gene model) uniqueness
   duplicate_reads_ += fields.read_is_duplicate;
@@ -277,9 +274,9 @@ void CellMetricGatherer::ingestLine(std::string const& str)
       {1, fields.tag_triple.second}, 
       {2, fields.tag_triple.third}};
 
-  std::cout << "Position of gene_id in TagOrder is :" << geneid_position << "\n" ;
+  //std::cout << "Position of gene_id in TagOrder is :" << geneid_position << "\n" ;
   std::string gene_id = indexToField_TagOrder[getGeneIdPosition()]; 
-  std::cout << "Gene name " << gene_id << "\n";
+  //std::cout << "Gene name " << gene_id << "\n";
 
   if (fields.alignment_location == 7) {
     if (fields.number_mappings == 1)

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -35,6 +35,7 @@ MetricGatherer::~MetricGatherer() {}
 void MetricGatherer::clearCellAndGeneCommon()
 {
   n_reads_ = 0;
+  n_mitochondrial_reads_ = 0; 
   // noise_reads = 0; //# long polymers, N-sequences; NotImplemented
   fragment_histogram_.clear();
   molecule_histogram_.clear();

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -100,6 +100,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
         std::cout << "- " << item << '\n';
   }
   std::cout << "END\n";
+  std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.second) << "\n";
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.third) << "\n";
 
   // Check if not a mitochondrial gene

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -202,7 +202,7 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
 {
   // write metrics csv header
   std::string s;
-  for (int i=0; i<25; i++)
+  for (int i=0; i<26; i++)
     metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<11; i++)
     metrics_csv_outfile_ << "," << cell_specific_headers[i];
@@ -324,7 +324,7 @@ GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
 {
   // write metrics csv header
   std::string s;
-  for (int i=0; i<25; i++)
+  for (int i=0; i<26; i++)
     metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<2; i++)
     metrics_csv_outfile_ << "," << gene_specific_headers[i];

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -216,23 +216,6 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
                                       std::string mitochondrial_gene_names_filename)
   : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
-  // if (gtf_file.empty())
-  //   crash("CellMetricGatherer needs a non-empty gtf_file name!");
-  // // it's ok if mitochondrial_gene_names_filename is empty;
-  // // getInterestingMitochondrialGenes() has logic to handle that case.
-  // mitochondrial_genes_ = getInterestingMitochondrialGenes(
-  //     gtf_file, mitochondrial_gene_names_filename);
-
-  std::unordered_set<std::string> mitochondrial_genes_ = getMTgenes();
-  int geneid_position = getGeneIdPosition();
-
-  std::cout << "TEST in Cell class mitochondrial_genes_: ";
-  for (const auto& gene : mitochondrial_genes_) {
-        std::cout << gene << " ";
-  }
-  std::cout << std::endl;
-  std::cout<< "CELL GENE " << geneid_position << "\n";
-
   // write metrics csv header
   std::string s;
   for (int i=0; i<25; i++)
@@ -274,6 +257,9 @@ void CellMetricGatherer::ingestLine(std::string const& str)
 
   // need to change this 
   // tag_order_str is a combination of BGU so find order of where gene_id is in gene_id,barcode,umi
+  mitochondrial_genes_ = getMTgenes();
+  geneid_position = getGeneIdPosition();
+  
   std::cout << "Fields tag triple in ingestLine\n";
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
@@ -281,7 +267,7 @@ void CellMetricGatherer::ingestLine(std::string const& str)
       {2, fields.tag_triple.third}};
 
   std::cout << geneid_position << "\n" ;
-  std::string gene_id = indexToField_TagOrder[geneid_position]; 
+  std::string gene_id = indexToField_TagOrder[getGeneIdPosition()]; 
   std::cout << "gene name in ingestLine" << gene_id << "\n";
 
   if (fields.alignment_location == 7) {

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -237,7 +237,7 @@ void CellMetricGatherer::ingestLine(std::string const& str)
   perfect_cell_barcodes_ += fields.cell_barcode_perfect;
 
   // need to change this 
-  if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end())) {
+  //if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end())) {
     if (fields.alignment_location == 7) {
       if (fields.number_mappings == 1) 
         reads_mapped_intergenic_ += 1;
@@ -245,7 +245,7 @@ void CellMetricGatherer::ingestLine(std::string const& str)
     else if(fields.alignment_location == 0) {
       reads_unmapped_ += 1;
     }
-  }
+  //}
 
   genes_histogram_[std::string(fields.tag_triple.third)] += 1;
   // END cell-metric-specific stuff

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -21,7 +21,7 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
 
   std::cout<<"set tagorderstr to tag order";
   tag_order_str = tagOrderToString(tag_order);
-  std::cout<<tag_order_str;
+  std::cout<<tag_order_str<<"\n";
   
   // get list of mitochondrial genes 
   if (gtf_file.empty())
@@ -102,11 +102,6 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
                                  is_strand + "\t" + hyphenated_tags;
   fragment_histogram_[ref_pos_str_tags] += 1;
   std::cout << "ParseAlignedReadFields\n";
-  std::cout << "PRINT mitochondrial_genes_ in parseAlignedReadFields:\n";
-  for (const auto& item : mitochondrial_genes_) {
-        std::cout << "- " << item << '\n';
-  }
-  std::cout << "END\n";
   // fields.tag_triple 
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.first) << "\n";
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.second) << "\n";

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -71,7 +71,7 @@ void MetricGatherer::ingestLineCellAndGeneCommon(LineFields const& fields)
   n_reads_++; //with/without mt? == uniquely + multimapped 
  
   //-----------------------------------------------------------------------
-  // Will remove this after
+  // Will remove this
   // std::cout << "TEST -- to increment number of n_mitochondrial_reads -- \n";
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
@@ -114,9 +114,9 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
       {0, fields.tag_triple.first}, 
       {1, fields.tag_triple.second}, 
       {2, fields.tag_triple.third}};
-
   std::string gene_id = indexToField_TagOrder[geneid_position]; 
   
+  // Check if not a mitochondrial gene
   if (!(mitochondrial_genes_.find(gene_id) != mitochondrial_genes_.end())) {
    if (fields.number_mappings == 1) {
       reads_mapped_uniquely_ += 1;
@@ -141,11 +141,6 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
 
 void MetricGatherer::outputMetricsLineCellAndGeneCommon()
 {
-  //-----------------------------------------------------------------------
-  // Will remove this after
-  std::cout<<"TEST : Number of n_mitochondrial_reads " << n_mitochondrial_reads <<"\n";
-  //-----------------------------------------------------------------------
-
   float reads_per_molecule = -1.0f;   // float("nan")
   if (molecule_histogram_.size() != 0)
     reads_per_molecule = n_reads_ / (float)molecule_histogram_.size();
@@ -194,7 +189,8 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
       << reads_per_fragment << ","
       << fragments_per_molecule << ","
       << fragments_with_single_read_evidence << ","
-      << molecules_with_single_read_evidence;
+      << molecules_with_single_read_evidence << ","
+      << n_mitochondrial_reads;
 }
 
 void MetricGatherer::setGeneIdPosition(TagOrder tag_order) {
@@ -283,6 +279,7 @@ void CellMetricGatherer::ingestLine(std::string const& str)
       {2, fields.tag_triple.third}};
 
   std::string gene_id = indexToField_TagOrder[getGeneIdPosition()]; 
+
   if (fields.alignment_location == 7) {
     if (fields.number_mappings == 1)
       if (!(mitochondrial_genes_.find(gene_id) != mitochondrial_genes_.end()))

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -35,7 +35,6 @@ MetricGatherer::~MetricGatherer() {}
 void MetricGatherer::clearCellAndGeneCommon()
 {
   n_reads_ = 0;
-  n_mitochondrial_reads_ = 0; 
   // noise_reads = 0; //# long polymers, N-sequences; NotImplemented
   fragment_histogram_.clear();
   molecule_histogram_.clear();
@@ -82,8 +81,6 @@ bool MetricGatherer::isMitochondrial(LineFields const& fields) const
 void MetricGatherer::ingestLineCellAndGeneCommon(LineFields const& fields)
 {
   n_reads_++; //with/without mt? == uniquely + multimapped
-  if (isMitochondrial(fields))
-    n_mitochondrial_reads_ += 1;
 
   // the tags passed to this function define a molecule, this increments the counter,
   // identifying a new molecule only if a new tag combination is observed
@@ -186,8 +183,7 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
       << reads_per_fragment << ","
       << fragments_per_molecule << ","
       << fragments_with_single_read_evidence << ","
-      << molecules_with_single_read_evidence << ","
-      << n_mitochondrial_reads_;
+      << molecules_with_single_read_evidence;
 }
 
 
@@ -203,7 +199,7 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
 {
   // write metrics csv header
   std::string s;
-  for (int i=0; i<26; i++)
+  for (int i=0; i<25; i++)
     metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<11; i++)
     metrics_csv_outfile_ << "," << cell_specific_headers[i];
@@ -325,7 +321,7 @@ GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
 {
   // write metrics csv header
   std::string s;
-  for (int i=0; i<26; i++)
+  for (int i=0; i<25; i++)
     metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<2; i++)
     metrics_csv_outfile_ << "," << gene_specific_headers[i];

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -12,10 +12,16 @@ std::string to_nan(float x)
 }
 
 MetricGatherer::MetricGatherer(std::string metric_output_file,
+                               TagOrder tag_order,
                                std::string gtf_file,
                                std::string mitochondrial_gene_names_filename)
 {
   std::cout<<"Constructor for metric gatherer called.\n";
+
+  std::cout<<"Get tagorder";
+  std::string tag_order_str = tagOrderToString(tag_order);
+  std::cout<<tag_order_str;
+
   // get list of mitochondrial genes 
   if (gtf_file.empty())
     crash("MetricGatherer needs a non-empty gtf_file name!");
@@ -100,10 +106,14 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
         std::cout << "- " << item << '\n';
   }
   std::cout << "END\n";
+  // fields.tag_triple 
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.first) << "\n";
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.second) << "\n";
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.third) << "\n";
+  
+  std::string geneID = std::string(fields.tag_triple.third);
 
+  
   // Check if not a mitochondrial gene
   if (!(mitochondrial_genes_overall.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_overall.end())) {
    if (fields.number_mappings == 1) {
@@ -190,9 +200,10 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
 ////////////////  CellMetricGatherer ////////////////////////
 
 CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
+                                       TagOrder tag_order,
                                        std::string gtf_file,
                                        std::string mitochondrial_gene_names_filename)
-  : MetricGatherer(metric_output_file, gtf_file, mitochondrial_gene_names_filename)
+  : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
   if (gtf_file.empty())
     crash("CellMetricGatherer needs a non-empty gtf_file name!");
@@ -328,9 +339,10 @@ void CellMetricGatherer::clear()
 
 ////////////////  GeneMetricGatherer ////////////////////////
 GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
+                                       TagOrder tag_order,
                                        std::string gtf_file,
                                        std::string mitochondrial_gene_names_filename)
-  : MetricGatherer(metric_output_file, gtf_file, mitochondrial_gene_names_filename)
+  : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
   
   std::cout<<"Constructor for gene metric gatherer called.\n";
@@ -400,7 +412,7 @@ UmiMetricGatherer::UmiMetricGatherer(std::string metric_output_file,
                                      TagOrder tag_order,
                                      std::string gtf_file,
                                      std::string mitochondrial_gene_names_filename)
-  : MetricGatherer(metric_output_file, gtf_file, mitochondrial_gene_names_filename)
+  : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
   metrics_csv_outfile_ << tagOrderToString(tag_order) << ",count\n";
 }

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -95,10 +95,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   fragment_histogram_[ref_pos_str_tags] += 1;
 
   // Check if not a mitochondrial gene
-  std::cout<<"Check if mitochrondrial gene\n";
-  std::cout<<"GENE " << std::string(fields.tag_triple.third) <<"\n";
   if (!(mitochondrial_genes_overall.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_overall.end())) {
-   std::cout<<"not a mitochrondrial gene\n"; 
    if (fields.number_mappings == 1) {
       reads_mapped_uniquely_ += 1;
       if (fields.alignment_location == 1 || fields.alignment_location == 3)
@@ -112,6 +109,11 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
     else {
       reads_mapped_multiple_ += 1;  // without multi-mapping, this number is zero!
     }
+  }
+  else {
+    std::cout<<"Check if mitochrondrial gene\n";
+    std::cout<<"GENE " << std::string(fields.tag_triple.third) <<"\n";
+    std::cout<<"not a mitochrondrial gene\n"; 
   }
 
   // in futher check if read maps outside window (when we add a  gene model)

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -115,6 +115,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
       {2, fields.tag_triple.third}};
 
   std::cout << "Fields tag triple\n";
+  std::cout<< tag_order_str << "\n";
   std::cout << geneIndex << "\n" ;
   std::string GeneID = indexToField_TagOrder[geneIndex]; 
   std::cout << "gene name " << GeneID << "\n";

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -101,7 +101,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
                                  std::to_string(fields.position) + "\t" +
                                  is_strand + "\t" + hyphenated_tags;
   fragment_histogram_[ref_pos_str_tags] += 1;
-
+  std::cout << "ParseAlignedReadFields\n";
   std::cout << "PRINT mitochondrial_genes_ in parseAlignedReadFields:\n";
   for (const auto& item : mitochondrial_genes_) {
         std::cout << "- " << item << '\n';
@@ -115,9 +115,9 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   // tag_order_str is a combination of BGU so find order of where G is
   size_t geneIndex = tag_order_str.find('G');
   std::map<size_t, std::string> indexToField_TagOrder = {
-      {1, fields.tag_triple.first}, 
-      {2, fields.tag_triple.second}, 
-      {3, fields.tag_triple.third}};
+      {0, fields.tag_triple.first}, 
+      {1, fields.tag_triple.second}, 
+      {2, fields.tag_triple.third}};
 
   std::cout << "Fields tag triple\n";
   std::string GeneID = indexToField_TagOrder[geneIndex]; 

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -33,6 +33,13 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
   mitochondrial_genes_ = getInterestingMitochondrialGenes(
                                 gtf_file, mitochondrial_gene_names_filename);
 
+  // Print the elements of the unordered_set
+  std::cout << "Mitochondrial Genes in metric gatherer: ";
+  for (const auto& gene : mitochondrial_genes_) {
+        std::cout << gene << " ";
+  }
+  std::cout << std::endl;
+  
   metrics_csv_outfile_.open(metric_output_file);
   if (!metrics_csv_outfile_)
     crash("Failed to open for writing " + metric_output_file);
@@ -200,7 +207,7 @@ void MetricGatherer::setGeneIdPosition(TagOrder tag_order) {
   for (int i = 0; std::getline(tag_order_i, token, ','); ++i) {
     if (token == "gene_id" && (i == 0 || i == 1 || i == 2)) {
         geneid_position_i = i; 
-        std::cout << "'gene_id' is at position: " << geneid_position << std::endl;
+        std::cout << "'gene_id' is at position: " << geneid_position_i << std::endl;
         break;
     }
   }
@@ -227,6 +234,14 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
 {
   std::cout<<"CELL METRIC GATHERER CONSTRUCTOR\n";
   std::cout<< getGeneIdPosition()<<"\n";
+  std::unordered_set<std::string>  mt = getMTgenes();
+
+  // Print the elements of the unordered_set
+  std::cout << "Mitochondrial Genes in cell metric gatherer: ";
+  for (const auto& gene : mt) {
+        std::cout << gene << " ";
+  }
+  std::cout << std::endl;
   
   // write metrics csv header
   std::string s;

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -237,15 +237,14 @@ void CellMetricGatherer::ingestLine(std::string const& str)
   perfect_cell_barcodes_ += fields.cell_barcode_perfect;
 
   // need to change this 
-  //if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end())) {
-    if (fields.alignment_location == 7) {
-      if (fields.number_mappings == 1) 
+  if (fields.alignment_location == 7) {
+    if (fields.number_mappings == 1)
+      if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end()))
         reads_mapped_intergenic_ += 1;
     }
     else if(fields.alignment_location == 0) {
       reads_unmapped_ += 1;
     }
-  //}
 
   genes_histogram_[std::string(fields.tag_triple.third)] += 1;
   // END cell-metric-specific stuff

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -241,7 +241,7 @@ void CellMetricGatherer::ingestLine(std::string const& str)
   perfect_cell_barcodes_ += fields.cell_barcode_perfect;
 
   bool is_mito = isMitochondrial(fields);
-  if (fields.alignment_location == 7 && fields.number_mappings == 1 && is_mito)
+  if (fields.alignment_location == 7 && fields.number_mappings == 1 && !is_mito)
     reads_mapped_intergenic_ += 1;
   else if (fields.alignment_location == 0)
     reads_unmapped_ += 1;

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -107,8 +107,8 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.second) << "\n";
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.third) << "\n";
   
-  // tag_order_str is a combination of BGU so find order of where G is
-  size_t geneIndex = tag_order_str.find('G');
+  // tag_order_str is a combination of BGU so find order of where gene_id is in gene_id,barcode,umi
+  size_t geneIndex = tag_order_str.find('gene_id');
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
       {1, fields.tag_triple.second}, 

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -113,7 +113,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   else {
     std::cout<<"Check if mitochrondrial gene\n";
     std::cout<<"GENE " << std::string(fields.tag_triple.third) <<"\n";
-    std::cout<<"not a mitochrondrial gene\n"; 
+    std::cout<<"mitochrondrial gene\n"; 
   }
 
   // in futher check if read maps outside window (when we add a  gene model)
@@ -236,12 +236,16 @@ void CellMetricGatherer::ingestLine(std::string const& str)
   cell_barcode_fraction_bases_above_30_.update(fields.cell_barcode_base_above_30);
   perfect_cell_barcodes_ += fields.cell_barcode_perfect;
 
-  if (fields.alignment_location == 7) {
-    if (fields.number_mappings == 1) 
-      reads_mapped_intergenic_ += 1;
-  }
-  else if(fields.alignment_location == 0) {
-    reads_unmapped_ += 1;
+  // need to change this 
+  if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end())) {
+  {
+    if (fields.alignment_location == 7) {
+      if (fields.number_mappings == 1) 
+        reads_mapped_intergenic_ += 1;
+    }
+    else if(fields.alignment_location == 0) {
+      reads_unmapped_ += 1;
+    }
   }
 
   genes_histogram_[std::string(fields.tag_triple.third)] += 1;

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -1,10 +1,6 @@
 #include "metricgatherer.h"
-#include "mitochondrial_gene_selector.h"
 
-#include <map>
-#include <iostream>
-#include <sstream>
-#include <string>
+#include "mitochondrial_gene_selector.h"
 
 constexpr int kMetricsFloatPrintPrecision = 10;
 
@@ -19,19 +15,15 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
                                TagOrder tag_order,
                                std::string gtf_file,
                                std::string mitochondrial_gene_names_filename)
+  : tag_order_(tag_order)
 {
-
-  //Get and set gene_id position in tag_order. gene_id position varies depending on user input.
-  setGeneIdPosition(tag_order);
-
-  // get list of mitochondrial genes 
   if (gtf_file.empty())
     crash("MetricGatherer needs a non-empty gtf_file name!");
   // it's ok if mitochondrial_gene_names_filename is empty;
   // getInterestingMitochondrialGenes() has logic to handle that case.
-  mitochondrial_genes_ = getInterestingMitochondrialGenes(
-                                gtf_file, mitochondrial_gene_names_filename);
-  
+  mito_genes_ = getInterestingMitochondrialGenes(
+      gtf_file, mitochondrial_gene_names_filename);
+
   metrics_csv_outfile_.open(metric_output_file);
   if (!metrics_csv_outfile_)
     crash("Failed to open for writing " + metric_output_file);
@@ -66,23 +58,32 @@ void MetricGatherer::clearCellAndGeneCommon()
   spliced_reads_ = 0;
 }
 
+bool MetricGatherer::isMitochondrial(LineFields const& fields) const
+{
+  switch (tag_order_)
+  {
+    case TagOrder::GUB:
+    case TagOrder::GBU:
+    return mito_genes_.find(fields.tag_triple.first) != mito_genes_.end();
+
+    case TagOrder::BGU:
+    case TagOrder::UGB:
+    return mito_genes_.find(fields.tag_triple.second) != mito_genes_.end();
+
+    case TagOrder::UBG:
+    case TagOrder::BUG:
+    return mito_genes_.find(fields.tag_triple.third) != mito_genes_.end();
+  }
+  crash("unknown TagOrder value");
+  return false;
+}
+
 void MetricGatherer::ingestLineCellAndGeneCommon(LineFields const& fields)
 {
-  n_reads_++; //with/without mt? == uniquely + multimapped 
- 
-  //-----------------------------------------------------------------------
-  // Will remove this
-  // std::cout << "TEST -- to increment number of n_mitochondrial_reads -- \n";
-  std::map<size_t, std::string> indexToField_TagOrder = {
-      {0, fields.tag_triple.first}, 
-      {1, fields.tag_triple.second}, 
-      {2, fields.tag_triple.third}};
-  std::string gene_id = indexToField_TagOrder[geneid_position]; 
-  if (mitochondrial_genes_.find(gene_id) != mitochondrial_genes_.end()){
-    n_mitochondrial_reads+=1;
-  }
-  //-----------------------------------------------------------------------
- 
+  n_reads_++; //with/without mt? == uniquely + multimapped
+  if (isMitochondrial(fields))
+    n_mitochondrial_reads_ += 1;
+
   // the tags passed to this function define a molecule, this increments the counter,
   // identifying a new molecule only if a new tag combination is observed
   std::string hyphenated_tags = fields.tag_triple.first + "-" +
@@ -110,15 +111,10 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
                                  is_strand + "\t" + hyphenated_tags;
   fragment_histogram_[ref_pos_str_tags] += 1;
 
-  std::map<size_t, std::string> indexToField_TagOrder = {
-      {0, fields.tag_triple.first}, 
-      {1, fields.tag_triple.second}, 
-      {2, fields.tag_triple.third}};
-  std::string gene_id = indexToField_TagOrder[geneid_position]; 
-  
-  // Check if not a mitochondrial gene
-  if (!(mitochondrial_genes_.find(gene_id) != mitochondrial_genes_.end())) {
-   if (fields.number_mappings == 1) {
+  if (!isMitochondrial(fields))
+  {
+    if (fields.number_mappings == 1)
+    {
       reads_mapped_uniquely_ += 1;
       if (fields.alignment_location == 1 || fields.alignment_location == 3)
         reads_mapped_exonic_ += 1;
@@ -127,12 +123,12 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
       else if (fields.alignment_location == 5)
         reads_mapped_intronic_ += 1;
       else if (fields.alignment_location == 6)
-        reads_mapped_intronic_as_ += 1; }
-    else {
-      reads_mapped_multiple_ += 1;  // without multi-mapping, this number is zero!
+        reads_mapped_intronic_as_ += 1;
     }
+    else
+      reads_mapped_multiple_ += 1;  // without multi-mapping, this number is zero!
   }
- 
+
   // in futher check if read maps outside window (when we add a  gene model)
   // and  create distances from terminate side (needs gene model) uniqueness
   duplicate_reads_ += fields.read_is_duplicate;
@@ -193,40 +189,15 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
       << n_mitochondrial_reads;
 }
 
-void MetricGatherer::setGeneIdPosition(TagOrder tag_order) {
-  // This function gets the gene_id position from the tag_order object
 
-  //tagOrderToString return gene_id,barcode,umi where order depends on user input
-  std::istringstream tag_order_i(tagOrderToString(tag_order));
-  std::string token;
-  int geneid_position_i = -1; 
 
-  // Tokenize tag_order_str and check positions
-  for (int i = 0; std::getline(tag_order_i, token, ','); ++i) {
-    if (token == "gene_id" && (i == 0 || i == 1 || i == 2)) {
-        geneid_position_i = i; 
-        std::cout << "'gene_id' is at position: " << geneid_position_i << std::endl;
-        break;
-    }
-  }
-  std::cout << "'gene_id' is at position outside of for loop: " << geneid_position_i << std::endl;
-  geneid_position = geneid_position_i; 
-}
-
-int MetricGatherer::getGeneIdPosition() {
-    return geneid_position;
-}
-
-std::unordered_set<std::string> MetricGatherer::getMTgenes() {
-    return mitochondrial_genes_;
-}
 
 ////////////////  CellMetricGatherer ////////////////////////
 
 CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
-                                      TagOrder tag_order,
-                                      std::string gtf_file,
-                                      std::string mitochondrial_gene_names_filename)
+                                       TagOrder tag_order,
+                                       std::string gtf_file,
+                                       std::string mitochondrial_gene_names_filename)
   : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
   // write metrics csv header
@@ -268,26 +239,11 @@ void CellMetricGatherer::ingestLine(std::string const& str)
   cell_barcode_fraction_bases_above_30_.update(fields.cell_barcode_base_above_30);
   perfect_cell_barcodes_ += fields.cell_barcode_perfect;
 
-  // need to change this 
-  // tag_order_str is a combination of BGU so find order of where gene_id is in gene_id,barcode,umi
-  mitochondrial_genes_ = getMTgenes();
-  geneid_position = getGeneIdPosition();
-  
-  std::map<size_t, std::string> indexToField_TagOrder = {
-      {0, fields.tag_triple.first}, 
-      {1, fields.tag_triple.second}, 
-      {2, fields.tag_triple.third}};
-
-  std::string gene_id = indexToField_TagOrder[getGeneIdPosition()]; 
-
-  if (fields.alignment_location == 7) {
-    if (fields.number_mappings == 1)
-      if (!(mitochondrial_genes_.find(gene_id) != mitochondrial_genes_.end()))
-        reads_mapped_intergenic_ += 1;
-    }
-    else if(fields.alignment_location == 0) {
-      reads_unmapped_ += 1;
-    }
+  bool is_mito = isMitochondrial(fields);
+  if (fields.alignment_location == 7 && fields.number_mappings == 1 && is_mito)
+    reads_mapped_intergenic_ += 1;
+  else if (fields.alignment_location == 0)
+    reads_unmapped_ += 1;
 
   genes_histogram_[std::string(fields.tag_triple.third)] += 1;
   // END cell-metric-specific stuff
@@ -316,7 +272,7 @@ void CellMetricGatherer::outputMetricsLine()
   {
     if (count > 1)
       genes_detected_multiple_observations++;
-    if (mitochondrial_genes_.find(gene) != mitochondrial_genes_.end())
+    if (mito_genes_.find(gene) != mito_genes_.end())
     {
       n_mitochondrial_genes++;
       n_mitochondrial_molecules += count;
@@ -366,7 +322,6 @@ GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
                                        std::string mitochondrial_gene_names_filename)
   : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
-  
   // write metrics csv header
   std::string s;
   for (int i=0; i<25; i++)

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -21,19 +21,9 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
                                std::string mitochondrial_gene_names_filename)
 {
   std::cout<<"Constructor for metric gatherer called.\n";
-  std::cout<<"Get gene ID position\n";
-  std::istringstream tag_order_i(tagOrderToString(tag_order));
-  std::string token;
-  int geneid_position;
- 
-  // Tokenize tag_order_str and check positions
-  for (int i = 0; std::getline(tag_order_i, token, ','); ++i) {
-    if (token == "gene_id" && (i == 0 || i == 1 || i == 2)) {
-        geneid_position = i; 
-        std::cout << "'gene_id' is at position: " << geneid_position << std::endl;
-        break;
-    }
-  }
+  std::cout<<"set gene ID position\n";
+
+  setGeneIdPosition(tag_order);
 
   // get list of mitochondrial genes 
   if (gtf_file.empty())
@@ -200,12 +190,30 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
       << molecules_with_single_read_evidence;
 }
 
-int MetricGatherer::getGeneIdPosition() const{
+void MetricGatherer::setGeneIdPosition(TagOrder tag_order) {
+  
+  std::istringstream tag_order_i(tagOrderToString(tag_order));
+  std::string token;
+  int geneid_position_i = -1; 
+
+  // Tokenize tag_order_str and check positions
+  for (int i = 0; std::getline(tag_order_i, token, ','); ++i) {
+    if (token == "gene_id" && (i == 0 || i == 1 || i == 2)) {
+        geneid_position_i = i; 
+        std::cout << "'gene_id' is at position: " << geneid_position << std::endl;
+        break;
+    }
+  }
+  std::cout << "'gene_id' is at position outside of for loop: " << geneid_position_i << std::endl;
+  geneid_position = geneid_position_i; 
+}
+
+int MetricGatherer::getGeneIdPosition() {
     std::cout<<"GET GENE ID"<< geneid_position <<"\n";
     return geneid_position;
 }
 
-std::unordered_set<std::string> MetricGatherer::getMTgenes() const {
+std::unordered_set<std::string> MetricGatherer::getMTgenes() {
     return mitochondrial_genes_;
 }
 

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -2,6 +2,9 @@
 #include "mitochondrial_gene_selector.h"
 
 #include <map>
+#include <iostream>
+#include <sstream>
+#include <string>
 
 constexpr int kMetricsFloatPrintPrecision = 10;
 
@@ -108,17 +111,29 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.third) << "\n";
   
   // tag_order_str is a combination of BGU so find order of where gene_id is in gene_id,barcode,umi
+
+  std::cout << "Fields tag triple\n";
+  std::cout<< tag_order_str << "\n";
+
   size_t geneIndex = tag_order_str.find('gene_id');
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
       {1, fields.tag_triple.second}, 
       {2, fields.tag_triple.third}};
 
-  std::cout << "Fields tag triple\n";
-  std::cout<< tag_order_str << "\n";
   std::cout << geneIndex << "\n" ;
   std::string GeneID = indexToField_TagOrder[geneIndex]; 
   std::cout << "gene name " << GeneID << "\n";
+
+  std::istringstream ss(tag_order_str);
+  std::string token;
+
+  // Tokenize the string and check positions
+  for (int i = 0; std::getline(ss, token, ','); ++i) {
+    if (token == "gene_id" && (i == 0 || i == 1 || i == 2)) {
+        std::cout << "'gene_id' is at position: " << i << std::endl;
+    }
+  }
 
   auto it = indexToField_TagOrder.find(geneIndex);
   if (it != indexToField_TagOrder.end()) {

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -238,7 +238,6 @@ void CellMetricGatherer::ingestLine(std::string const& str)
 
   // need to change this 
   if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end())) {
-  {
     if (fields.alignment_location == 7) {
       if (fields.number_mappings == 1) 
         reads_mapped_intergenic_ += 1;

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -201,6 +201,7 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
 }
 
 int MetricGatherer::getGeneIdPosition() const{
+    std::cout<<"GET GENE ID"<< geneid_position <<"\n";
     return geneid_position;
 }
 
@@ -216,6 +217,9 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
                                       std::string mitochondrial_gene_names_filename)
   : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
+  std::cout<<"CELL METRIC GATHERER CONSTRUCTOR\n";
+  std::cout<< getGeneIdPosition()<<"\n";
+  
   // write metrics csv header
   std::string s;
   for (int i=0; i<25; i++)

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -100,6 +100,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
         std::cout << "- " << item << '\n';
   }
   std::cout << "END\n";
+  std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.first) << "\n";
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.second) << "\n";
   std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.third) << "\n";
 

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -20,9 +20,8 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
                                std::string gtf_file,
                                std::string mitochondrial_gene_names_filename)
 {
-  std::cout<<"Constructor for metric gatherer called.\n";
-  std::cout<<"set gene ID position\n";
 
+  //Get and set gene_id position in tag_order. gene_id position varies depending on user input.
   setGeneIdPosition(tag_order);
 
   // get list of mitochondrial genes 
@@ -34,7 +33,7 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
                                 gtf_file, mitochondrial_gene_names_filename);
 
   // Print the elements of the unordered_set
-  std::cout << "Mitochondrial Genes in metric gatherer: ";
+  std::cout << "The mitochondrial genes are: ";
   for (const auto& gene : mitochondrial_genes_) {
         std::cout << gene << " ";
   }
@@ -105,16 +104,14 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
                                  is_strand + "\t" + hyphenated_tags;
   fragment_histogram_[ref_pos_str_tags] += 1;
 
-  // tag_order_str is a combination of BGU so find order of where gene_id is in gene_id,barcode,umi
-  std::cout << "Fields tag triple\n";
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
       {1, fields.tag_triple.second}, 
       {2, fields.tag_triple.third}};
 
-  std::cout << geneid_position << "\n" ;
+  std::cout << "Position of gene_id in TagOrder is :" << geneid_position << "\n" ;
   std::string gene_id = indexToField_TagOrder[geneid_position]; 
-  std::cout << "gene name " << gene_id << "\n";
+  std::cout << "Gene name " << gene_id << "\n";
   
   // Check if not a mitochondrial gene
   if (!(mitochondrial_genes_.find(gene_id) != mitochondrial_genes_.end())) {
@@ -133,9 +130,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
     }
   }
   else {
-    std::cout<<"Check if mitochrondrial gene\n";
-    std::cout<<"GENE " << std::string(fields.tag_triple.third) <<"\n";
-    std::cout<<"mitochrondrial gene\n"; 
+    std::cout<< gene_id << "is a mitochrondrial gene. Skip.\n";
   }
 
   // in futher check if read maps outside window (when we add a  gene model)
@@ -198,7 +193,9 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
 }
 
 void MetricGatherer::setGeneIdPosition(TagOrder tag_order) {
-  
+  // This function gets the gene_id position from the tag_order object
+
+  //tagOrderToString return gene_id,barcode,umi where order depends on user input
   std::istringstream tag_order_i(tagOrderToString(tag_order));
   std::string token;
   int geneid_position_i = -1; 
@@ -216,7 +213,6 @@ void MetricGatherer::setGeneIdPosition(TagOrder tag_order) {
 }
 
 int MetricGatherer::getGeneIdPosition() {
-    std::cout<<"GET GENE ID"<< geneid_position <<"\n";
     return geneid_position;
 }
 
@@ -232,17 +228,6 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
                                       std::string mitochondrial_gene_names_filename)
   : MetricGatherer(metric_output_file, tag_order, gtf_file, mitochondrial_gene_names_filename)
 {
-  std::cout<<"CELL METRIC GATHERER CONSTRUCTOR\n";
-  std::cout<< getGeneIdPosition()<<"\n";
-  std::unordered_set<std::string>  mt = getMTgenes();
-
-  // Print the elements of the unordered_set
-  std::cout << "Mitochondrial Genes in cell metric gatherer: ";
-  for (const auto& gene : mt) {
-        std::cout << gene << " ";
-  }
-  std::cout << std::endl;
-  
   // write metrics csv header
   std::string s;
   for (int i=0; i<25; i++)
@@ -287,15 +272,14 @@ void CellMetricGatherer::ingestLine(std::string const& str)
   mitochondrial_genes_ = getMTgenes();
   geneid_position = getGeneIdPosition();
   
-  std::cout << "Fields tag triple in ingestLine\n";
   std::map<size_t, std::string> indexToField_TagOrder = {
       {0, fields.tag_triple.first}, 
       {1, fields.tag_triple.second}, 
       {2, fields.tag_triple.third}};
 
-  std::cout << geneid_position << "\n" ;
+  std::cout << "Position of gene_id in TagOrder is :" << geneid_position << "\n" ;
   std::string gene_id = indexToField_TagOrder[getGeneIdPosition()]; 
-  std::cout << "gene name in ingestLine" << gene_id << "\n";
+  std::cout << "Gene name " << gene_id << "\n";
 
   if (fields.alignment_location == 7) {
     if (fields.number_mappings == 1)

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -120,6 +120,13 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
   std::string GeneID = indexToField_TagOrder[geneIndex]; 
   std::cout << "gene name " << GeneID << "\n";
 
+  auto it = indexToField_TagOrder.find(geneIndex);
+  if (it != indexToField_TagOrder.end()) {
+      std::string result = it->second;
+      std::cout << "Index of 'G' in the tag_order_str: " << geneIndex << std::endl;
+      std::cout << "Corresponding field: " << result << std::endl;
+  }
+
   // Check if not a mitochondrial gene
   //if (!(mitochondrial_genes_.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_.end())) {
   if (!(mitochondrial_genes_.find(GeneID) != mitochondrial_genes_.end())) {

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -189,6 +189,12 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
   mitochondrial_genes_ = getInterestingMitochondrialGenes(
       gtf_file, mitochondrial_gene_names_filename);
 
+  std::cout << "PRINT mitochondrial_genes_overall:\n";
+  for (const auto& item : mitochondrial_genes_) {
+        std::cout << "- " << item << '\n';
+  }
+  std::cout << "END\n";
+  
   // write metrics csv header
   std::string s;
   for (int i=0; i<25; i++)

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -115,6 +115,7 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
       {2, fields.tag_triple.third}};
 
   std::cout << "Fields tag triple\n";
+  std::cout << geneIndex << "\n" ;
   std::string GeneID = indexToField_TagOrder[geneIndex]; 
   std::cout << "gene name " << GeneID << "\n";
 

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -24,7 +24,7 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
   mitochondrial_genes_overall = getInterestingMitochondrialGenes(
                                 gtf_file, mitochondrial_gene_names_filename);
 
-  std::cout << "PRINT mitochondrial_genes_overall:\n";
+  std::cout << "PRINT mitochondrial_genes_overall in MetricGatherer:\n";
   for (const auto& item : mitochondrial_genes_overall) {
         std::cout << "- " << item << '\n';
   }
@@ -94,6 +94,13 @@ void MetricGatherer::parseAlignedReadFields(LineFields const& fields, std::strin
                                  std::to_string(fields.position) + "\t" +
                                  is_strand + "\t" + hyphenated_tags;
   fragment_histogram_[ref_pos_str_tags] += 1;
+
+  std::cout << "PRINT mitochondrial_genes_overall in parseAlignedReadFields:\n";
+  for (const auto& item : mitochondrial_genes_overall) {
+        std::cout << "- " << item << '\n';
+  }
+  std::cout << "END\n";
+  std::cout << "gene in parseAlignedReadFields " << std::string(fields.tag_triple.third) << "\n";
 
   // Check if not a mitochondrial gene
   if (!(mitochondrial_genes_overall.find(std::string(fields.tag_triple.third)) != mitochondrial_genes_overall.end())) {

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -307,8 +307,10 @@ void CellMetricGatherer::clear()
 
 
 ////////////////  GeneMetricGatherer ////////////////////////
-GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file)
-  : MetricGatherer(metric_output_file)
+GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
+                                       std::string gtf_file,
+                                       std::string mitochondrial_gene_names_filename)
+  : MetricGatherer(metric_output_file, gtf_file, mitochondrial_gene_names_filename)
 {
   // write metrics csv header
   std::string s;
@@ -372,8 +374,11 @@ void GeneMetricGatherer::clear()
 
 
 ////////////////  UmiMetricGatherer ////////////////////////
-UmiMetricGatherer::UmiMetricGatherer(std::string metric_output_file, TagOrder tag_order)
-  : MetricGatherer(metric_output_file)
+UmiMetricGatherer::UmiMetricGatherer(std::string metric_output_file,
+                                     TagOrder tag_order,
+                                     std::string gtf_file,
+                                     std::string mitochondrial_gene_names_filename)
+  : MetricGatherer(metric_output_file, gtf_file, mitochondrial_gene_names_filename)
 {
   metrics_csv_outfile_ << tagOrderToString(tag_order) << ",count\n";
 }

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -15,6 +15,7 @@ MetricGatherer::MetricGatherer(std::string metric_output_file,
                                std::string gtf_file,
                                std::string mitochondrial_gene_names_filename)
 {
+  std::cout<<"Constructor for metric gatherer called.\n";
   // get list of mitochondrial genes 
   if (gtf_file.empty())
     crash("MetricGatherer needs a non-empty gtf_file name!");
@@ -322,6 +323,8 @@ GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
                                        std::string mitochondrial_gene_names_filename)
   : MetricGatherer(metric_output_file, gtf_file, mitochondrial_gene_names_filename)
 {
+  
+  std::cout<<"Constructor for gene metric gatherer called.\n";
   // write metrics csv header
   std::string s;
   for (int i=0; i<25; i++)

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -186,7 +186,7 @@ void MetricGatherer::outputMetricsLineCellAndGeneCommon()
       << fragments_per_molecule << ","
       << fragments_with_single_read_evidence << ","
       << molecules_with_single_read_evidence << ","
-      << n_mitochondrial_reads;
+      << n_mitochondrial_reads_;
 }
 
 

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -125,7 +125,9 @@ private:
   std::unordered_map<std::string, int> fragment_histogram_;
 
   // Make copy of ordered set of mitochonrial genes from Cell Metrics to parent class Metrics
-  std::unordered_set<std::string> mitochondrial_genes_overall;
+  std::unordered_set<std::string> mitochondrial_genes_;
+  // String of tag order 
+  std::string tag_order_str;
   
   // molecule information
   OnlineGaussianSufficientStatistic molecule_barcode_fraction_bases_above_30_;

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -81,7 +81,7 @@ protected:
   void clearCellAndGeneCommon();
   bool isMitochondrial(LineFields const& fields) const;
 
-  const std::string kCommonHeaders[25] =
+  const std::string kCommonHeaders[26] =
   {
     "n_reads",
     "noise_reads",
@@ -107,7 +107,8 @@ protected:
     "reads_per_fragment",
     "fragments_per_molecule",
     "fragments_with_single_read_evidence",
-    "molecules_with_single_read_evidence"
+    "molecules_with_single_read_evidence",
+    "n_mitochondrial_reads"
   };
 
   void parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags);

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -85,7 +85,7 @@ protected:
   void outputMetricsLineCellAndGeneCommon();
   void clearCellAndGeneCommon();
 
-  const std::string kCommonHeaders[25] =
+  const std::string kCommonHeaders[26] =
   {
     "n_reads",
     "noise_reads",
@@ -111,7 +111,8 @@ protected:
     "reads_per_fragment",
     "fragments_per_molecule",
     "fragments_with_single_read_evidence",
-    "molecules_with_single_read_evidence"
+    "molecules_with_single_read_evidence",
+    "n_mitochondrial_reads" 
   };
 
   void parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags);
@@ -162,6 +163,8 @@ private:
   int spliced_reads_ = 0;
   const int kAntisenseReads = 0; // TODO is never changed from 0
   // int plus_strand_reads_ = 0;  // strand balance (currently unused)
+  // test for mt -- will need to remove
+  int n_mitochondrial_reads = 0;
 };
 
 class CellMetricGatherer: public MetricGatherer
@@ -211,8 +214,8 @@ private:
     "genes_detected_multiple_observations",
     "n_mitochondrial_genes",
     "n_mitochondrial_molecules",
-    "pct_mitochondrial_molecules"
-  };
+    "pct_mitochondrial_molecules" 
+  }; 
 };
 
 

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -208,7 +208,9 @@ private:
 class GeneMetricGatherer: public MetricGatherer
 {
 public:
-  explicit GeneMetricGatherer(std::string metric_output_file);
+  explicit GeneMetricGatherer(std::string metric_output_file,
+                              std::string gtf_file,
+                              std::string mitochondrial_gene_names_filename);
 
   void ingestLine(std::string const& str) override;
 
@@ -229,7 +231,10 @@ private:
 class UmiMetricGatherer: public MetricGatherer
 {
 public:
-  UmiMetricGatherer(std::string metric_output_file, TagOrder tag_order);
+  UmiMetricGatherer(std::string metric_output_file, 
+                    TagOrder tag_order, 
+                    std::string gtf_file,
+                    std::string mitochondrial_gene_names_filename);
   void ingestLine(std::string const& str) override;
   void outputMetricsLine() override;
 

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -81,7 +81,7 @@ protected:
   void clearCellAndGeneCommon();
   bool isMitochondrial(LineFields const& fields) const;
 
-  const std::string kCommonHeaders[26] =
+  const std::string kCommonHeaders[25] =
   {
     "n_reads",
     "noise_reads",
@@ -107,8 +107,7 @@ protected:
     "reads_per_fragment",
     "fragments_per_molecule",
     "fragments_with_single_read_evidence",
-    "molecules_with_single_read_evidence",
-    "n_mitochondrial_reads"
+    "molecules_with_single_read_evidence"
   };
 
   void parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags);

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -62,7 +62,9 @@ private:
 class MetricGatherer
 {
 public:
-  MetricGatherer(std::string metric_output_file);
+  MetricGatherer(std::string metric_output_file,
+                 std::string gtf_file,
+                 std::string mitochondrial_gene_names_filename);
   virtual ~MetricGatherer();
 
   virtual void ingestLine(std::string const& str) = 0;
@@ -121,6 +123,9 @@ private:
 
   std::unordered_map<std::string, int> fragment_histogram_;
 
+  // Make copy of ordered set of mitochonrial genes from Cell Metrics to parent class Metrics
+  std::unordered_set<std::string> mitochondrial_genes_overall;
+  
   // molecule information
   OnlineGaussianSufficientStatistic molecule_barcode_fraction_bases_above_30_;
 
@@ -193,7 +198,7 @@ private:
     "cell_barcode_fraction_bases_above_30_mean",
     "n_genes",
     "genes_detected_multiple_observations",
-    "n_mitochondrial_genes",
+    "mitochondrial_genes_",
     "n_mitochondrial_molecules",
     "pct_mitochondrial_molecules"
   };

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -62,6 +62,11 @@ private:
 class MetricGatherer
 {
 public:
+  // Unordered set of mitochondrial genes
+  std::unordered_set<std::string> mitochondrial_genes_;
+  // Integer to tell us where geneid_position
+  int geneid_position;
+
   MetricGatherer(std::string metric_output_file,
                  TagOrder tag_order, 
                  std::string gtf_file,
@@ -70,6 +75,7 @@ public:
 
   virtual void ingestLine(std::string const& str) = 0;
   virtual void outputMetricsLine() = 0;
+  
 
 protected:
   // Each line of metric output is built from all alignments with a given tag.
@@ -124,11 +130,6 @@ private:
 
   std::unordered_map<std::string, int> fragment_histogram_;
 
-  // Make copy of ordered set of mitochonrial genes from Cell Metrics to parent class Metrics
-  std::unordered_set<std::string> mitochondrial_genes_;
-  // String of tag order 
-  std::string tag_order_str;
-  
   // molecule information
   OnlineGaussianSufficientStatistic molecule_barcode_fraction_bases_above_30_;
 
@@ -164,9 +165,9 @@ class CellMetricGatherer: public MetricGatherer
 {
 public:
   CellMetricGatherer(std::string metric_output_file,
-                     TagOrder tag_order,
-                     std::string gtf_file,
-                     std::string mitochondrial_gene_names_filename);
+                    TagOrder tag_order, 
+                    std::string gtf_file,
+                    std::string mitochondrial_gene_names_filename);
   void ingestLine(std::string const& str) override;
   void outputMetricsLine() override;
 
@@ -174,8 +175,6 @@ protected:
   void clear() override;
 
 private:
-  std::unordered_set<std::string> mitochondrial_genes_;
-
   int perfect_cell_barcodes_ = 0; // The number of reads whose cell barcodes contain no errors (tag ``CB`` == ``CR``)
   int reads_mapped_intergenic_ = 0; // The number of reads mapped to an intergenic region for this cell
 

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -71,8 +71,9 @@ public:
   virtual void ingestLine(std::string const& str) = 0;
   virtual void outputMetricsLine() = 0;
   
-  int getGeneIdPosition() const;
-  std::unordered_set<std::string> getMTgenes() const;
+  void setGeneIdPosition(TagOrder tag_order);
+  int getGeneIdPosition();
+  std::unordered_set<std::string> getMTgenes();
 
 protected:
   // Each line of metric output is built from all alignments with a given tag.
@@ -120,12 +121,12 @@ protected:
 
   std::string prev_tag_;
 
-private:
   // Unordered set of mitochondrial genes
   std::unordered_set<std::string> mitochondrial_genes_;
   // Integer to tell us where geneid_position
   int geneid_position;
 
+private:
   // count information
   int n_reads_ = 0;
   const int noise_reads = 0; //# long polymers, N-sequences; NotImplemented

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -177,6 +177,11 @@ protected:
   void clear() override;
 
 private:
+  // Unordered set of mitochondrial genes
+  std::unordered_set<std::string> mitochondrial_genes_;
+  // Integer to tell us where geneid_position
+  int geneid_position;
+
   int perfect_cell_barcodes_ = 0; // The number of reads whose cell barcodes contain no errors (tag ``CB`` == ``CR``)
   int reads_mapped_intergenic_ = 0; // The number of reads mapped to an intergenic region for this cell
 

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -209,7 +209,7 @@ private:
     "cell_barcode_fraction_bases_above_30_mean",
     "n_genes",
     "genes_detected_multiple_observations",
-    "mitochondrial_genes_",
+    "n_mitochondrial_genes",
     "n_mitochondrial_molecules",
     "pct_mitochondrial_molecules"
   };

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -62,11 +62,6 @@ private:
 class MetricGatherer
 {
 public:
-  // Unordered set of mitochondrial genes
-  std::unordered_set<std::string> mitochondrial_genes_;
-  // Integer to tell us where geneid_position
-  int geneid_position;
-
   MetricGatherer(std::string metric_output_file,
                  TagOrder tag_order, 
                  std::string gtf_file,
@@ -76,6 +71,8 @@ public:
   virtual void ingestLine(std::string const& str) = 0;
   virtual void outputMetricsLine() = 0;
   
+  int getGeneIdPosition() const;
+  std::unordered_set<std::string> getMTgenes() const;
 
 protected:
   // Each line of metric output is built from all alignments with a given tag.
@@ -124,6 +121,11 @@ protected:
   std::string prev_tag_;
 
 private:
+  // Unordered set of mitochondrial genes
+  std::unordered_set<std::string> mitochondrial_genes_;
+  // Integer to tell us where geneid_position
+  int geneid_position;
+
   // count information
   int n_reads_ = 0;
   const int noise_reads = 0; //# long polymers, N-sequences; NotImplemented

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -63,6 +63,7 @@ class MetricGatherer
 {
 public:
   MetricGatherer(std::string metric_output_file,
+                 TagOrder tag_order, 
                  std::string gtf_file,
                  std::string mitochondrial_gene_names_filename);
   virtual ~MetricGatherer();
@@ -161,6 +162,7 @@ class CellMetricGatherer: public MetricGatherer
 {
 public:
   CellMetricGatherer(std::string metric_output_file,
+                     TagOrder tag_order,
                      std::string gtf_file,
                      std::string mitochondrial_gene_names_filename);
   void ingestLine(std::string const& str) override;
@@ -209,6 +211,7 @@ class GeneMetricGatherer: public MetricGatherer
 {
 public:
   explicit GeneMetricGatherer(std::string metric_output_file,
+                              TagOrder tag_order,
                               std::string gtf_file,
                               std::string mitochondrial_gene_names_filename);
 

--- a/tools/TagSort/src/partial_file_merge.cpp
+++ b/tools/TagSort/src/partial_file_merge.cpp
@@ -106,12 +106,12 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
   if (options.metric_type == MetricType::Cell)
   {
     return std::make_unique<CellMetricGatherer>(
-        options.metric_output_file, options.gtf_file,
-        options.mitochondrial_gene_names_filename);
+        options.metric_output_file, getTagOrder(options), 
+        options.gtf_file, options.mitochondrial_gene_names_filename);
   }
   else if (options.metric_type == MetricType::Gene)
-    return std::make_unique<GeneMetricGatherer>(options.metric_output_file, options.gtf_file,
-                                                options.mitochondrial_gene_names_filename);
+    return std::make_unique<GeneMetricGatherer>(options.metric_output_file, getTagOrder(options),
+                                                options.gtf_file, options.mitochondrial_gene_names_filename);
   else if (options.metric_type == MetricType::Umi)
     return std::make_unique<UmiMetricGatherer>(options.metric_output_file, getTagOrder(options), 
                                                options.gtf_file, options.mitochondrial_gene_names_filename);

--- a/tools/TagSort/src/partial_file_merge.cpp
+++ b/tools/TagSort/src/partial_file_merge.cpp
@@ -124,7 +124,6 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
 int mergePartialFiles(INPUT_OPTIONS_TAGSORT const& options,
                       std::vector<std::string> const& partial_files)
 {
-  std::cout << "mergePartialFiles\n ";
   int num_alignments = 0;
 
   std::unique_ptr<MetricGatherer> metric_gatherer = maybeMakeMetricGatherer(options);

--- a/tools/TagSort/src/partial_file_merge.cpp
+++ b/tools/TagSort/src/partial_file_merge.cpp
@@ -110,9 +110,11 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
         options.mitochondrial_gene_names_filename);
   }
   else if (options.metric_type == MetricType::Gene)
-    return std::make_unique<GeneMetricGatherer>(options.metric_output_file);
+    return std::make_unique<GeneMetricGatherer>(options.metric_output_file, options.gtf_file,
+                                                options.mitochondrial_gene_names_filename);
   else if (options.metric_type == MetricType::Umi)
-    return std::make_unique<UmiMetricGatherer>(options.metric_output_file, getTagOrder(options));
+    return std::make_unique<UmiMetricGatherer>(options.metric_output_file, getTagOrder(options), 
+                                               options.gtf_file, options.mitochondrial_gene_names_filename);
   else
     crash("new MetricType enum value is not yet handled by MetricGatherer!");
   return nullptr;

--- a/tools/TagSort/src/partial_file_merge.cpp
+++ b/tools/TagSort/src/partial_file_merge.cpp
@@ -124,6 +124,7 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
 int mergePartialFiles(INPUT_OPTIONS_TAGSORT const& options,
                       std::vector<std::string> const& partial_files)
 {
+  std::cout << "mergePartialFiles\n ";
   int num_alignments = 0;
 
   std::unique_ptr<MetricGatherer> metric_gatherer = maybeMakeMetricGatherer(options);

--- a/tools/TagSort/src/partial_file_merge.cpp
+++ b/tools/TagSort/src/partial_file_merge.cpp
@@ -106,17 +106,22 @@ std::unique_ptr<MetricGatherer> maybeMakeMetricGatherer(INPUT_OPTIONS_TAGSORT co
   if (options.metric_type == MetricType::Cell)
   {
     return std::make_unique<CellMetricGatherer>(
-        options.metric_output_file, getTagOrder(options), 
+        options.metric_output_file, getTagOrder(options),
         options.gtf_file, options.mitochondrial_gene_names_filename);
   }
-  else if (options.metric_type == MetricType::Gene)
-    return std::make_unique<GeneMetricGatherer>(options.metric_output_file, getTagOrder(options),
-                                                options.gtf_file, options.mitochondrial_gene_names_filename);
-  else if (options.metric_type == MetricType::Umi)
-    return std::make_unique<UmiMetricGatherer>(options.metric_output_file, getTagOrder(options), 
-                                               options.gtf_file, options.mitochondrial_gene_names_filename);
-  else
-    crash("new MetricType enum value is not yet handled by MetricGatherer!");
+  if (options.metric_type == MetricType::Gene)
+  {
+    return std::make_unique<GeneMetricGatherer>(
+        options.metric_output_file, getTagOrder(options), options.gtf_file,
+        options.mitochondrial_gene_names_filename);
+  }
+  if (options.metric_type == MetricType::Umi)
+  {
+    return std::make_unique<UmiMetricGatherer>(
+        options.metric_output_file, getTagOrder(options),  options.gtf_file,
+        options.mitochondrial_gene_names_filename);
+  }
+  crash("new MetricType enum value is not yet handled by MetricGatherer!");
   return nullptr;
 }
 


### PR DESCRIPTION
Remove reads on MT genes from the intronic, exonic, and intergenic counts in Optimus/Multiome. To do this, we did the following:

1. Added the protected variables `std::unordered_set<std::string> mito_genes_` to the class `MetricGatherer`. `mito_genes_` are a set of MT genes 

3. Added the following additional input parameters to the`MetricGatherer` class: TagOrder tag_order, std::string gtf_file, std::string mitochondrial_gene_names_filename.

4. Added function `isMitochondrial` to the class `MetricGatherer` which returns whether or not a gene is mitochondrial based on the tag_order.

5. Moved function `getInterestingMitochondrialGenes` in the `MetricGatherer` constructor. 
6. Function `parseAlignedReadFields` in the `MetricGatherer`  class. 
- Added condition if mitochondrial (this calls `isMitochondrial`) to check if the gene is mitochondrial or not before counting the number of reads_mapped_uniquely_, reads_mapped_exonic_, reads_mapped_intronic_,  reads_mapped_intronic_as_ and reads_mapped_multiple_. 

7. Function  `ingestLine` in the `CellMetricGatherer`  class.  
- Added condition if mitochondrial (this calls `isMitochondrial`) in if statement to check if gene is mitochondrial or not. 

