### PR TITLE
PD-2434 Fix failing test for arrays-picard-private docker image

### DIFF
--- a/.github/workflows/build-arrays-picard-private.yml
+++ b/.github/workflows/build-arrays-picard-private.yml
@@ -20,6 +20,7 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/arrays-picard-private
+  ACR_PATH: arrays-picard-private
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -72,12 +73,6 @@ jobs:
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
-    - name: Check working directory and parameters'
-      run: |
-        echo "Current directory: "
-        pwd
-        ls -lht
-        echo "Pushing to: " ${ACR_PATH}:${TAG}
     - name: 'Build and push image'
       uses: azure/docker-login@v1
       with:

--- a/.github/workflows/build-arrays-picard-private.yml
+++ b/.github/workflows/build-arrays-picard-private.yml
@@ -72,7 +72,12 @@ jobs:
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
+    - name: Check working directory and parameters'
+      run: |
+        echo "Current directory: "
+        pwd
+        ls -lht
+        echo "Pushing to: " ${ACR_PATH}:${TAG}
     - name: 'Build and push image'
       uses: azure/docker-login@v1
       with:

--- a/.github/workflows/build-arrays-picard-private.yml
+++ b/.github/workflows/build-arrays-picard-private.yml
@@ -25,8 +25,7 @@ env:
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # The job that builds our container
-  build:
-    # The type of runner that the job will run on
+  build-for-gcr:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -58,3 +57,28 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
+
+  build-for-acr:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 3rd-party-tools/arrays-picard-private
+    steps:
+    # checkout the repo
+    - name: 'Checkout GitHub Action'
+      uses: actions/checkout@v3
+      
+    - name: 'Login via Azure CLI'
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+    
+    - name: 'Build and push image'
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+    - run: |
+        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
+        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/3rd-party-tools/arrays-picard-private/Dockerfile
+++ b/3rd-party-tools/arrays-picard-private/Dockerfile
@@ -40,8 +40,7 @@ RUN set -eux; \
     ; \
 # Install tini
     wget https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -O /sbin/tini; \
-    chmod +x /sbin/tini \
-    ;
+    chmod +x /sbin/tini;
 
 # Set tini as default entry point
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/3rd-party-tools/arrays-picard-private/Dockerfile
+++ b/3rd-party-tools/arrays-picard-private/Dockerfile
@@ -1,5 +1,5 @@
 # Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
-FROM --platform="linux/amd64" adoptopenjdk/openjdk8:debian-slim
+FROM --platform="linux/amd64" adoptopenjdk/openjdk8:alpine-slim
 
 ARG PICARD_PRIVATE_VERSION=c24d8e2dfd6de9c663416278040a9f91b6a5e3eb
 
@@ -17,9 +17,7 @@ WORKDIR /usr/gitc
 
 # Install dependencies
 RUN set -eux; \
-        apt-get update; \
-        apt-get upgrade -y; \
-        apt-get install -y \    
+        apk add --no-cache \
             bash \
             curl \ 
             findutils \
@@ -43,9 +41,7 @@ RUN set -eux; \
 # Install tini
     wget https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -O /sbin/tini; \
     chmod +x /sbin/tini \
-    ; \
-# Clean up cached files
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    ;
 
 # Set tini as default entry point
 ENTRYPOINT ["/sbin/tini", "--"]


### PR DESCRIPTION
- Updated base image from `adoptopenjdk/openjdk8:debian-slim` -> `adoptopenjdk/openjdk8:alpine-slim`
- Updated commands from apt-get to apk
- Removed cleanup section since we are using --no-cache flag