### PR TITLE
PD-2516: Update GitHub actions for snapATAC to include Azure build

### DIFF
--- a/.github/workflows/build-snapatac2.yml
+++ b/.github/workflows/build-snapatac2.yml
@@ -20,12 +20,13 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/snapatac2
+  ACR_PATH: snapatac2
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # The job that builds our container
-  build:
+  build-for-gcr:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -57,3 +58,28 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
+
+  build-for-acr:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 3rd-party-tools/snapatac2
+    steps:
+      # checkout the repo
+      - name: 'Checkout GitHub Action'
+        uses: actions/checkout@v3
+
+      - name: 'Login via Azure CLI'
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: 'Build and push image'
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - run: |
+          docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
+          docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/3rd-party-tools/snapatac2/README.MD
+++ b/3rd-party-tools/snapatac2/README.MD
@@ -19,7 +19,7 @@ SnapATAC2 image uses the following convention for verisoning:
 
 We keep track of all past versions in [docker_versions](docker_versions.tsv) with the last image listed being the currently used version in WARP.
 
-You can see more information about the image, including the tool versions, by running the following command:
+You can see more information about the image, including the tool versions, by running the following commands:
 
 ```bash
 $ docker pull us.gcr.io/broad-gotc-prod/snapatac2:1.0.2-2.2.0-1679678908


### PR DESCRIPTION
Adding ACR automation for `snapatac2` container

NOTE: The changes in https://github.com/broadinstitute/warp/pull/1212 required both the `snapatac2` and the `upstools` images to have an ACR component. The `upstools` build already has ACR included (see [here](https://github.com/broadinstitute/warp-tools/blob/9b0ca36de8d59ca226a4539a1de79ec4c3bcf73a/.github/workflows/build-upstools.yml#L62)), so only `snapatac2` was updated as part of this change. 

Relates to: https://github.com/broadinstitute/warp/pull/1212 