### PR TITLE
update star in samtools star docker

### DIFF
--- a/3rd-party-tools/samtools-star/Dockerfile
+++ b/3rd-party-tools/samtools-star/Dockerfile
@@ -1,7 +1,7 @@
 # Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
 FROM --platform="linux/amd64" us.gcr.io/broad-gotc-prod/samtools:1.0.0-1.11-1624651616
 
-ARG STAR_VERSION=2.7.10a
+ARG STAR_VERSION=2.7.11a
 
 ENV TERM=xterm-256color \
         STAR_URL=https://github.com/alexdobin/STAR/archive/${STAR_VERSION}.tar.gz

--- a/3rd-party-tools/samtools-star/docker_build.sh
+++ b/3rd-party-tools/samtools-star/docker_build.sh
@@ -14,7 +14,7 @@ QUAY_URL="quay.io/broadinstitute/gotc-prod-samtools-star"
 SAMTOOLS_VERSION="1.11"
 
 # STAR version
-STAR_VERSION="2.7.10a"
+STAR_VERSION="2.7.11a"
 
 # Necessary tools and help text
 TOOLS=(docker gcloud)

--- a/3rd-party-tools/samtools-star/docker_versions.tsv
+++ b/3rd-party-tools/samtools-star/docker_versions.tsv
@@ -1,2 +1,3 @@
 DOCKER_VERSION
 us.gcr.io/broad-gotc-prod/samtools-star:1.0.0-1.11-2.7.10a-1642556627
+us.gcr.io/broad-gotc-prod/samtools-star:1.0.0-1.11-2.7.11a-1731516196


### PR DESCRIPTION
I updated the version of star in the samtools-star docker. For context, we wanted to add a bam validation check in the StarSoloFastq task https://github.com/broadinstitute/warp/pull/1428 

In order to do so, we needed a docker that has samtools and star in it. This pr is updating star from 2.7.10a to 2.7.11a as that is the version of star we need to run in StarSoloFastq