### PR TITLE
updated kcommondheaders for gene metrics

### DIFF
--- a/tools/TagSort/src/metricgatherer.cpp
+++ b/tools/TagSort/src/metricgatherer.cpp
@@ -326,7 +326,7 @@ GeneMetricGatherer::GeneMetricGatherer(std::string metric_output_file,
 {
   // write metrics csv header
   std::string s;
-  for (int i=0; i<25; i++)
+  for (int i=0; i<26; i++)
     metrics_csv_outfile_ << "," << kCommonHeaders[i]; // TODO ok to start with ,?
   for (int i=0; i<2; i++)
     metrics_csv_outfile_ << "," << gene_specific_headers[i];


### PR DESCRIPTION
This PR updates the number of columns that should be in the output CSV file. This fixes a bug from the previous docker version that caused gene metrics to lose the last column. New docker will be v2.1.1