### PR TITLE
add reads_mapped_mitochondrial field to output, fix reads_mapped_multiple

### DIFF
--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -209,7 +209,7 @@ CellMetricGatherer::CellMetricGatherer(std::string metric_output_file,
 {
   // write metrics csv header
   std::string s;
-  for (int i=0; i<26; i++)
+  for (int i=0; i<27; i++)
     metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<11; i++)
     metrics_csv_outfile_ << "," << cell_specific_headers[i];
@@ -331,7 +331,7 @@ GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
 {
   // write metrics csv header
   std::string s;
-  for (int i=0; i<26; i++)
+  for (int i=0; i<27; i++)
     metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<2; i++)
     metrics_csv_outfile_ << "," << gene_specific_headers[i];

--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -48,7 +48,8 @@ void MetricGatherer::clearCellAndGeneCommon()
   reads_mapped_exonic_as_ = 0;
   reads_mapped_intronic_ = 0;
   reads_mapped_intronic_as_ = 0;
-
+  reads_mapped_mitochondrial_ =0;
+  
   // alignment uniqueness information
   reads_mapped_uniquely_ = 0;
   reads_mapped_multiple_ = 0;

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -81,7 +81,7 @@ protected:
   void clearCellAndGeneCommon();
   bool isMitochondrial(LineFields const& fields) const;
 
-  const std::string kCommonHeaders[25] =
+  const std::string kCommonHeaders[26] =
   {
     "n_reads",
     "noise_reads",
@@ -107,7 +107,8 @@ protected:
     "reads_per_fragment",
     "fragments_per_molecule",
     "fragments_with_single_read_evidence",
-    "molecules_with_single_read_evidence"
+    "molecules_with_single_read_evidence",
+    "reads_mapped_mitochondrial"
   };
 
   void parseAlignedReadFields(LineFields const& fields, std::string hyphenated_tags);
@@ -136,12 +137,15 @@ private:
 
   OnlineGaussianSufficientStatistic genomic_read_quality_;
 
+  // (Note that all of these reads_mapped fields count only unique reads; any
+  //  read that has duplicates does not contribute to them *at all*)
   // alignment location information
   int reads_mapped_exonic_ = 0;
   int reads_mapped_exonic_as_ = 0;
   int reads_mapped_intronic_ = 0;
   int reads_mapped_intronic_as_ = 0;
   //int reads_mapped_utr_ = 0;
+  int reads_mapped_mitochondrial_ = 0;
 
   // in future we can implement this when we have a gene model
   // self.reads_mapped_outside_window = 0  # reads should be within 1000 bases of UTR

--- a/tools/TagSort/src/metricgatherer.h
+++ b/tools/TagSort/src/metricgatherer.h
@@ -81,7 +81,7 @@ protected:
   void clearCellAndGeneCommon();
   bool isMitochondrial(LineFields const& fields) const;
 
-  const std::string kCommonHeaders[26] =
+  const std::string kCommonHeaders[27] =
   {
     "n_reads",
     "tso_reads",

--- a/tools/scripts/create_h5ad_optimus.py
+++ b/tools/scripts/create_h5ad_optimus.py
@@ -169,6 +169,7 @@ def generate_col_attr(args):
         "n_fragments",
         "fragments_with_single_read_evidence",
         "molecules_with_single_read_evidence",
+        "reads_mapped_mitochondrial",
         "perfect_cell_barcodes",
         "reads_mapped_intergenic",
         "reads_unmapped",

--- a/tools/scripts/create_snrna_optimus_exons_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_exons_h5ad.py
@@ -162,6 +162,7 @@ def generate_col_attr(barcode_1_path,barcode_2_path,cell_metrics_path):
         "n_fragments",
         "fragments_with_single_read_evidence",
         "molecules_with_single_read_evidence",
+        "reads_mapped_mitochondrial",
         "perfect_cell_barcodes",
         "reads_mapped_intergenic",
         "reads_unmapped",

--- a/tools/scripts/create_snrna_optimus_full_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_full_h5ad.py
@@ -159,6 +159,7 @@ def generate_col_attr(args):
         "n_fragments",
         "fragments_with_single_read_evidence",
         "molecules_with_single_read_evidence",
+        "reads_mapped_mitochondrial",
         "perfect_cell_barcodes",
         "reads_mapped_intergenic",
         "reads_unmapped",


### PR DESCRIPTION
reads_mapped_mitochondrial is now tallied; it includes only uniquely mapped mitochondrial reads (just as the other reads_mapped_ fields also exclude multi-mapped reads)

In addition to adding reads_mapped_mitochondrial, the existing reads_mapped_multiple output field now no longer excludes mitochondrial from its count.

To be clear on how all these fields relate:
`reads_mapped_uniquely = reads_mapped_exonic + reads_mapped_exonic_as + reads_mapped_intronic + reads_mapped_intronic_as + reads_mapped_intergenic + reads_mapped_mitochondrial`
(Actually it would be nice to add a test enforcing that relationship)