### PR TITLE
[TSPS-682] Update Beagle Dockerfile to build jar from Github repo

### DIFF
--- a/3rd-party-tools/beagle/Dockerfile
+++ b/3rd-party-tools/beagle/Dockerfile
@@ -49,12 +49,9 @@ RUN set -eux; \
     rm -r bcftools-${BCFTOOLS_VERSION}; \
     rm bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
     ; \
-#    # Download Beagle jars
-#    # beagle runs phasing and imputation
-#    # curl -L https://faculty.washington.edu/browning/beagle/beagle.${BEAGLE_VERSION}.jar > beagle.${BEAGLE_VERSION}.jar \
-    # Clone repo and generate Beagle jar
+    # Clone `base-version` branch from `tmp-sharing/imp-server` repo and generate Beagle jar
     # beagle runs phasing and imputation
-    git clone https://github.com/tmp-sharing/imp-server.git; \
+    git clone --branch base-version --single-branch https://github.com/tmp-sharing/imp-server.git; \
     javac -cp imp-server/src/ imp-server/src/main/Main.java; \
     jar cfe beagle.${BEAGLE_VERSION}.jar main/Main -C imp-server/src/ ./; \
     rm -rf imp-server \

--- a/3rd-party-tools/beagle/Dockerfile
+++ b/3rd-party-tools/beagle/Dockerfile
@@ -1,7 +1,7 @@
 # Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
 FROM --platform="linux/amd64" eclipse-temurin:17-jdk-alpine
 
-ARG BEAGLE_VERSION=17Dec24.224 \
+ARG BEAGLE_COMMIT_HASH=d820c4e21ad0ca55548c658f59848038971b9143 \
     BREF3_VERSION=17Dec24.224 \
     BCFTOOLS_VERSION=1.10.2
 
@@ -9,7 +9,7 @@ ENV TERM=xterm-256color \
     TINI_VERSION=v0.19.0
 
 LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
-        BEAGLE_VERSION=${BEAGLE_VERSION} \
+        BEAGLE_COMMIT_HASH=${BEAGLE_COMMIT_HASH} \
         BREF3_VERSION=${BREF3_VERSION} \
         BCFTOOLS_VERSION=${BCFTOOLS_VERSION}
 
@@ -49,11 +49,15 @@ RUN set -eux; \
     rm -r bcftools-${BCFTOOLS_VERSION}; \
     rm bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
     ; \
-    # Clone `base-version` branch from `tmp-sharing/imp-server` repo and generate Beagle jar
-    # beagle runs phasing and imputation
-    git clone --branch base-version --single-branch https://github.com/tmp-sharing/imp-server.git; \
+    # Clone BEAGLE_COMMIT_HASH from `tmp-sharing/imp-server` repo and generate Beagle jar
+    # beagle runs phasing and imputation \
+    BEAGLE_COMMIT_SHORT="${BEAGLE_COMMIT_HASH:0:7}"; \
+    git clone https://github.com/tmp-sharing/imp-server.git; \
+    cd imp-server; \
+    git checkout ${BEAGLE_COMMIT_HASH}; \
+    cd ..; \
     javac -cp imp-server/src/ imp-server/src/main/Main.java; \
-    jar cfe beagle.${BEAGLE_VERSION}.jar main/Main -C imp-server/src/ ./; \
+    jar cfe beagle.${BEAGLE_COMMIT_SHORT}.jar main/Main -C imp-server/src/ ./; \
     rm -rf imp-server \
     ; \
     # bref3 converts a reference panel from vcf to the bref3 format that Beagle needs

--- a/3rd-party-tools/beagle/Dockerfile
+++ b/3rd-party-tools/beagle/Dockerfile
@@ -25,6 +25,7 @@ RUN set -eux; \
             curl \
             g++ \
             gcc \
+            git \
             gsl-dev \
             make \
             musl-dev \
@@ -48,9 +49,15 @@ RUN set -eux; \
     rm -r bcftools-${BCFTOOLS_VERSION}; \
     rm bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
     ; \
-    # Download Beagle jars
+#    # Download Beagle jars
+#    # beagle runs phasing and imputation
+#    # curl -L https://faculty.washington.edu/browning/beagle/beagle.${BEAGLE_VERSION}.jar > beagle.${BEAGLE_VERSION}.jar \
+    # Clone repo and generate Beagle jar
     # beagle runs phasing and imputation
-    curl -L https://faculty.washington.edu/browning/beagle/beagle.${BEAGLE_VERSION}.jar > beagle.${BEAGLE_VERSION}.jar \
+    git clone https://github.com/tmp-sharing/imp-server.git; \
+    javac -cp imp-server/src/ imp-server/src/main/Main.java; \
+    jar cfe beagle.${BEAGLE_VERSION}.jar main/Main -C imp-server/src/ ./; \
+    rm -rf imp-server \
     ; \
     # bref3 converts a reference panel from vcf to the bref3 format that Beagle needs
        curl -L https://faculty.washington.edu/browning/beagle/bref3.${BREF3_VERSION}.jar > bref3.${BREF3_VERSION}.jar \

--- a/3rd-party-tools/beagle/README.md
+++ b/3rd-party-tools/beagle/README.md
@@ -4,9 +4,9 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035`
+#### `docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:2.0.0-d820c4e-1763720636`
 
-- __What is this image:__ This image is a lightweight alpine-based image for running Beagle in the [ImputationBeagle pipeline](../../../../pipelines/broad/arrays/imputation_beagle/ImputationBeagle.wdl).
+- __What is this image:__ This image is a lightweight alpine-based image for running Beagle in the [ImputationBeagle pipeline](https://github.com/broadinstitute/warp/blob/develop/tasks/wdl/ImputationBeagleTasks.wdl).
 - __What is Beagle:__ Beagle is a software package for phasing genotypes and imputing ungenotyped markers. Beagle version 5.4 has improved memory and computational efficiency when analyzing large sequence data sets. See [here](https://faculty.washington.edu/browning/beagle/beagle.html) for more information.
 - __How to see Beagle version used in image:__ Please see below.
 
@@ -14,15 +14,17 @@ Copy and paste to pull this image
 
 The Imputation Beagle image uses the following convention for versioning:
 
-#### `us.gcr.io/broad-gotc-prod/imputation-beagle:<image-version>-<beagle-version>-<unix-timestamp>`
+#### `us.gcr.io/broad-gotc-prod/imputation-beagle:<image-version>-<short-git-commit-hash>-<unix-timestamp>`
 
 We keep track of all past versions in [docker_versions](docker_versions.tsv) with the last image listed being the currently used version in WARP.
+
+_Note: The commit hash comes from GitHub repo [tmp-sharing/imp-serve](https://github.com/tmp-sharing/imp-server/tree/master)._
 
 You can see more information about the image, including the tool versions, by running the following command:
 
 ```bash
-$ docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035
-$ docker inspect us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035
+$ docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:2.0.0-d820c4e-1763720636
+$ docker inspect us.gcr.io/broad-gotc-prod/imputation-beagle:2.0.0-d820c4e-1763720636
 ```
 
 ## Usage
@@ -31,5 +33,5 @@ $ docker inspect us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1
 
 ```bash
 $ docker run --rm -it \
-    us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035 java -jar /usr/gitc/beagle.17Dec24.224.jar
+    us.gcr.io/broad-gotc-prod/imputation-beagle:2.0.0-d820c4e-1763720636 java -jar /usr/gitc/beagle.d820c4e.jar
 ```

--- a/3rd-party-tools/beagle/README.md
+++ b/3rd-party-tools/beagle/README.md
@@ -18,7 +18,7 @@ The Imputation Beagle image uses the following convention for versioning:
 
 We keep track of all past versions in [docker_versions](docker_versions.tsv) with the last image listed being the currently used version in WARP.
 
-_Note: The commit hash comes from GitHub repo [tmp-sharing/imp-serve](https://github.com/tmp-sharing/imp-server/tree/master)._
+_Note: The commit hash comes from GitHub repo [tmp-sharing/imp-server](https://github.com/tmp-sharing/imp-server/tree/master)._
 
 You can see more information about the image, including the tool versions, by running the following command:
 

--- a/3rd-party-tools/beagle/docker_versions.tsv
+++ b/3rd-party-tools/beagle/docker_versions.tsv
@@ -1,3 +1,3 @@
-us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.1-17Dec24.224-1763664735
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.1.0-17Dec24.224-1758207261
+us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.1-17Dec24.224-1763664735

--- a/3rd-party-tools/beagle/docker_versions.tsv
+++ b/3rd-party-tools/beagle/docker_versions.tsv
@@ -1,2 +1,3 @@
+us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.1-17Dec24.224-1763664735
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.1.0-17Dec24.224-1758207261

--- a/3rd-party-tools/beagle/docker_versions.tsv
+++ b/3rd-party-tools/beagle/docker_versions.tsv
@@ -1,3 +1,3 @@
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.1.0-17Dec24.224-1758207261
-us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.1-17Dec24.224-1763664735
+us.gcr.io/broad-gotc-prod/imputation-beagle:2.0.0-d820c4e-1763720636


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/TSPS-682

This PR uses `base-version` branch from [tmp-sharing/imp-server](https://github.com/tmp-sharing/imp-server/tree/base-version) repo to generate the Beagle jar. I have added a new image version to docker_versions.tsv and will run the GHA to generate the image once this PR is merged.

Latest Warp plumbing test using the image manually built from Docker file succeeded: 
- Warp PR: https://github.com/broadinstitute/warp/pull/1722
- Pluming test GHA: https://github.com/broadinstitute/warp/actions/runs/19583154386/job/56085772545?pr=1722