### PR TITLE
TSPS-949 update picard and bcftools in glimpse2 image

### DIFF
--- a/3rd-party-tools/glimpse2/Dockerfile
+++ b/3rd-party-tools/glimpse2/Dockerfile
@@ -18,7 +18,7 @@ cd .. && \
 rm -r bcftools-1.21
 
 # Download picard (for updating sequence dictionary)
-RUN wget https://github.com/broadinstitute/picard/releases/download/3.4.0/picard.jar && \
+RUN wget https://github.com/broadinstitute/picard/releases/download/2.27.5/picard.jar && \
 mv picard.jar /
 
 WORKDIR /

--- a/3rd-party-tools/glimpse2/Dockerfile
+++ b/3rd-party-tools/glimpse2/Dockerfile
@@ -6,19 +6,19 @@ WORKDIR /docker_build/
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-8-jre-headless curl python3
 
 # Download and build bcftools
-RUN wget https://github.com/samtools/bcftools/releases/download/1.16/bcftools-1.16.tar.bz2 && \
-tar -xf bcftools-1.16.tar.bz2 && \
-rm bcftools-1.16.tar.bz2 && \
-cd bcftools-1.16 && \
+RUN wget https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.tar.bz2 && \
+tar -xf bcftools-1.21.tar.bz2 && \
+rm bcftools-1.21.tar.bz2 && \
+cd bcftools-1.21 && \
 autoheader && \
 autoconf && \
 ./configure --enable-libcurl && \
 make install && \
 cd .. && \
-rm -r bcftools-1.16
+rm -r bcftools-1.21
 
 # Download picard (for updating sequence dictionary)
-RUN wget https://github.com/broadinstitute/picard/releases/download/2.26.11/picard.jar && \
+RUN wget https://github.com/broadinstitute/picard/releases/download/3.4.0/picard.jar && \
 mv picard.jar /
 
 WORKDIR /

--- a/3rd-party-tools/glimpse2/Dockerfile
+++ b/3rd-party-tools/glimpse2/Dockerfile
@@ -3,7 +3,7 @@ FROM temp_glimpse2_base
 WORKDIR /docker_build/
 
 # Install required packages
-RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-8-jre-headless curl python3
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-17-jre-headless curl python3
 
 # Download and build bcftools
 RUN wget https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.tar.bz2 && \
@@ -18,7 +18,7 @@ cd .. && \
 rm -r bcftools-1.21
 
 # Download picard (for updating sequence dictionary)
-RUN wget https://github.com/broadinstitute/picard/releases/download/2.27.5/picard.jar && \
+RUN wget https://github.com/broadinstitute/picard/releases/download/3.4.0/picard.jar && \
 mv picard.jar /
 
 WORKDIR /


### PR DESCRIPTION
This PR will not create a new glimpse image to use in the official glimpse wdl pipeline since we are in parallel making changes to the glimpse code for the issue around dropping variants silently.

Warp test showing an image with these changes do not change the pipeline output
- https://github.com/broadinstitute/warp/pull/1871 and the associated GHA https://github.com/broadinstitute/warp/actions/runs/28177808621/job/83458871953?pr=1871


Jira ticket:
https://broadworkbench.atlassian.net/browse/TSPS-949