### PR TITLE
Lk build indices macaque

### DIFF
--- a/3rd-party-tools/build-indices/README.md
+++ b/3rd-party-tools/build-indices/README.md
@@ -156,3 +156,25 @@ When modifying these tools:
 - Docker container provides consistent environment
 - All scripts are accessible within the container
 - Use reference files for reliable testing
+
+## Macaque add_gene_names.py and modify_macaque_mt.py
+These scripts are currently used as standalone script to modify a Cell Ranger output GTF (for NCBI) and make it compatible with warp-tools TagSort.
+
+### Usage
+Cell ranger produces a genes.gtf file. First, run the add_gene_names.py script in the local folder with the genes.gtf. It will produce an `output_gene_name.gtf`.
+
+Run:
+```python3 add_gene_name.py```
+
+Next, run the modify_macaque_mt. This requires as input the `output_gene_name.gtf`, the text file containing the genes that are mitochondrial genes. An example can be found at gs://warp-testing-public/references/BuildIndices_outs/Macaque_MT_genes.txt.
+
+Overall, this script identifies all GTF entries for the listed mitochondrial genes and enters and extra record in the GTF with these genes listed as `gene` in the 3rd GTF field. This allows TagSort to quantify these genes.
+
+Run:
+
+```python
+python3 modify_macaque_mt.py output_gene_name.gtf Macaque_MT_genes.txt > mt_modified.gtf
+```
+
+The result `mt_modified.gtf` can be used with STARsolo indexing. 
+

--- a/3rd-party-tools/build-indices/add_gene_name.py
+++ b/3rd-party-tools/build-indices/add_gene_name.py
@@ -1,4 +1,3 @@
-# Script for adding gene_name as an additional attribute
 import re
 
 input_gtf = "genes.gtf"
@@ -17,16 +16,16 @@ with open(input_gtf, "r") as infile, open(output_gtf, "w") as outfile:
 
         attributes = fields[8]
 
-        # Extract gene value
-        match = re.search(r'gene\s+"([^"]+)"', attributes)
-        if match:
-            gene_value = match.group(1)
-            # Only add gene_name if it doesn't already exist
-            if 'gene_name' not in attributes:
-                attributes = attributes.replace(
-                    f'gene "{gene_value}";',
-                    f'gene "{gene_value}"; gene_name "{gene_value}";'
-                )
+        # Parse attributes into a dictionary
+        attr_dict = dict(re.findall(r'(\S+)\s+"(.*?)"', attributes))
+
+        # If gene_name is missing, try to add it
+        if "gene_name" not in attr_dict:
+            # Try to use 'gene' first, then 'gene_id', then 'transcript_id'
+            gene_value = attr_dict.get("gene") or attr_dict.get("gene_id") or attr_dict.get("transcript_id")
+            if gene_value:
+                # Add the gene_name at the end of the attributes string
+                attributes = attributes.strip() + f' gene_name "{gene_value}";'
+
         fields[8] = attributes
         outfile.write("\t".join(fields) + "\n")
-

--- a/3rd-party-tools/build-indices/add_gene_name.py
+++ b/3rd-party-tools/build-indices/add_gene_name.py
@@ -1,0 +1,32 @@
+# Script for adding gene_name as an additional attribute
+import re
+
+input_gtf = "genes.gtf"
+output_gtf = "output_gene_name.gtf"
+
+with open(input_gtf, "r") as infile, open(output_gtf, "w") as outfile:
+    for line in infile:
+        if line.startswith("#"):
+            outfile.write(line)
+            continue
+
+        fields = line.strip().split("\t")
+        if len(fields) != 9:
+            outfile.write(line)
+            continue
+
+        attributes = fields[8]
+
+        # Extract gene value
+        match = re.search(r'gene\s+"([^"]+)"', attributes)
+        if match:
+            gene_value = match.group(1)
+            # Only add gene_name if it doesn't already exist
+            if 'gene_name' not in attributes:
+                attributes = attributes.replace(
+                    f'gene "{gene_value}";',
+                    f'gene "{gene_value}"; gene_name "{gene_value}";'
+                )
+        fields[8] = attributes
+        outfile.write("\t".join(fields) + "\n")
+

--- a/3rd-party-tools/build-indices/modify_macaque_mt.py
+++ b/3rd-party-tools/build-indices/modify_macaque_mt.py
@@ -1,0 +1,86 @@
+# Script to find mitochondrial genes and add them as gene entries
+import sys
+
+def load_mito_gene_list(txt_file):
+    with open(txt_file) as f:
+        return set(line.strip() for line in f if line.strip() and not line.startswith("#"))
+
+def add_gene_entries(gtf_file, mito_txt_file):
+    mito_genes = load_mito_gene_list(mito_txt_file)
+    genes = {}
+
+    # First collect features for mitochondrial genes only
+    with open(gtf_file) as f:
+        for line in f:
+            if line.startswith("#"): continue
+            fields = line.strip().split('\t')
+            if len(fields) != 9:
+                continue
+
+            attrs = {}
+            for attr in fields[8].split(';'):
+                attr = attr.strip()
+                if attr:
+                    key_value = attr.split(' ', 1)
+                    if len(key_value) == 2:
+                        key, value = key_value
+                        attrs[key] = value.strip('"')
+
+            gene_name = attrs.get("gene_name", "")
+            gene_id = attrs.get("gene_id", "")
+            if gene_name in mito_genes:
+                if gene_id not in genes:
+                    genes[gene_id] = {
+                        'chrom': fields[0],
+                        'source': fields[1],
+                        'min_start': int(fields[3]),
+                        'max_end': int(fields[4]),
+                        'strand': fields[6],
+                        'attrs': attrs,
+                        'features': set([fields[2]])
+                    }
+                else:
+                    genes[gene_id]['min_start'] = min(genes[gene_id]['min_start'], int(fields[3]))
+                    genes[gene_id]['max_end'] = max(genes[gene_id]['max_end'], int(fields[4]))
+                    genes[gene_id]['features'].add(fields[2])
+
+    # Create synthetic 'gene' entries
+    gene_entries = []
+    for gene_id, info in sorted(genes.items()):
+        attrs = info['attrs']
+        attrs_str = f'gene_id "{gene_id}"; '
+        if 'gene' in attrs:
+            attrs_str += f'gene "{attrs["gene"]}"; '
+        if 'transcript_biotype' in attrs:
+            attrs_str += f'transcript_biotype "{attrs["transcript_biotype"]}"; '
+        if 'gene_version' in attrs:
+            attrs_str += f'gene_version "{attrs["gene_version"]}"; '
+        if 'gene_name' in attrs:
+            attrs_str += f'gene_name "{attrs["gene_name"]}";'
+
+        gene_entry = [
+            info['chrom'],
+            info['source'],
+            'gene',
+            str(info['min_start']),
+            str(info['max_end']),
+            '.',
+            info['strand'],
+            '.',
+            attrs_str
+        ]
+        gene_entries.append('\t'.join(gene_entry))
+
+    # Output header and full GTF content + added gene entries
+    with open(gtf_file) as f:
+        for line in f:
+            print(line.strip())
+    for entry in gene_entries:
+        print(entry)
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("Usage: python script.py input.gtf mito_gene_list.txt")
+        sys.exit(1)
+    add_gene_entries(sys.argv[1], sys.argv[2])
+

--- a/3rd-party-tools/build-indices/modify_macaque_mt.py
+++ b/3rd-party-tools/build-indices/modify_macaque_mt.py
@@ -80,7 +80,7 @@ def add_gene_entries(gtf_file, mito_txt_file):
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print("Usage: python script.py input.gtf mito_gene_list.txt")
+        print("Usage: python3 script.py input.gtf mito_gene_list.txt")
         sys.exit(1)
     add_gene_entries(sys.argv[1], sys.argv[2])
 


### PR DESCRIPTION
This PR adds the scripts we used to create the Macaque reference GTF from a Cell Ranger GTF. It adds gene_names as an extra attribute and copies mitochondrial genes into a new gene record in the GTF ("gene" is in the 3rd field). This results in a new GTF with an additional line for every MT gene that is passed into the script via a text file (so 13 MT genes = 13 new lines).