### PR TITLE
DDO-4138 read from GAR

### DIFF
--- a/3rd-party-tools/arrays-picard-private/Dockerfile
+++ b/3rd-party-tools/arrays-picard-private/Dockerfile
@@ -5,7 +5,7 @@ ARG PICARD_PRIVATE_VERSION=c24d8e2dfd6de9c663416278040a9f91b6a5e3eb
 
 ENV TERM=xterm-256color \
     NO_VAULT=true \
-    ARTIFACTORY_URL=https://broadinstitute.jfrog.io/artifactory/libs-snapshot-local/org/broadinstitute/picard-private \
+    ARTIFACTORY_URL=https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/org/broadinstitute/picard-private \
     TINI_VERSION=v0.19.0 \
     PATH=$PATH:/root/google-cloud-sdk/bin 
 

--- a/3rd-party-tools/gatk/Dockerfile
+++ b/3rd-party-tools/gatk/Dockerfile
@@ -7,7 +7,7 @@ ARG GATK3_VERSION=3.5
 
 ENV TERM=xterm-256color \
     GATK4_URL=https://github.com/broadinstitute/gatk/releases/download/${GATK4_VERSION}/gatk-${GATK4_VERSION}.zip \
-    GATK3_URL=https://broadinstitute.jfrog.io/artifactory/libs-release-local/org/broadinstitute/gatk/gatk-utils/${GATK3_VERSION}/gatk-utils-${GATK3_VERSION}.jar
+    GATK3_URL=https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/org/broadinstitute/gatk/gatk-utils/${GATK3_VERSION}/gatk-utils-${GATK3_VERSION}.jar
 
 LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
         GATK4_VERSION=${GATK4_VERSION} \

--- a/3rd-party-tools/illumina-iaap-autocall/Dockerfile
+++ b/3rd-party-tools/illumina-iaap-autocall/Dockerfile
@@ -4,7 +4,7 @@ FROM --platform="linux/amd64" frolvlad/alpine-mono:5.4-glibc
 ARG IAAP_CLI_VERSION=iaap-cli-linux-x64-1.1.0-sha.80d7e5b3d9c1fdfc2e99b472a90652fd3848bbc7
 
 ENV TERM=xterm-256color \
-    IAAP_CLI_URL=https://broadinstitute.jfrog.io/artifactory/libs-release-local/org/broadinstitute/illumina-iaap-cli
+    IAAP_CLI_URL=https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/org/broadinstitute/illumina-iaap-cli
 
 LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
         IAAP_CLI_VERSION=${IAAP_CLI_VERSION}


### PR DESCRIPTION
JIRA ticket https://broadworkbench.atlassian.net/browse/DDO-4138


**Summary of changes**
Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

**What**
Modified the config to pull artifacts from GAR. No publishing changes were made.

**Why**
This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

**Testing these changes**
Will rely on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline (where they exist) failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).