### PR TITLE
MT Merge - adjust median coverage calculation and change default data type to avoid overflow

### DIFF
--- a/3rd-party-tools/aou_mito_coverage_db/Dockerfile
+++ b/3rd-party-tools/aou_mito_coverage_db/Dockerfile
@@ -1,7 +1,7 @@
 # Minimal image to run the v2 coverage DB builder (HDF5 + exact summary metrics)
 #
 # Build from this directory:
-#   docker build -t us.gcr.io/broad-gotc-prod/aou-mito-coverage-db:1.0.0 .
+#   docker build -t us.gcr.io/broad-gotc-prod/aou-mito-coverage-db:1.0.1 .
 
 FROM python:3.12-slim
 

--- a/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/README.md
+++ b/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/README.md
@@ -58,5 +58,5 @@ python -m generate_mtdna_call_mt.coverage_db.build_coverage_db \
 ## Notes on exact median
 
 The output schema expects `median` to be an `int32`.
-For even N, the builder computes the average of the two middle values and casts to int.
+For even N, the builder computes the average of the two middle values and casts to int (floor division), matching Hail's `hl.median` behavior.
 If parity testing against Hail indicates a different rounding convention, adjust that conversion.

--- a/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/build_coverage_db.py
+++ b/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/build_coverage_db.py
@@ -105,8 +105,11 @@ def _read_processed_tsv(input_tsv: str, sample_col: str, coverage_col: str) -> L
 
 
 def _infer_uint_dtype(max_value: int) -> np.dtype:
-    if max_value <= np.iinfo(np.uint16).max:
-        return np.uint16
+    # Default to uint32 to avoid silent truncation of high-coverage positions.
+    # uint16 max (65535) is plausible for mtDNA coverage in large cohorts,
+    # so we do not risk it. uint32 max (~4.3 billion) is safely beyond any
+    # realistic mtDNA coverage value; overflow at that level would indicate
+    # a pipeline error and is caught explicitly below.
     return np.uint32
 
 
@@ -306,6 +309,13 @@ def build_coverage_db(
                     chunks=(min(batch_size, n_samples), min(position_block_size, n_pos)),
                     compression=compression,
                     compression_opts=compression_level,
+                )
+
+            dtype_max = int(np.iinfo(cov_ds.dtype).max)
+            if batch_max > dtype_max:
+                raise OverflowError(
+                    f"Coverage value {batch_max} in samples {start}..{end} exceeds the maximum "
+                    f"for dtype {cov_ds.dtype} ({dtype_max}). This likely indicates a pipeline error."
                 )
 
             cov_ds[start:end, :] = mat.astype(cov_ds.dtype, copy=False)

--- a/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/build_coverage_db.py
+++ b/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/build_coverage_db.py
@@ -33,11 +33,8 @@ Notes
 -----
 - Exactness: mean, median, and threshold fractions are computed exactly.
 - Median definition: we match the usual median of a multiset. For even N, we
-  use the average of the two middle values and then cast to int32 to match the
-  Hail schema (`median: int32`).
-  This is the most likely behavior of `hl.median` on integer arrays.
-  If parity testing reveals a different rounding rule, we can adjust the
-  even-N path.
+  use the average of the two middle values (floor division) and cast to int32
+  to match the Hail schema (`median: int32`) and `hl.median` behavior.
 
 This script intentionally avoids Hail/Spark.
 """
@@ -183,9 +180,9 @@ def _median_int32_from_int_array(values: np.ndarray) -> np.int32:
 
     This matches Hail's `hl.median` semantics for collections of numbers.
 
-    In particular, for even N, Hail returns the *lower* of the two middle
-    values (a discrete median), NOT the average. See Hail docs example:
-    `hl.median([1, 3, 5, 6, 7, 9]) == 5`.
+    For odd N, returns the middle value of the sorted array.
+    For even N, returns int(floor((lower_middle + upper_middle) / 2)), i.e.
+    the average of the two middle values cast to int32.
     """
     if values.ndim != 1:
         raise ValueError("values must be 1D")
@@ -193,13 +190,16 @@ def _median_int32_from_int_array(values: np.ndarray) -> np.int32:
     if n == 0:
         raise ValueError("Cannot compute median of empty array")
 
-    # Work on a copy because partition mutates.
     v = values.astype(np.int64, copy=True)
 
-    # Hail uses a discrete median: element at floor((n-1)/2) in the sorted array.
-    k = (n - 1) // 2
-    v_part = np.partition(v, k)
-    return np.int32(v_part[k])
+    if n % 2 == 1:
+        k = n // 2
+        return np.int32(np.partition(v, k)[k])
+    else:
+        lo = n // 2 - 1
+        hi = n // 2
+        v_part = np.partition(v, [lo, hi])
+        return np.int32((int(v_part[lo]) + int(v_part[hi])) // 2)
 
 
 def build_coverage_db(

--- a/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/smoke_test_build_coverage_db.py
+++ b/3rd-party-tools/aou_mito_coverage_db/scripts/coverage_db/smoke_test_build_coverage_db.py
@@ -44,9 +44,12 @@ def _read_summary(path: str):
 
 
 def main() -> None:
-    # Sanity-check median semantics against Hail docs:
-    # hl.median([1, 3, 5, 6, 7, 9]) == 5 (lower-of-two-middles for even N)
+    # Sanity-check median semantics:
+    # For even N, we take floor((lower_middle + upper_middle) / 2), matching hl.median.
+    # [1, 3, 5, 6, 7, 9]: middles are 5 and 6 → (5+6)//2 = 5
     assert int(_median_int32_from_int_array(np.array([1, 3, 5, 6, 7, 9], dtype=np.int64))) == 5
+    # [50, 150]: middles are 50 and 150 → (50+150)//2 = 100
+    assert int(_median_int32_from_int_array(np.array([50, 150], dtype=np.int64))) == 100
 
     with tempfile.TemporaryDirectory() as d:
         cov1 = os.path.join(d, "s1.tsv")
@@ -79,18 +82,18 @@ def main() -> None:
 
         got = _read_summary(out_sum)
 
-        # Expected:
-        # pos1: mean=0 median=0 over_100=0 over_1000=0
-    # pos2: mean=100 median=50 over_100=0.5 (150>100) over_1000=0
-    # pos3: mean=100 median=99 over_100=0.5 (101>100) over_1000=0
-    # pos4: mean=1000 median=999 over_100=1 over_1000=0.5 (1001>1000)
-        # pos5: mean=7 median=7 over_100=0 over_1000=0
+        # Expected (median = floor((lo + hi) / 2) for even N=2):
+        # pos1: mean=0   median=0    over_100=0   over_1000=0
+        # pos2: mean=100 median=100  over_100=0.5 (150>100) over_1000=0   → (50+150)//2=100
+        # pos3: mean=100 median=100  over_100=0.5 (101>100) over_1000=0   → (99+101)//2=100
+        # pos4: mean=1000 median=1000 over_100=1  over_1000=0.5 (1001>1000) → (999+1001)//2=1000
+        # pos5: mean=7   median=7    over_100=0   over_1000=0
         exp = {
-            1: {"mean": 0.0, "median": 0, "over_100": 0.0, "over_1000": 0.0},
-            2: {"mean": 100.0, "median": 50, "over_100": 0.5, "over_1000": 0.0},
-            3: {"mean": 100.0, "median": 99, "over_100": 0.5, "over_1000": 0.0},
-            4: {"mean": 1000.0, "median": 999, "over_100": 1.0, "over_1000": 0.5},
-            5: {"mean": 7.0, "median": 7, "over_100": 0.0, "over_1000": 0.0},
+            1: {"mean": 0.0,    "median": 0,    "over_100": 0.0, "over_1000": 0.0},
+            2: {"mean": 100.0,  "median": 100,  "over_100": 0.5, "over_1000": 0.0},
+            3: {"mean": 100.0,  "median": 100,  "over_100": 0.5, "over_1000": 0.0},
+            4: {"mean": 1000.0, "median": 1000, "over_100": 1.0, "over_1000": 0.5},
+            5: {"mean": 7.0,    "median": 7,    "over_100": 0.0, "over_1000": 0.0},
         }
 
         for pos, e in exp.items():


### PR DESCRIPTION
This PR updates the per-position median coverage calculation to match the way median is computed in Hail. For positions with an even number of samples, the code now uses the integer average of the two middle values rather than selecting the lower of the two middle values. In practice, this change did not alter any median values in our 50k-sample validation dataset, so we expect minimal downstream impact.

This PR also changes the default datatype used to store coverage values in the coverage HDF5 file from uint16 to uint32. In addition, we added an explicit overflow check that will fail if a value exceeds the representable range. This is expected to be extremely unlikely, since uint32 supports values up to approximately 4 billion. This increased the size of our h5 file from 1.53 GB to 1.92 GB for our 50k sample validation dataset.

Corresponding Warp PR is here: https://github.com/broadinstitute/warp/pull/1854