### PR TITLE
TSPS-612 add beagle GHA and update docker to use java 17 instead of java 8

### DIFF
--- a/.github/workflows/build-beagle.yml
+++ b/.github/workflows/build-beagle.yml
@@ -1,0 +1,59 @@
+name: Beagle CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "develop" and "master" branch
+  pull_request:
+    branches: [ "develop", "master" ]
+    paths:
+      - '3rd-party-tools/beagle/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker Image Tag (default: branch_name)' 
+
+env:
+  PROJECT_NAME: WARP 3rd Party Tools
+  # Github repo name
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
+  # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
+  DOCKER_REGISTRY: us.gcr.io
+  GCR_PATH: broad-gotc-prod/imputation-beagle
+  TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
+
+  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # The job that builds our container
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 3rd-party-tools/beagle
+    # Map a step output to a job output
+    outputs:
+      imagePath: ${{ steps.saveImagePath.outputs.url }}
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}
+    - name: Check working directory'
+      run: |
+        echo "Current directory: "
+        pwd
+        ls -lht
+    # Save the image path to an output
+    - id: 'saveImagePath'
+      run: echo "url=${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}" >> $GITHUB_OUTPUT
+    # Log into the Google Docker registry
+    - id: 'Auth'
+      name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.DOCKER_REGISTRY }}
+        username: _json_key
+        password: ${{ secrets.GCR_CI_KEY }}
+    # Push the image to the Google Docker registry
+    - name: Push image
+      run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,6 +26,7 @@ jobs:
         - 3rd-party-tools/zcall
         - 3rd-party-tools/bcftools-vcftools
         - 3rd-party-tools/eagle
+        - 3rd-party-tools/beagle
         - 3rd-party-tools/minimac4
         - 3rd-party-tools/fgbio
         - 3rd-party-tools/umi-tools

--- a/3rd-party-tools/beagle/Dockerfile
+++ b/3rd-party-tools/beagle/Dockerfile
@@ -1,5 +1,5 @@
 # Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
-FROM --platform="linux/amd64" adoptopenjdk/openjdk8:alpine-slim
+FROM --platform="linux/amd64" eclipse-temurin:17-jdk-alpine
 
 ARG BEAGLE_VERSION=17Dec24.224 \
     BREF3_VERSION=17Dec24.224 \

--- a/3rd-party-tools/beagle/docker_build.sh
+++ b/3rd-party-tools/beagle/docker_build.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.0.0
+DOCKER_IMAGE_VERSION=1.1.0
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 

--- a/3rd-party-tools/beagle/docker_versions.tsv
+++ b/3rd-party-tools/beagle/docker_versions.tsv
@@ -1,1 +1,2 @@
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035
+us.gcr.io/broad-gotc-prod/imputation-beagle:1.1.0-17Dec24.224-1758207261


### PR DESCRIPTION
* Java 17 has better memory management than java 8 so we want to use that as our base image for the beagle image

* Adding a GHA to push beagle images to the gotc gcr repo