### PR TITLE
[TSPS-770] Update Beagle hash to remove trailing zeros from AF and DR2 annotations

### DIFF
--- a/3rd-party-tools/beagle/Dockerfile
+++ b/3rd-party-tools/beagle/Dockerfile
@@ -1,7 +1,7 @@
 # Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
 FROM --platform="linux/amd64" eclipse-temurin:17-jdk-alpine
 
-ARG BEAGLE_COMMIT_HASH=b00155dbacb0b576755878b9935b635768d89fc5 \
+ARG BEAGLE_COMMIT_HASH=0b17ad0214dc2a4c1c1bbeef8f221e6e3a5052f2 \
     BREF3_VERSION=17Dec24.224 \
     BCFTOOLS_VERSION=1.10.2
 

--- a/3rd-party-tools/beagle/README.md
+++ b/3rd-party-tools/beagle/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:3.0.0-b00155d-1765390731`
+#### `docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:3.1.0-0b17ad0-1768971822`
 
 - __What is this image:__ This image is a lightweight alpine-based image for running Beagle in the [ImputationBeagle pipeline](https://github.com/broadinstitute/warp/blob/develop/tasks/wdl/ImputationBeagleTasks.wdl).
 - __What is Beagle:__ Beagle is a software package for phasing genotypes and imputing ungenotyped markers. Beagle version 5.4 has improved memory and computational efficiency when analyzing large sequence data sets. See [here](https://faculty.washington.edu/browning/beagle/beagle.html) for more information.
@@ -23,8 +23,8 @@ _Note: The commit hash comes from GitHub repo [tmp-sharing/imp-server](https://g
 You can see more information about the image, including the tool versions, by running the following command:
 
 ```bash
-$ docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:3.0.0-b00155d-1765390731
-$ docker inspect us.gcr.io/broad-gotc-prod/imputation-beagle:3.0.0-b00155d-1765390731
+$ docker pull us.gcr.io/broad-gotc-prod/imputation-beagle:3.1.0-0b17ad0-1768971822
+$ docker inspect us.gcr.io/broad-gotc-prod/imputation-beagle:3.1.0-0b17ad0-1768971822
 ```
 
 ## Usage
@@ -33,5 +33,5 @@ $ docker inspect us.gcr.io/broad-gotc-prod/imputation-beagle:3.0.0-b00155d-17653
 
 ```bash
 $ docker run --rm -it \
-    us.gcr.io/broad-gotc-prod/imputation-beagle:3.0.0-b00155d-1765390731 java -jar /usr/gitc/beagle.b00155d.jar
+    us.gcr.io/broad-gotc-prod/imputation-beagle:3.1.0-0b17ad0-1768971822 java -jar /usr/gitc/beagle.b00155d.jar
 ```

--- a/3rd-party-tools/beagle/docker_versions.tsv
+++ b/3rd-party-tools/beagle/docker_versions.tsv
@@ -2,3 +2,4 @@ us.gcr.io/broad-gotc-prod/imputation-beagle:1.0.0-17Dec24.224-1740423035
 us.gcr.io/broad-gotc-prod/imputation-beagle:1.1.0-17Dec24.224-1758207261
 us.gcr.io/broad-gotc-prod/imputation-beagle:2.0.0-d820c4e-1763720636
 us.gcr.io/broad-gotc-prod/imputation-beagle:3.0.0-b00155d-1765390731
+us.gcr.io/broad-gotc-prod/imputation-beagle:3.1.0-0b17ad0-1768971822


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/TSPS-770

Main Beagle tool changes are here: https://github.com/tmp-sharing/imp-server/commits/master/. The changes there are to remove trailing 0s from AF and DR2 annotations from output VCF record.

WARP PR run that tests the changes - https://github.com/broadinstitute/warp/actions/runs/21225450839/job/61071091934?pr=1747. Here the failing test is expected because the output VCF format is being changed.

I will run the GHA to generate new Beagle docker image once the PR is approved.

Sample output example:
```
chr21	5033602	.	C	T	.	PASS	DR2=0.12;AF=0.025;IMP	GT:DS	0|0:0.17	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0.17	0|0:0	0|0:0.17	0|0:0	0|0:0
chr21	5033666	.	G	A	.	PASS	DR2=0.03;AF=0.006;IMP	GT:DS	0|0:0.05	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0.03	0|0:0	0|0:0.03	0|0:0	0|0:0
chr21	5033703	.	G	A	.	PASS	DR2=0;AF=0;IMP	GT:DS	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0
chr21	5033714	.	T	C	.	PASS	DR2=0.3;AF=0.1252;IMP	GT:DS	0|0:0.8	0|0:0	0|0:0.02	0|0:0.02	0|0:0.02	0|0:0.8	0|0:0	0|0:0.81	0|0:0	0|0:0.02
chr21	5033773	.	C	T	.	PASS	DR2=0;AF=0.0002;IMP	GT:DS	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0
chr21	5033784	.	C	T	.	PASS	DR2=0;AF=0;IMP	GT:DS	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0
chr21	5033785	.	A	G	.	PASS	DR2=0;AF=0;IMP	GT:DS	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0	0|0:0
```