### PR TITLE
fix localize required=True bug

### DIFF
--- a/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
+++ b/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
@@ -520,7 +520,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '-l',
         '--localize',
-        required=True,
+        required=False,
         default=False,
         action="store_true",
         help="Localize input files and push outputs back to bucket"


### PR DESCRIPTION
For the localize flag:

 With action="store_true", required=True makes no sense — it forces the flag to always be passed, so localize can never be False. With required=False, omitting -l gives False (the default) and passing -l gives True.