### PR TITLE
PD-2476: Update Dockerfile to checkout to aa-distbwa branch

### DIFF
--- a/3rd-party-tools/samtools-dist-bwa/Dockerfile
+++ b/3rd-party-tools/samtools-dist-bwa/Dockerfile
@@ -20,6 +20,9 @@ RUN set -eux; \
     cd temp; \
     # clone fork of Open-Omics-Acceleration-Framework with changes added for input/output
     git clone --recursive https://github.com/IntelLabs/Open-Omics-Acceleration-Framework.git; \
+    # for testing purposes checkout to branch 
+    cd Open-Omics-Acceleration-Framework; \
+    git checkout aa-distbwa; \
     
     # install packages 
     cd Open-Omics-Acceleration-Framework/pipelines/fq2sortedbam; \

--- a/3rd-party-tools/samtools-dist-bwa/Dockerfile
+++ b/3rd-party-tools/samtools-dist-bwa/Dockerfile
@@ -19,8 +19,10 @@ RUN set -eux; \
     pwd; \
     cd temp; \
     # clone fork of Open-Omics-Acceleration-Framework with changes added for input/output
-    git clone --recursive https://github.com/IntelLabs/Open-Omics-Acceleration-Framework.git; \
-    # for testing purposes checkout to branch 
+    ## git clone --recursive https://github.com/IntelLabs/Open-Omics-Acceleration-Framework.git
+    
+    # for testing purposes checkout to branch     
+    git clone --recursive https://github.com/aawdeh/Open-Omics-Acceleration-Framework.git; \
     cd Open-Omics-Acceleration-Framework; \
     git checkout aa-distbwa; \
     

--- a/3rd-party-tools/samtools-dist-bwa/Dockerfile
+++ b/3rd-party-tools/samtools-dist-bwa/Dockerfile
@@ -27,7 +27,8 @@ RUN set -eux; \
     git checkout aa-distbwa; \
     
     # install packages 
-    cd Open-Omics-Acceleration-Framework/pipelines/fq2sortedbam; \
+    ## cd Open-Omics-Acceleration-Framework/pipelines/fq2sortedbam
+    cd pipelines/fq2sortedbam; \
     ./install.sh; \
     
     # Tini


### PR DESCRIPTION
This is to build docker based off aa-distbwa to incorporate the new changes (error messages) in distributed bwa-mem2 