### PR TITLE
adding GTF to uns field of h5ad for optimus

### DIFF
--- a/tools/scripts/create_h5ad_optimus.py
+++ b/tools/scripts/create_h5ad_optimus.py
@@ -391,7 +391,18 @@ def create_h5ad_files(args):
     new_data.var_names = [x for x in new_data.var["Gene"]]
     
     # Add GTF to uns field
-    new_data.uns["GTF"] = str(args.annotation_file)
+    
+    # Original path from args.annotation_file
+    annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
+
+    # Transform the path
+    if annotation_gtf.startswith('/cromwell_root/'):
+        stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
+        updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
+    else:
+        updated_path = str(args.annotation_file)
+    
+    new_data.uns["reference_gtf_file"] = updated_path
     
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")

--- a/tools/scripts/create_h5ad_optimus.py
+++ b/tools/scripts/create_h5ad_optimus.py
@@ -390,6 +390,8 @@ def create_h5ad_files(args):
     # Set variable names
     new_data.var_names = [x for x in new_data.var["Gene"]]
     
+    # Add GTF to uns field
+    new_data.uns["GTF"] = str(args.annotation_file)
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")
 

--- a/tools/scripts/create_h5ad_optimus.py
+++ b/tools/scripts/create_h5ad_optimus.py
@@ -474,8 +474,8 @@ def main():
     )
 
     parser.add_argument(
-        "--gtf-path",
-        dest="gtf-path",
+        "--gtf_path",
+        dest="gtf_path",
         default=None,
         required=False,
         help="annotation file path",

--- a/tools/scripts/create_h5ad_optimus.py
+++ b/tools/scripts/create_h5ad_optimus.py
@@ -391,16 +391,6 @@ def create_h5ad_files(args):
     new_data.var_names = [x for x in new_data.var["Gene"]]
     
     # Add GTF to uns field
-    
-    # Original path from args.annotation_file
-    # annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
-
-    # # Transform the path
-    # if annotation_gtf.startswith('/cromwell_root/'):
-    #     stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
-    #     updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
-    # else:
-    #     updated_path = str(args.annotation_file)
 
     gtf_path = args.gtf_path
     new_data.uns["reference_gtf_file"] = gtf_path

--- a/tools/scripts/create_h5ad_optimus.py
+++ b/tools/scripts/create_h5ad_optimus.py
@@ -393,16 +393,17 @@ def create_h5ad_files(args):
     # Add GTF to uns field
     
     # Original path from args.annotation_file
-    annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
+    # annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
 
-    # Transform the path
-    if annotation_gtf.startswith('/cromwell_root/'):
-        stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
-        updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
-    else:
-        updated_path = str(args.annotation_file)
-    
-    new_data.uns["reference_gtf_file"] = updated_path
+    # # Transform the path
+    # if annotation_gtf.startswith('/cromwell_root/'):
+    #     stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
+    #     updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
+    # else:
+    #     updated_path = str(args.annotation_file)
+
+    gtf_path = args.gtf_path
+    new_data.uns["reference_gtf_file"] = gtf_path
     
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")
@@ -470,6 +471,14 @@ def main():
         default=None,
         required=False,
         help="annotation file in GTF format",
+    )
+
+    parser.add_argument(
+        "--gtf-path",
+        dest="gtf-path",
+        default=None,
+        required=False,
+        help="annotation file path",
     )
 
     parser.add_argument(

--- a/tools/scripts/create_h5ad_optimus.py
+++ b/tools/scripts/create_h5ad_optimus.py
@@ -392,6 +392,7 @@ def create_h5ad_files(args):
     
     # Add GTF to uns field
     new_data.uns["GTF"] = str(args.annotation_file)
+    
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")
 

--- a/tools/scripts/create_snrna_optimus_exons_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_exons_h5ad.py
@@ -352,8 +352,20 @@ def create_h5ad_files(args):
     # Set the layer = to the exon_counts csr matrix
     new_data.layers["exon_counts"]=exon_counts
     
-    # Add GTF to uns field
-    new_data.uns["GTF"] = str(args.annotation_file)
+    # Original path from args.annotation_file
+    annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
+
+    # Transform the path
+    if annotation_gtf.startswith('/cromwell_root/'):
+        stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
+        updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
+    else:
+        updated_path = str(args.annotation_file)
+    
+    new_data.uns["reference_gtf_file"] = updated_path
+    
+    # Write h5ad file
+    new_data.write(args.output_h5ad_path + ".h5ad")
     
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")

--- a/tools/scripts/create_snrna_optimus_exons_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_exons_h5ad.py
@@ -352,6 +352,9 @@ def create_h5ad_files(args):
     # Set the layer = to the exon_counts csr matrix
     new_data.layers["exon_counts"]=exon_counts
     
+    # Add GTF to uns field
+    new_data.uns["GTF"] = str(args.annotation_file)
+    
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")
 

--- a/tools/scripts/create_snrna_optimus_exons_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_exons_h5ad.py
@@ -353,16 +353,10 @@ def create_h5ad_files(args):
     new_data.layers["exon_counts"]=exon_counts
     
     # Original path from args.annotation_file
-    annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
+    # Add GTF to uns field
 
-    # Transform the path
-    if annotation_gtf.startswith('/cromwell_root/'):
-        stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
-        updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
-    else:
-        updated_path = str(args.annotation_file)
-    
-    new_data.uns["reference_gtf_file"] = updated_path
+    gtf_path = args.gtf_path
+    new_data.uns["reference_gtf_file"] = gtf_path
     
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")
@@ -439,6 +433,14 @@ def main():
         default=None,
         required=False,
         help="annotation file in GTF format",
+    )
+
+    parser.add_argument(
+        "--gtf_path",
+        dest="gtf_path",
+        default=None,
+        required=False,
+        help="annotation file path",
     )
 
     parser.add_argument(

--- a/tools/scripts/create_snrna_optimus_full_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_full_h5ad.py
@@ -335,6 +335,9 @@ def create_h5ad_files(args):
     # Set variable names
     new_data.var_names = [x for x in new_data.var["Gene"]]
     
+    # Add GTF to uns field
+    new_data.uns["GTF"] = str(args.annotation_file)
+    
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")
     

--- a/tools/scripts/create_snrna_optimus_full_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_full_h5ad.py
@@ -335,8 +335,20 @@ def create_h5ad_files(args):
     # Set variable names
     new_data.var_names = [x for x in new_data.var["Gene"]]
     
-    # Add GTF to uns field
-    new_data.uns["GTF"] = str(args.annotation_file)
+    # Original path from args.annotation_file
+    annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
+
+    # Transform the path
+    if annotation_gtf.startswith('/cromwell_root/'):
+        stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
+        updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
+    else:
+        updated_path = str(args.annotation_file)
+    
+    new_data.uns["reference_gtf_file"] = updated_path
+    
+    # Write h5ad file
+    new_data.write(args.output_h5ad_path + ".h5ad")
     
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")

--- a/tools/scripts/create_snrna_optimus_full_h5ad.py
+++ b/tools/scripts/create_snrna_optimus_full_h5ad.py
@@ -335,17 +335,10 @@ def create_h5ad_files(args):
     # Set variable names
     new_data.var_names = [x for x in new_data.var["Gene"]]
     
-    # Original path from args.annotation_file
-    annotation_gtf = args.annotation_file  # e.g., '/cromwell_root/gcp-public-data--broad-references/hg38/v0/star/v2_7_10a/modified_v43.annotation.gtf'
+    # Add GTF to uns field
 
-    # Transform the path
-    if annotation_gtf.startswith('/cromwell_root/'):
-        stripped_path = annotation_gtf[len('/cromwell_root/'):]  # Remove '/cromwell_root/'
-        updated_path = f'gs://{stripped_path}'  # Add 'gs://' prefix
-    else:
-        updated_path = str(args.annotation_file)
-    
-    new_data.uns["reference_gtf_file"] = updated_path
+    gtf_path = args.gtf_path
+    new_data.uns["reference_gtf_file"] = gtf_path
     
     # Write h5ad file
     new_data.write(args.output_h5ad_path + ".h5ad")
@@ -403,6 +396,14 @@ def main():
         default=None,
         required=False,
         help="annotation file in GTF format",
+    )
+
+    parser.add_argument(
+        "--gtf_path",
+        dest="gtf_path",
+        default=None,
+        required=False,
+        help="annotation file path",
     )
 
     parser.add_argument(


### PR DESCRIPTION
This PR updates the h5ad scripts in the warp-tools docker (now version 2.6.0) to take in a string for the annotation GTF file path. This enables the script to put the GTF path into h5ad's unstructured metadata (adata.uns) so that users are aware of which GTF file was used for analysis. Since the GTF file is stored in cloud repositories, this enables the user to pull the exact GTF file if needed. 