### PR TITLE
scvi-scanvi: add run_gex_only_model for GEX-only label transfer

### DIFF
--- a/.github/workflows/build-cutadapt.yml
+++ b/.github/workflows/build-cutadapt.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/cutadapt
-  ACR_PATH: cutadapt
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/cutadapt
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-docker-path-patch.yml
+++ b/.github/workflows/build-docker-path-patch.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/docker-path-patch
-  ACR_PATH: docker-path-patch
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/docker-path-patch
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-m3c-yap-hisat.yml
+++ b/.github/workflows/build-m3c-yap-hisat.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/m3c-yap-hisat
-  ACR_PATH: m3c-yap-hisat
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/m3c-yap-hisat
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-plink-regenie.yml
+++ b/.github/workflows/build-plink-regenie.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/plink-regenie
-  ACR_PATH: plink-regenie
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,27 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/plink-regenie
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-samtools-dist-bwa.yml
+++ b/.github/workflows/build-samtools-dist-bwa.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/samtools-dist-bwa
-  ACR_PATH: samtools-dist-bwa
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/samtools-dist-bwa
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-slide-tags.yml
+++ b/.github/workflows/build-slide-tags.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/slide-tags
-  ACR_PATH: slide-tags
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,27 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/slide-tags
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-snapatac2.yml
+++ b/.github/workflows/build-snapatac2.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/snapatac2
-  ACR_PATH: snapatac2
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  # build-for-acr:
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       working-directory: 3rd-party-tools/snapatac2
-  #   steps:
-  #     # checkout the repo
-  #     - name: 'Checkout GitHub Action'
-  #       uses: actions/checkout@v3
-
-  #     - name: 'Login via Azure CLI'
-  #       uses: azure/login@v1
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-  #     - name: 'Build and push image'
-  #       uses: azure/docker-login@v1
-  #       with:
-  #         login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-  #         username: ${{ secrets.REGISTRY_USERNAME }}
-  #         password: ${{ secrets.REGISTRY_PASSWORD }}
-  #     - run: |
-  #         docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-  #         docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-star-merge-npz.yml
+++ b/.github/workflows/build-star-merge-npz.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/star-merge-npz
-  ACR_PATH: star-merge-npz
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,31 +57,6 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/star-merge-npz
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
 
 #Runs pytest on all python code in 3rd party tools/star-merge-npz
   test-python:

--- a/.github/workflows/build-upstools.yml
+++ b/.github/workflows/build-upstools.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/upstools
-  ACR_PATH: upstools
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/upstools
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-vcftoallc.yml
+++ b/.github/workflows/build-vcftoallc.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/vcftoallc
-  ACR_PATH: vcftoallc
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/vcftoallc
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-verify-bam-id.yml
+++ b/.github/workflows/build-verify-bam-id.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/verify-bam-id
-  ACR_PATH: verify-bam-id
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/verify-bam-id
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.github/workflows/build-warp-tools-inverse.yml
+++ b/.github/workflows/build-warp-tools-inverse.yml
@@ -24,8 +24,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: 'echo "No build required"'
-  build-for-acr:
-      runs-on: ubuntu-latest
-      steps:
-      - run: 'echo "No build required"'
-    

--- a/.github/workflows/build-warp-tools.yml
+++ b/.github/workflows/build-warp-tools.yml
@@ -26,9 +26,7 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   GOOGLE_CONTAINER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/warp-tools
-  ACR_PATH: warp-tools
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
-
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -140,30 +138,3 @@ jobs:
           cd /warptools/fastqpreprocessing/bin
           ls -lht
           for f in *test; do ./"$f"; done;
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: tools
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-  
-  

--- a/.github/workflows/build-zcall.yml
+++ b/.github/workflows/build-zcall.yml
@@ -20,7 +20,6 @@ env:
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   DOCKER_REGISTRY: us.gcr.io
   GCR_PATH: broad-gotc-prod/zcall
-  ACR_PATH: zcall
   TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
 
   # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -58,28 +57,3 @@ jobs:
     # Push the image to the Google Docker registry
     - name: Push image
       run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"
-
-  build-for-acr:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: 3rd-party-tools/zcall
-    steps:
-    # checkout the repo
-    - name: 'Checkout GitHub Action'
-      uses: actions/checkout@v3
-      
-    - name: 'Login via Azure CLI'
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    
-    - name: 'Build and push image'
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - run: |
-        docker build . -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}
-        docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/${ACR_PATH}:${TAG}

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,11 @@ atlassian-ide-plugin.xml
 
 # Ignore all .DS_Store for all directories
 **/.DS_Store
+
+# Claude Code local config/state
+.claude/
+
+# Local container/GPU test artifacts (run locally, kept out of version control)
+.cache/
+scanvi_gpu_test/
+*.h5ad

--- a/3rd-party-tools/scvi-scanvi/README.md
+++ b/3rd-party-tools/scvi-scanvi/README.md
@@ -52,6 +52,7 @@ The CLI consumes three AnnData `.h5ad` files. (In the WARP pipeline, ATAC is opt
 | `-g` / `--gex-file` | AnnData `.h5ad` | yes | Gene expression. Expected `obs['star_IsCell']` (STARsolo cell calls). |
 | `-a` / `--atac-file` | AnnData `.h5ad` (cell-by-bin) | yes (CLI) | ATAC cell-by-bin matrix. Expected `obs['gex_barcodes']` to align with GEX. |
 | `-r` / `--ref-file` | AnnData `.h5ad` | yes | Annotated reference. **Must** carry `obs['final_annotation']` (cell-type labels) **and** `obs['batch']` (training is batch-aware). |
+| `-e` / `--max-epochs` | int | no | Maximum SCVI/SCANVI training epochs (default `500`). Lower it for fast smoke runs or to bound wall-clock on very large datasets. Also available on `run_multi_model`/`run_gex_only_model` as the `max_epochs` keyword. |
 | `-l` / `--localize` | flag | no | Localize inputs from / delocalize outputs to GCS via `gcs_utils`. |
 
 ## Outputs

--- a/3rd-party-tools/scvi-scanvi/README.md
+++ b/3rd-party-tools/scvi-scanvi/README.md
@@ -1,88 +1,102 @@
-# Label Transfer for Multiome data with SCVI and SCANVI
-This image outlines a workflow for integrating single-cell RNA and ATAC data using deep generative models (SCVI and SCANVI).
-It demonstrates how to preprocess the data, train models, and transfer cell type labels from a gene expression (GEX) 
-reference dataset to an ATAC-seq query dataset for downstream analysis and visualization.
-
-We use a full Multiome dataset with peak calling as our query, and the annotated PBMC reference from the scArches tutorial.
-
-This workflow follows the SnapATAC2 annotation tutorial: SnapATAC2 Tutorial https://kzhang.org/SnapATAC2/tutorials/annotation.html
+# scvi-scanvi
 
 ## Quick reference
 
-Copy and paste to pull this image
+```bash
+docker pull us.gcr.io/broad-gotc-prod/scvi-scanvi@sha256:635d4391d50cba9bd58f1fc41b10d8e1c61285a73bde75371815ce9a0db3430c
+```
 
-#### `docker pull us.gcr.io/broad-gotc-prod/scvi-scanvi:1.0.0-1.2-1756234975`
+- **What is this image:** a GPU-enabled Python image (Debian `python:3.12-slim` base) for single-cell cell-type **label transfer** with deep generative models, bundling the `multiome_label_transfer.py` workflow.
+- **What is scvi-tools:** [scvi-tools](https://docs.scvi-tools.org/) provides SCVI (unsupervised variational inference) and SCANVI (semi-supervised annotation) models for single-cell omics.
+
+## Synopsis
+
+This image trains SCVI/SCANVI models to transfer cell-type labels from an annotated reference onto unlabeled query cells. It supports two modes: **multiome** (gene expression + ATAC gene-activity + reference) and **GEX-only** (gene expression + reference, no ATAC). It is the execution environment for the Broad WARP [scANVI pipeline](https://github.com/broadinstitute/warp/tree/develop/pipelines/wdl/scanvi); the workflow follows the [SnapATAC2 annotation tutorial](https://kzhang.org/SnapATAC2/tutorials/annotation.html) and uses the annotated PBMC reference from the scArches tutorial.
+
+## Image contents
+
+- Base image: `python:3.12-slim-trixie` (`--platform=linux/amd64`)
+- `scvi-tools` 1.2 · `snapatac2` 2.7 · `scanpy` · `anndata` · `numpy` · `scikit-misc` · `google-cloud-storage`
+- GENCODE v41 basic annotation (`/usr/local/gencode.v41.basic.annotation.gff3.gz`), used for ATAC gene-activity conversion
+- Scripts: `multiome_label_transfer.py`, `gcs_utils.py` (see [Scripts](#scripts))
 
 ## Versioning
 
-This image uses the following convention for versioning:
-
-#### `us.gcr.io/broad-gotc-prod/scvi-scanvi:<image-version>-<scvi-version>-<unix-timestamp>` 
-
-We keep track of all past versions in [docker_versions](docker_versions.tsv) with the last image listed being the currently used version in WARP.
-
-You can see more information about the image, including the tool versions, by running the following commands:
+This image follows the WARP-Tools tag convention `us.gcr.io/broad-gotc-prod/scvi-scanvi:<image-version>-<scvi-tools-version>-<unix-timestamp>` (see [BUILDING.md → Versioning strategy](../../BUILDING.md#versioning-strategy)). Published tags are recorded in `docker_versions.tsv`. The WARP scANVI pipeline pins the image by immutable `@sha256` digest (shown in [Quick reference](#quick-reference)). Inspect an image with:
 
 ```bash
-$ docker pull us.gcr.io/broad-gotc-prod/scvi-scanvi:1.0.0-1.2-1756234975
-$ docker inspect us.gcr.io/broad-gotc-prod/scvi-scanvi:1.0.0-1.2-1756234975
+docker inspect us.gcr.io/broad-gotc-prod/scvi-scanvi@sha256:<digest>
 ```
+
+## Scripts
+
+| Script | Language | Purpose |
+| --- | --- | --- |
+| `multiome_label_transfer.py` | Python | Preprocessing, SCVI/SCANVI training, and label transfer. Exposes importable functions (below) and a CLI `main()`. |
+| `gcs_utils.py` | Python | Google Cloud Storage localize/delocalize helpers used by the `--localize` flag. |
+
+Key importable functions in `multiome_label_transfer.py`:
+
+- `run_multi_model(gex, atac_activity, ref)` — train SCVI+SCANVI on GEX + ATAC activity + reference.
+- `run_gex_only_model(gex, ref)` — train SCVI+SCANVI on GEX + reference only (GEX-only mode).
+- `_concat_and_train_models(adatas, keys)` — shared training core used by both of the above (avoids drift).
+- `transfer_labels(data, lvae)` — predict labels (`C_scANVI`) and compute the SCANVI UMAP.
+- `finalize_output(scanvi_output)` — add metadata, rename `final_annotation` → `celltype`, copy counts into `.raw`.
+
+## Inputs
+
+The CLI consumes three AnnData `.h5ad` files. (In the WARP pipeline, ATAC is optional — see [Task descriptions](#task-descriptions).)
+
+| Input | Type / format | Required | Description |
+| --- | --- | --- | --- |
+| `-g` / `--gex-file` | AnnData `.h5ad` | yes | Gene expression. Expected `obs['star_IsCell']` (STARsolo cell calls). |
+| `-a` / `--atac-file` | AnnData `.h5ad` (cell-by-bin) | yes (CLI) | ATAC cell-by-bin matrix. Expected `obs['gex_barcodes']` to align with GEX. |
+| `-r` / `--ref-file` | AnnData `.h5ad` | yes | Annotated reference. **Must** carry `obs['final_annotation']` (cell-type labels) **and** `obs['batch']` (training is batch-aware). |
+| `-l` / `--localize` | flag | no | Localize inputs from / delocalize outputs to GCS via `gcs_utils`. |
+
+## Outputs
+
+| Output | Format | Description |
+| --- | --- | --- |
+| `SCANVI_predictions.h5ad` | AnnData | Combined object with SCANVI predictions (`celltype`), UMAP, and metadata; counts in `.raw`. |
+| `gex_annotated_matrix.h5ad` | AnnData | GEX cells with transferred `final_annotation`. |
+| `atac_annotated_matrix.h5ad` | AnnData | ATAC gene-activity cells with transferred `final_annotation` (multiome mode only). |
+| `vae_test_model_/`, `scvi_scanvi_test_model_/` | scvi-tools model dirs | Saved SCVI and SCANVI models. |
+| `adata_scanvi_labels.h5ad` | AnnData | Intermediate labeled object written by `transfer_labels`. |
 
 ## Usage
+
+Run the multiome workflow standalone (GPU required for reasonable runtime):
+
 ```bash
-$ docker run --rm -it \
-    -v /files:/files --gpus all \
-    us.gcr.io/broad-gotc-prod/scvi-scanvi:1.0.0-1.2-1756234975 \
-    python multiome_label_transfer.py --gex-file /files/gex.h5ad \
-    --atac-file /files/atac.h5ad --ref-file /files/pbmc.h5ad 
+docker run --rm -it --gpus all \
+    -v /files:/files \
+    us.gcr.io/broad-gotc-prod/scvi-scanvi@sha256:<digest> \
+    python multiome_label_transfer.py \
+      --gex-file /files/gex.h5ad \
+      --atac-file /files/atac.cellbybin.h5ad \
+      --ref-file /files/pbmc.h5ad
 ```
 
+With `podman` and CDI GPU support, replace `--gpus all` with `--device nvidia.com/gpu=all`.
 
-## Environment Setup
-Environment Setup
-Note: GPU acceleration is strongly recommended in order to run this container efficiently, though it is not a strict hardware requirement. 
-Ensure that GPU support is enabled when creating your environment. When running the container, you must grant access to 
-any GPUs by setting the `--gpus all` flag in `docker run`.
+> The CLI `main()` always runs the **multiome** path. **GEX-only** mode is exercised through the WARP pipeline, which imports `run_gex_only_model` directly (it does not call `main()`).
 
-VM Specifications:
+## Task descriptions
 
-* GPU: NVIDIA Tesla T4
-* CPU: 8 vCPUs
-* Memory: 30 GB RAM
-* Disk: 200 GB
-* Input Files and Sizes:
-  * GEX h5ad file test_gex.h5ad: 675 MB
-  * ATAC peaks called per cluster human.cellbybin.h5ad: 591 MB 
-  * Annotated reference pbmc.h5ad: 2 GB
+This image is consumed by the WARP [scANVI pipeline](https://github.com/broadinstitute/warp/tree/develop/pipelines/wdl/scanvi/scANVI.wdl):
 
-## Overview
+- **`PreprocessFilter`** (CPU) — runs inline Python (loads/filters GEX, builds the ATAC gene-activity matrix with `snapatac2` in multiome mode); does not import from the script.
+- **`MultiomeLabelTransfer`** (GPU) — imports `run_multi_model` / `run_gex_only_model`, `transfer_labels`, and `finalize_output` from `/usr/local`, and **never calls `main()`**. It calls `run_multi_model` when ATAC is present and `run_gex_only_model` when it is not.
 
-### Train SCVI and SCANVI models to integrate RNA (query and reference) and ATAC datasets
-#### Preprocessing steps:
+The imported function API is the production contract — keep signatures and behavior stable (see [AGENTS.md → Keep scripts importable](../../AGENTS.md#keep-scripts-importable)).
 
-Filter gene expression (GEX) using `filt_gex` to retain barcodes called as cells by `STARsolo` and store raw counts in .layers.
-Reindex ATAC using `reindex_barcodes` to align ATAC data with GEX barcodes to ensure matching cells.
-Filter to shared barcodes using `shared_barcodes` to retain only the intersecting cells in GEX and ATAC datasets.
-Align gene features using `get_shared_features` to ensure GEX, ATAC (activity matrix), and reference datasets share the same gene space.
-#### Training process:
+## Requirements / dependencies
 
-Combine GEX, ATAC, and reference & select highly variable genes using `run_multi_model`.
-Train SCVI model using `run_multi_model` to learn an unsupervised latent representation from the combined data.
-Train SCANVI model using `run_multi_model` to transfer cell type labels from reference to query using semi-supervised learning.
-Save outputs of trained models and annotated AnnData objects.
-#### Transfer labels using SCANVI model.
-Use transfer_labels to apply the trained SCANVI model to new data and visualize cell types via UMAP.
+- **GPU strongly recommended** (e.g. NVIDIA T4 or better); pass `--gpus all` (docker) or `--device nvidia.com/gpu=all` (podman/CDI).
+- **Network at runtime**: the ATAC gene-activity step downloads `snapatac2`'s hg38 annotation (`snap.genome.hg38`).
+- Reference sizing: the PBMC reference is ~2 GB; a full multiome run is comfortable with ~30 GB RAM and ~200 GB disk.
 
-### Explore previously trained model for Single Cell Portal.
-Separate the combined multiome AnnData object into RNA and ATAC subsets (rna_unannotated and atac_unannotated), while preserving:
+## Troubleshooting
 
-transferred annotations
-shared barcodes
-relevant metadata for downstream analysis.
-### Perform label transfer and save predictions.
-Use:
-
-`subset_multiome_data` to isolate modalities
-`check_cell_matches` to validate cell integrity across modalities.
-### Output timing summary table
-Report time taken for each stage: preprocessing, training, and prediction.
+To poke around the image, start a shell: `docker run -it --rm us.gcr.io/broad-gotc-prod/scvi-scanvi@sha256:<digest> bash`. See [BUILDING.md → Troubleshooting and running standalone](../../BUILDING.md#troubleshooting-and-running-standalone).

--- a/3rd-party-tools/scvi-scanvi/README.md
+++ b/3rd-party-tools/scvi-scanvi/README.md
@@ -17,12 +17,12 @@ This image trains SCVI/SCANVI models to transfer cell-type labels from an annota
 
 - Base image: `python:3.12-slim-trixie` (`--platform=linux/amd64`)
 - `scvi-tools` 1.2 · `snapatac2` 2.7 · `scanpy` · `anndata` · `numpy` · `scikit-misc` · `google-cloud-storage`
-- GENCODE v41 basic annotation (`/usr/local/gencode.v41.basic.annotation.gff3.gz`), used for ATAC gene-activity conversion
+- ATAC gene-activity conversion uses snapatac2's hg38 annotation (`snap.genome.hg38`), fetched at runtime. (A GENCODE v41 GFF3 is baked in at `/usr/local/gencode.v41.basic.annotation.gff3.gz` but is legacy — the current code path does not use it.)
 - Scripts: `multiome_label_transfer.py`, `gcs_utils.py` (see [Scripts](#scripts))
 
 ## Versioning
 
-This image follows the WARP-Tools tag convention `us.gcr.io/broad-gotc-prod/scvi-scanvi:<image-version>-<scvi-tools-version>-<unix-timestamp>` (see [BUILDING.md → Versioning strategy](../../BUILDING.md#versioning-strategy)). Published tags are recorded in `docker_versions.tsv`. The WARP scANVI pipeline pins the image by immutable `@sha256` digest (shown in [Quick reference](#quick-reference)). Inspect an image with:
+This image follows the WARP-Tools tag convention `us.gcr.io/broad-gotc-prod/scvi-scanvi:<image-version>-<scvi-tools-version>-<unix-timestamp>` (see [BUILDING.md → Versioning strategy](../../BUILDING.md#versioning-strategy)). Published references are recorded in [docker_versions.tsv](docker_versions.tsv), with the last line being the version currently used by WARP. The current production image is built by CI (branch-tagged) and the scANVI pipeline pins it by immutable `@sha256` digest (shown in [Quick reference](#quick-reference)) — hence the digest rather than a semantic tag for the latest entry. Inspect an image with:
 
 ```bash
 docker inspect us.gcr.io/broad-gotc-prod/scvi-scanvi@sha256:<digest>

--- a/3rd-party-tools/scvi-scanvi/docker_build.sh
+++ b/3rd-party-tools/scvi-scanvi/docker_build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.0.0
+# Update version when changes to Dockerfile or scripts are made
+DOCKER_IMAGE_VERSION=1.1.0
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 

--- a/3rd-party-tools/scvi-scanvi/docker_versions.tsv
+++ b/3rd-party-tools/scvi-scanvi/docker_versions.tsv
@@ -1,0 +1,3 @@
+DOCKER_VERSION
+us.gcr.io/broad-gotc-prod/scvi-scanvi:1.0.0-1.2-1756234975
+us.gcr.io/broad-gotc-prod/scvi-scanvi@sha256:635d4391d50cba9bd58f1fc41b10d8e1c61285a73bde75371815ce9a0db3430c

--- a/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
+++ b/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
@@ -253,9 +253,13 @@ def run_multi_model(gex, atac_activity_matrix, ref):
         - Saves both trained models and annotated data.
 
         Parameters:
-        - gex (AnnData): Gene expression data (unannotated).
+        - gex (AnnData): Gene expression data (unannotated). Must carry a `batch` column.
         - atac_activity_matrix (AnnData): ATAC data in gene activity format (unannotated).
+          Must carry a `batch` column.
         - ref (AnnData): Annotated reference GEX dataset with `final_annotation` in `.obs`.
+          Must also carry a `batch` column: training is batch-aware
+          (`highly_variable_genes`/`SCVI.setup_anndata` use `batch_key="batch"`) over the
+          concatenated object, which includes the reference rows.
 
         Returns:
         - data (AnnData): Combined and annotated data object.
@@ -281,6 +285,10 @@ def run_gex_only_model(gex, ref):
         Parameters:
         - gex (AnnData): Gene expression data (unannotated). Must carry a `batch` column.
         - ref (AnnData): Annotated reference GEX dataset with `final_annotation` in `.obs`.
+          Must also carry a `batch` column: training is batch-aware
+          (`highly_variable_genes`/`SCVI.setup_anndata` use `batch_key="batch"`) over the
+          concatenated object, which includes the reference rows. This is the same
+          requirement as `run_multi_model`.
 
         Returns:
         - data (AnnData): Combined and annotated data object.

--- a/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
+++ b/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
@@ -164,21 +164,21 @@ def get_shared_features(gex, atac, ref):
     return gex, atac, ref
 
 
-def run_multi_model(gex, atac_activity_matrix, ref):
+def _concat_and_train_models(adatas, keys):
     """
-        Train a SCVI/SCANVI model on concatenated GEX, ATAC, and reference datasets.
+        Concatenate query/reference AnnData objects and train SCVI + SCANVI on them.
 
-        This function:
-        - Merges GEX, ATAC activity, and reference datasets into a unified AnnData object.
-        - Identifies highly variable genes (HVGs) for feature selection.
-        - Trains a SCVI model for unsupervised representation learning.
-        - Transfers cell type annotations using SCANVI (semi-supervised learning).
-        - Saves both trained models and annotated data.
+        This is the shared core used by both the multiome (GEX + ATAC + reference) and
+        GEX-only (GEX + reference) entry points. Everything from feature selection through
+        SCANVI training is identical across modalities; only the set of datasets being
+        concatenated (and their modality keys) differs.
 
         Parameters:
-        - gex (AnnData): Gene expression data (unannotated).
-        - atac_activity_matrix (AnnData): ATAC data in gene activity format (unannotated).
-        - ref (AnnData): Annotated reference GEX dataset with `final_annotation` in `.obs`.
+        - adatas (list[AnnData]): Datasets to concatenate, in order matching `keys`. Each
+          must carry a `batch` column in `.obs`; the reference must carry `final_annotation`.
+        - keys (list[str]): Modality keys, one per dataset. Stored in `obs['modality']` and
+          appended to `obs_names` (via `index_unique='_'`) so labels can later be propagated
+          back to the original objects (e.g. `<barcode>_rna_unannotated`).
 
         Returns:
         - data (AnnData): Combined and annotated data object.
@@ -187,10 +187,10 @@ def run_multi_model(gex, atac_activity_matrix, ref):
     """
     # Concatenate the datasets across modalities
     data = ad.concat(
-        [gex, atac_activity_matrix, ref],
+        adatas,
         join='inner',
         label='modality',
-        keys=["rna_unannotated", "atac_unannotated", "rna_annotated"],
+        keys=keys,
         index_unique='_',
     )
     # Filter genes expressed in at least 5 cells
@@ -239,6 +239,58 @@ def run_multi_model(gex, atac_activity_matrix, ref):
     lvae.save("scvi_scanvi_test_model_", save_anndata=True)
 
     return data, vae, lvae
+
+
+def run_multi_model(gex, atac_activity_matrix, ref):
+    """
+        Train a SCVI/SCANVI model on concatenated GEX, ATAC, and reference datasets.
+
+        This function:
+        - Merges GEX, ATAC activity, and reference datasets into a unified AnnData object.
+        - Identifies highly variable genes (HVGs) for feature selection.
+        - Trains a SCVI model for unsupervised representation learning.
+        - Transfers cell type annotations using SCANVI (semi-supervised learning).
+        - Saves both trained models and annotated data.
+
+        Parameters:
+        - gex (AnnData): Gene expression data (unannotated).
+        - atac_activity_matrix (AnnData): ATAC data in gene activity format (unannotated).
+        - ref (AnnData): Annotated reference GEX dataset with `final_annotation` in `.obs`.
+
+        Returns:
+        - data (AnnData): Combined and annotated data object.
+        - vae (SCVI model): Trained SCVI model.
+        - lvae (SCANVI model): Trained SCANVI model with transferred labels.
+    """
+    return _concat_and_train_models(
+        [gex, atac_activity_matrix, ref],
+        keys=["rna_unannotated", "atac_unannotated", "rna_annotated"],
+    )
+
+
+def run_gex_only_model(gex, ref):
+    """
+        Train a SCVI/SCANVI model on GEX and reference datasets only (no ATAC).
+
+        Used when the pipeline runs in GEX-only mode (no ATAC h5ad provided). Behaves
+        identically to `run_multi_model` but concatenates only the gene expression query
+        and the annotated reference. The GEX modality key is unchanged
+        ("rna_unannotated"), so downstream label propagation
+        (`gex.obs_names + '_rna_unannotated'`) works exactly as in the multiome path.
+
+        Parameters:
+        - gex (AnnData): Gene expression data (unannotated). Must carry a `batch` column.
+        - ref (AnnData): Annotated reference GEX dataset with `final_annotation` in `.obs`.
+
+        Returns:
+        - data (AnnData): Combined and annotated data object.
+        - vae (SCVI model): Trained SCVI model.
+        - lvae (SCANVI model): Trained SCANVI model with transferred labels.
+    """
+    return _concat_and_train_models(
+        [gex, ref],
+        keys=["rna_unannotated", "rna_annotated"],
+    )
 
 
 def transfer_labels(data, lvae):

--- a/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
+++ b/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
@@ -164,7 +164,7 @@ def get_shared_features(gex, atac, ref):
     return gex, atac, ref
 
 
-def _concat_and_train_models(adatas, keys):
+def _concat_and_train_models(adatas, keys, max_epochs=500):
     """
         Concatenate query/reference AnnData objects and train SCVI + SCANVI on them.
 
@@ -179,6 +179,9 @@ def _concat_and_train_models(adatas, keys):
         - keys (list[str]): Modality keys, one per dataset. Stored in `obs['modality']` and
           appended to `obs_names` (via `index_unique='_'`) so labels can later be propagated
           back to the original objects (e.g. `<barcode>_rna_unannotated`).
+        - max_epochs (int): Maximum training epochs applied to both the SCVI and SCANVI
+          models (default 500). SCVI also uses early stopping. Lower it for fast
+          plumbing/smoke runs or to bound wall-clock on very large datasets.
 
         Returns:
         - data (AnnData): Combined and annotated data object.
@@ -216,7 +219,7 @@ def _concat_and_train_models(adatas, keys):
     )
 
     # Train SCVI
-    vae.train(max_epochs=500, early_stopping=True)
+    vae.train(max_epochs=max_epochs, early_stopping=True)
     vae.save("vae_test_model_", save_anndata=True)
 
     # Plot training history
@@ -235,13 +238,13 @@ def _concat_and_train_models(adatas, keys):
         labels_key="celltype_scanvi",
         unlabeled_category="Unknown",
     )
-    lvae.train(max_epochs=500, n_samples_per_label=100)
+    lvae.train(max_epochs=max_epochs, n_samples_per_label=100)
     lvae.save("scvi_scanvi_test_model_", save_anndata=True)
 
     return data, vae, lvae
 
 
-def run_multi_model(gex, atac_activity_matrix, ref):
+def run_multi_model(gex, atac_activity_matrix, ref, max_epochs=500):
     """
         Train a SCVI/SCANVI model on concatenated GEX, ATAC, and reference datasets.
 
@@ -260,6 +263,7 @@ def run_multi_model(gex, atac_activity_matrix, ref):
           Must also carry a `batch` column: training is batch-aware
           (`highly_variable_genes`/`SCVI.setup_anndata` use `batch_key="batch"`) over the
           concatenated object, which includes the reference rows.
+        - max_epochs (int): Maximum SCVI/SCANVI training epochs (default 500).
 
         Returns:
         - data (AnnData): Combined and annotated data object.
@@ -269,10 +273,11 @@ def run_multi_model(gex, atac_activity_matrix, ref):
     return _concat_and_train_models(
         [gex, atac_activity_matrix, ref],
         keys=["rna_unannotated", "atac_unannotated", "rna_annotated"],
+        max_epochs=max_epochs,
     )
 
 
-def run_gex_only_model(gex, ref):
+def run_gex_only_model(gex, ref, max_epochs=500):
     """
         Train a SCVI/SCANVI model on GEX and reference datasets only (no ATAC).
 
@@ -289,6 +294,7 @@ def run_gex_only_model(gex, ref):
           (`highly_variable_genes`/`SCVI.setup_anndata` use `batch_key="batch"`) over the
           concatenated object, which includes the reference rows. This is the same
           requirement as `run_multi_model`.
+        - max_epochs (int): Maximum SCVI/SCANVI training epochs (default 500).
 
         Returns:
         - data (AnnData): Combined and annotated data object.
@@ -298,6 +304,7 @@ def run_gex_only_model(gex, ref):
     return _concat_and_train_models(
         [gex, ref],
         keys=["rna_unannotated", "rna_annotated"],
+        max_epochs=max_epochs,
     )
 
 
@@ -407,7 +414,7 @@ def check_cell_matches(gex, atac):
     return mismatched_barcodes
 
 
-def main(gex_file, atac_file, ref_file):
+def main(gex_file, atac_file, ref_file, max_epochs=500):
     # This block performs initial preprocessing steps for integrating Multiome RNA and ATAC data
     # with a reference scRNA-seq dataset using scvi-tools.
     #
@@ -479,7 +486,7 @@ def main(gex_file, atac_file, ref_file):
     # - Returns the combined AnnData object (`data`) and trained models (`vae`, `lvae`)
 
     start = time.time()
-    data, vae, lvae = run_multi_model(gex_shared, query, ref)
+    data, vae, lvae = run_multi_model(gex_shared, query, ref, max_epochs=max_epochs)
     timing_summary['Model Training'] = time.time() - start
 
     # ----------------------------------------------
@@ -578,6 +585,14 @@ if __name__ == '__main__':
     parser.add_argument('-a', '--atac-file', required=True, help="Input ATAC AnnData file")
     parser.add_argument('-r', '--ref-file', required=True, help="Input label reference AnnData file")
     parser.add_argument(
+        '-e',
+        '--max-epochs',
+        required=False,
+        default=500,
+        type=int,
+        help="Maximum SCVI/SCANVI training epochs (default: 500)"
+    )
+    parser.add_argument(
         '-l',
         '--localize',
         required=False,
@@ -590,7 +605,7 @@ if __name__ == '__main__':
         gex, atac, ref = pull_all_files([parsed_args.gex_file, parsed_args.atac_file, parsed_args.ref_file])
     else:
         gex, atac, ref = parsed_args.gex_file, parsed_args.atac_file, parsed_args.ref_file
-    main(gex, atac, ref)
+    main(gex, atac, ref, max_epochs=parsed_args.max_epochs)
     if parsed_args.localize:
         bucket_name = get_bucket_and_path(parsed_args.ref_file)[0]
         delocalize_file(bucket_name, "SCANVI_predictions.h5ad", "SCANVI_predictions.h5ad")

--- a/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
+++ b/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
@@ -229,7 +229,7 @@ def _concat_and_train_models(adatas, keys, max_epochs=500):
     # Prepare labels for SCANVI
     data.obs["celltype_scanvi"] = 'Unknown'
     ref_idx = data.obs['modality'] == "rna_annotated"
-    data.obs["celltype_scanvi"][ref_idx] = data.obs['final_annotation'][ref_idx]
+    data.obs.loc[ref_idx, "celltype_scanvi"] = data.obs.loc[ref_idx, "final_annotation"]
 
     # Initialize and train SCANVI
     lvae = scvi.model.SCANVI.from_scvi_model(
@@ -454,11 +454,9 @@ def main(gex_file, atac_file, ref_file, max_epochs=500):
     # Add placeholder annotations to the query datasets (used later by scanVI)
     gex_shared.obs['final_annotation'] = "Unknown"
 
-    query = snap.pp.make_gene_matrix(
-        atac_shared,
-        gene_anno="gencode.v41.basic.annotation.gff3.gz"
-    )
-
+    # Convert ATAC cell-by-bin matrix into a gene activity matrix (hg38), matching
+    # the production WDL (PreprocessFilter), which uses snap.genome.hg38.
+    query = snap.pp.make_gene_matrix(atac_shared, gene_anno=snap.genome.hg38)
     print("query shape: ", query.shape)
     query.obs['final_annotation'] = "Unknown"
 
@@ -468,16 +466,6 @@ def main(gex_file, atac_file, ref_file, max_epochs=500):
     ref.obs["modality"] = "rna_annotated"
 
     timing_summary['Preprocessing'] = time.time() - start
-
-    # Convert ATAC cell-by-bin matrix into gene activity matrix using reference genome annotation
-    query = snap.pp.make_gene_matrix(atac_shared, gene_anno=snap.genome.hg38)
-    print("query shape: ", query.shape)
-    query.obs['final_annotation'] = "Unknown"
-
-    # Tag each dataset with its modality (required for scanVI integration)
-    gex_shared.obs["modality"] = "rna_unannotated"
-    query.obs["modality"] = "atac_unannotated"
-    ref.obs["modality"] = "rna_annotated"
 
     timing_summary['Preprocessing'] = time.time() - start
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,18 @@ You can build and run these images locally — including GPU images — without 
 - The gencode annotation is baked in; `snap.genome.hg38` is downloaded at runtime (the container needs network during the ATAC gene-activity step).
 - SCVI/SCANVI training is **stochastic** — outputs are not bit-reproducible, so the consuming pipeline verifies **tolerantly** (warp `VerifyScANVI` / `CompareScanviH5ad`), not by exact match. See the image's [README](3rd-party-tools/scvi-scanvi/README.md).
 
+## Pipeline verification & CI (in the warp consuming repo)
+
+How this image's outputs get tested lives in the [warp](https://github.com/broadinstitute/warp) repo, but these cross-repo lessons are easy to trip over:
+
+- **Tolerant verification for stochastic models.** scvi-scanvi training is non-deterministic, so the scANVI pipeline does **not** compare outputs to truth by exact equality. Its `CompareScanviH5ad` task checks structure + distribution: cell counts match, the predicted-label vocabulary is a subset of truth's, and per-cell-type proportions correlate with truth above a threshold. Use this pattern for any stochastic/ML image.
+- **Keep a pipeline's verification task out of the shared `verification/VerifyTasks.wdl`.** That shared file is in **~27** pipelines' GitHub Actions `paths:` filters, so editing it triggers **every** pipeline's (Terra-based) test suite — slow, costly, noisy. Put the compare task in the pipeline's own `verification/Verify<Pipeline>.wdl` instead (scANVI keeps `CompareScanviH5ad` in `VerifyScANVI.wdl`). The same "don't touch in a feature PR" caution applies to other shared trigger files: `tasks/wdl/Utilities.wdl`, `tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl`, `.github/workflows/warp_test_workflow.yml`, and `scripts/firecloud_api/firecloud_api.py` (each in ~24–27 path filters).
+- **New `test_<pipeline>.yml` needs an explicit `permissions:` block.** The reusable `warp_test_workflow.yml` job requests `contents: read`, `id-token: write` (Terra/GCP auth), and `actions: write`; the caller must grant at least those (CodeQL also flags a missing block).
+
+### Future work (stashed, separate PR)
+
+- **`firecloud_api.py` robustness.** Terra/Dockstore intermittently return non-JSON 5xx (e.g. an HTML `502`) during submission polling and method-config cleanup; `firecloud_api.py` parses the body unconditionally and crashes with `requests.exceptions.JSONDecodeError`. This surfaces as widespread, transient red CI across unrelated pipelines — infrastructure flakiness, not real breakage. A future PR should detect non-JSON / 5xx responses and retry-with-backoff instead of crashing. Note: `firecloud_api.py` is itself in ~24 pipeline `paths:` filters, so that fix is a CI-infra PR that triggers every pipeline — keep it out of feature PRs.
+
 ## Agent-Specific Notes
 
 Record recurring container-build learnings/mistakes here. Keep entries short and **link** to [BUILDING.md](BUILDING.md) or the warp AGENTS.md rather than duplicating them. Before adding a note, check it isn't already covered above or in a linked doc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Agent Instructions (warp-tools)
+
+Single entry point for agent-driven and AI-coding work in **warp-tools** — the repository that builds and publishes the Docker images consumed by the [WARP](https://github.com/broadinstitute/warp) pipelines.
+
+This file holds **container-operational** guidance only. It does **not** repeat the human-facing build guide or the WARP pipeline/WDL rules — follow the links instead of restating them.
+
+## Authoritative References
+
+| Topic | Document |
+| --- | --- |
+| Repo overview, directory structure, where images live, versioning strategy | [README.md](README.md) |
+| How to build/publish/add images, digest pinning, Dockerfile style guide | [BUILDING.md](BUILDING.md) (this repo; canonical for build mechanics) |
+| Standard structure for a tool's README | [TOOL_README_TEMPLATE.md](TOOL_README_TEMPLATE.md) |
+| Pipeline/WDL rules, changelog & **pipeline** versioning, when to package logic into a warp-tools image vs inline WDL | [warp `AGENTS.md`](https://github.com/broadinstitute/warp/blob/develop/AGENTS.md) |
+
+## Build & publish, in one line
+
+Images publish to **GCR only** (`us.gcr.io/broad-gotc-prod/<image>`); CI builds on a PR touching an image's directory; then pin the resulting `@sha256` digest in the consuming WARP pipeline. Commands and the full flow are in [BUILDING.md](BUILDING.md#how-images-are-consumed-by-warp-digest-pinning).
+
+> There is **no Quay** publishing. CI pushes only to GCR. Some `docker_build.sh` scripts still contain `quay.io/...` tag/push lines — these are **stale and nonfunctional** (the newer images were never pushed to Quay); treat them as dead code to be removed, not a live target.
+
+## Keep scripts importable
+
+WARP pipelines frequently import specific functions from a baked-in script rather than calling its `main()` (e.g. scANVI runs `from multiome_label_transfer import run_multi_model, run_gex_only_model, …`). The imported function API — not `main()` — is the production contract. Preserve signatures/behavior, factor shared internals into a helper when adding a variant (scvi-scanvi: `_concat_and_train_models` is shared by `run_multi_model` and `run_gex_only_model`), and document hidden preconditions in docstrings. See [BUILDING.md → Adding or updating an image](BUILDING.md#adding-or-updating-an-image).
+
+## Local build & GPU testing
+
+You can build and run these images locally — including GPU images — without CI.
+
+- **Sandbox note.** In a Flatpak/dev-container sandbox the host tools live under `/run/host` and are not on `PATH`. Run the host engine via `flatpak-spawn --host podman …` (direct exec of `/run/host/usr/bin/podman` fails on host libs). **Check for an existing host engine before installing one.**
+- **Build:** `flatpak-spawn --host podman build -t <tool>:local 3rd-party-tools/<tool>`.
+- **GPU passthrough:** the host NVIDIA Container Toolkit (`nvidia-ctk`) provides a CDI spec at `/etc/cdi/nvidia.yaml`; attach the GPU with `--device nvidia.com/gpu=all`. Smoke-test with `podman run --rm --device nvidia.com/gpu=all <img> nvidia-smi` and an in-container `python -c "import torch; print(torch.cuda.is_available())"`.
+- **Test edited code without rebuilding** by volume-mounting the changed script over the image copy: `-v "$PWD/3rd-party-tools/<tool>/script.py:/usr/local/script.py:Z"`.
+- **Verify a published image's contents** by importing the module and checking expected symbols, e.g. `python -c "import multiome_label_transfer as m; print(hasattr(m,'run_gex_only_model'))"`.
+- **Pull auth (GCR):** `gcloud auth print-access-token | podman login -u oauth2accesstoken --password-stdin us.gcr.io`.
+
+## Image-specific notes: scvi-scanvi (GPU)
+
+- `scvi-tools` and `snapatac2` are pinned via build `ARG`s — **keep them pinned**; changing `scvi-tools` changes model behavior for the consuming pipeline.
+- The gencode annotation is baked in; `snap.genome.hg38` is downloaded at runtime (the container needs network during the ATAC gene-activity step).
+- SCVI/SCANVI training is **stochastic** — outputs are not bit-reproducible, so the consuming pipeline verifies **tolerantly** (warp `VerifyScANVI` / `CompareScanviH5ad`), not by exact match. See the image's [README](3rd-party-tools/scvi-scanvi/README.md).
+
+## Agent-Specific Notes
+
+Record recurring container-build learnings/mistakes here. Keep entries short and **link** to [BUILDING.md](BUILDING.md) or the warp AGENTS.md rather than duplicating them. Before adding a note, check it isn't already covered above or in a linked doc.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,171 @@
+# Building and Maintaining WARP-Tools Images
+
+How to build, version, publish, and add Docker images in this repository, plus the Dockerfile style guide. For a high-level overview of the repo see [README.md](README.md); for agent/automation-specific guidance see [AGENTS.md](AGENTS.md).
+
+## Table of Contents
+
+- [How images are built and published](#how-images-are-built-and-published)
+- [Versioning strategy](#versioning-strategy)
+- [How images are consumed by WARP (digest pinning)](#how-images-are-consumed-by-warp-digest-pinning)
+- [Adding or updating an image](#adding-or-updating-an-image)
+- [Docker style guide](#docker-style-guide)
+- [Troubleshooting and running standalone](#troubleshooting-and-running-standalone)
+
+## How images are built and published
+
+All images publish to **Google Container Registry (GCR)** under `us.gcr.io/broad-gotc-prod/<image>`. There is **no Quay (or other) mirror** — GCR is the single source of truth.
+
+There are two build paths:
+
+1. **CI (canonical).** Each image has a `.github/workflows/build-<tool>.yml` workflow that triggers on a pull request touching that image's directory (e.g. `paths: ['3rd-party-tools/<tool>/**']`), and can also be run manually via **workflow_dispatch** (optional `image_tag` input). It builds the Dockerfile and pushes to `us.gcr.io/broad-gotc-prod/<tool>`, **tagged by the branch name** (`github.head_ref`). Authentication uses the `GCR_CI_KEY` repository secret — no local credentials are needed. **Opening a PR is the normal way to build an image.**
+2. **Local/manual (`docker_build.sh`).** A convenience script next to each Dockerfile for building locally. It tags the image per the [versioning strategy](#versioning-strategy), pushes to GCR, and appends the resulting reference to `docker_versions.tsv`. Running it requires a local container engine, `gcloud`, and GCR push access (`gcloud auth configure-docker`).
+
+> Image vulnerability scanning runs on every PR via [trivy](https://github.com/aquasecurity/trivy); when you add a new image, register it in [.github/workflows/trivy.yml](.github/workflows/trivy.yml).
+
+## Versioning strategy
+
+Images use **semantic tags**, never rolling tags like `latest` or `master` (rolling tags make it impossible to trace which image content a pipeline actually ran):
+
+```
+us.gcr.io/broad-gotc-prod/<image>:<image-version>-<tool-version>-<unix-timestamp>
+```
+
+- **`image-version`** — `major.minor.patch` of the image itself; bump it when the image changes for reasons unrelated to the wrapped tool (base OS, system packages, baked-in scripts).
+- **`tool-version`** — the version of the wrapped tool (e.g. `samtools` `1.19`), so consumers can identify it without inspecting the image.
+- **`unix-timestamp`** — guarantees a unique tag and avoids Cromwell image-cache collisions.
+
+Each image directory keeps a `docker_versions.tsv` recording every published tag; **the last line is the version currently used by WARP**. The `docker_build.sh` script appends to it automatically. When bumping a manual build, also bump `DOCKER_IMAGE_VERSION` in that image's `docker_build.sh`.
+
+## How images are consumed by WARP (digest pinning)
+
+WARP pipelines pin images by **immutable `@sha256` digest**, not by tag, so a pipeline always runs an exact image. After changing an image you must update the digest in the consuming pipeline or it keeps running the old image:
+
+1. Make the change here and open a PR → CI builds & pushes the branch-tagged image.
+2. Resolve the digest for that tag:
+   ```bash
+   gcloud container images list-tags us.gcr.io/broad-gotc-prod/<image> \
+     --filter="tags=<branch-or-tag>" --format="get(digest)"
+   ```
+   (or read it from the CI "Push image" log).
+3. In the [warp](https://github.com/broadinstitute/warp) repo, update the pipeline's `String docker = "us.gcr.io/broad-gotc-prod/<image>@sha256:<digest>"` (and any docs that cite the digest), and validate the WDL.
+
+## Adding or updating an image
+
+1. Create `3rd-party-tools/<tool>/` (third-party) or extend `tools/` (in-house) with a `Dockerfile`, a `docker_build.sh`, a `docker_versions.tsv`, and a `README.md`.
+2. Write the `README.md` from the standard [tool README template](TOOL_README_TEMPLATE.md) (synopsis, inputs, outputs, usage, task descriptions).
+3. Keep any baked-in scripts **importable and stable**: WARP pipelines often import specific functions from a script in the image (e.g. `from multiome_label_transfer import run_multi_model`) rather than calling its `main()`. The imported function API — not `main()` — is the production contract, so preserve signatures/behavior and document hidden preconditions in docstrings. When adding a variant, factor shared internals into a helper to avoid drift.
+4. Add a `.github/workflows/build-<tool>.yml` (copy an existing one; set `GCR_PATH: broad-gotc-prod/<tool>` and the `paths` trigger) and register the image in [.github/workflows/trivy.yml](.github/workflows/trivy.yml).
+5. Open a PR to build the image, then pin its digest in the consuming pipeline as above.
+
+## Docker style guide
+
+Guidelines and best practices for writing Dockerfiles in WARP.
+
+### Small images
+
+Smaller images mean faster upload/download, lower storage cost, and a reduced attack surface. The two easiest wins are a small base image and fewer layers.
+
+**Alpine base.** Prefer an [Alpine](https://alpinelinux.org/) base — it's built for size and security, deletes its package index automatically, and provides [tini](https://github.com/krallin/tini) via APK. Use a Debian base only as a last resort, when a dependency isn't available in APK.
+
+```dockerfile
+# OKAY, NOT GREAT - uses debian (must clean apt cache manually)
+FROM python:debian
+RUN set -eux; \
+        apt-get update; \
+        apt-get install -y curl bash; \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# GOOD - uses alpine
+FROM alpine:3.9
+RUN set -eux; \
+        apk add --no-cache curl bash
+```
+
+**Specify the platform.** Images built on ARM machines (e.g. Apple Silicon) can fail the automated PR test suite. Pin `linux/amd64`:
+
+```dockerfile
+FROM --platform="linux/amd64" alpine
+```
+
+**Minimal RUN steps.** Each instruction creates a layer; collapse installs into a single `RUN`. (Multi-stage builds help for statically linked binaries, but most WARP images need system-level dependencies, so multi-stage is uncommon here.)
+
+```dockerfile
+# GOOD - single RUN
+RUN set -eux; \
+        apk add --no-cache curl bash wget; \
+    wget https://example.com/zip; \
+    unzip zip
+```
+
+### Publicly accessible
+
+WARP pipelines are designed for public use, so the images should be too:
+
+- **Anybody can pull them** — they are hosted in the public GCR repo `us.gcr.io/broad-gotc-prod`.
+- **Anybody can build them** — all functionality is encapsulated in the Dockerfile. Download custom software/dependencies from public links; never copy files from internal Broad infrastructure into an image.
+
+### Semantic tagging
+
+Use the semantic tag described in [Versioning strategy](#versioning-strategy); avoid rolling tags.
+
+### Proper process reaping
+
+In a container, PID 1 is responsible for reaping orphaned/zombie processes, but the default `/bin/sh` won't do it — risking resource leaks. Install [tini](https://github.com/krallin/tini/issues/8) (available via APK) and set it as the entrypoint:
+
+```dockerfile
+FROM alpine:3.9
+RUN set -eux; \
+        apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
+```
+
+### Build scripts and README
+
+Each image keeps an easy-to-use `docker_build.sh` next to its `Dockerfile`, with configurable inputs for tool versions, and writes published tags to an accompanying `docker_versions.tsv` automatically. Every image also has a `README.md` (use the [tool README template](TOOL_README_TEMPLATE.md)). See [3rd-party-tools/samtools](3rd-party-tools/samtools) for an example (`docker_build.sh`, `docker_versions.tsv`, `README.md`).
+
+### Formatting
+
+- `ARG`, `ENV`, `LABEL` in that order
+- Always include tool versions in `LABEL`
+- Single `RUN` step
+- Alphabetize package installs
+- Clean up the package-index cache
+- Use `;` (not `&&`) for line continuation
+- Logically separate steps within a `RUN`
+- Four-space indentation
+- Short comments describing each step
+- `tini` is always the default entrypoint
+
+```dockerfile
+# Debian base (packages here are not available in Alpine)
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian
+
+ARG GIT_HASH=c1cba76e979904eb69c31520a0d7f5be63c72253
+ENV TERM=xterm-256color \
+    BAMID_URL=https://github.com/Griffan/VerifyBamID/archive \
+    TINI_VERSION=v0.19.0
+LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
+        GIT_HASH=${GIT_HASH}
+WORKDIR /usr/gitc
+
+RUN set -eux; \
+        apt-get update; \
+        apt-get install -y autoconf cmake g++ gcc git unzip wget zlib1g-dev; \
+# Install tini
+    wget https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -O /sbin/tini; \
+    chmod +x /sbin/tini; \
+# Clean up cached files
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT [ "/sbin/tini", "--" ]
+```
+
+## Troubleshooting and running standalone
+
+WARP images are designed to run from their WDL pipelines. To run one independently for testing, start a shell explicitly:
+
+```bash
+docker run -it --rm <image-url> bash
+```
+
+Questions? File a [GitHub issue in WARP](https://github.com/broadinstitute/warp/issues/new).

--- a/README.md
+++ b/README.md
@@ -1,262 +1,49 @@
 # WARP-Tools
-This repository has the container that hosts all the scripts and tools that [WARP](https://github.com/broadinstitute/warp) uses.
 
-The project structure is straightforward and contains essentially just two types of directories: a tool directory, containing all our in-house tools, and a 3rd-party-tools directory which hosts all the third-party containers we use in our pipelines.
-Each directory contains it's own README that describes the tool or scripts, along with a usage guide. 
+WARP-Tools hosts the Docker images — and the in-house scripts and tools they contain — used by the [WARP](https://github.com/broadinstitute/warp) cloud-optimized pipelines. Each image is an execution environment for one or more processing steps in a WARP WDL workflow.
 
-## .github/workflows
-  This contains all YML files for automated container builds.
+This README is a map of the repository. For build instructions and the Dockerfile style guide see **[BUILDING.md](BUILDING.md)**; for agent/automation guidance see **[AGENTS.md](AGENTS.md)**.
 
----
+## Repository structure
 
-# Docker Style Guide
+| Path | What it is |
+| --- | --- |
+| `tools/` | The in-house **`warp-tools`** image — a single image bundling Broad-authored tools (`fastqpreprocessing` and `TagSort` in C++, plus helper `scripts/`). It has its own `Dockerfile`, `docker_build.sh`, `docker_versions.tsv`, and `warp-tools.changelog.md` at the top level. |
+| `3rd-party-tools/` | One subdirectory per third-party image (~57). Each contains a `Dockerfile`, a `docker_build.sh`, a `docker_versions.tsv`, a `README.md`, and any baked-in scripts/assets. |
+| `.github/workflows/` | CI. One `build-<tool>.yml` per image (builds & pushes to GCR), plus `trivy.yml` for vulnerability scanning. |
 
-This style guide provides formatting guidelines and best practices for writing Dockerfiles in WARP.
+Every image directory carries its own `README.md` describing the tool and its usage — see the [tool README template](TOOL_README_TEMPLATE.md) for the standard structure.
 
-## :book: Table of Contents
+## Where images live
 
-* [Overview](#overview)  
-* [Goals](#goals)
-  * [Small images](#small) 
-    * [Alpine base](#alpine)
-    * [Specifying image platform](#platform)
-    * [Minimal RUN steps](#minimal-run)
-  * [Publicly accessible](#publicly)
-  * [Image scanning](#scanning)
-  * [Semantic tagging](#semantic)
-  * [Proper process reaping](#process)
-* [Build Scripts and README](#build)
-* [Formatting](#formatting)
-* [Troubleshooting and running standalone](#trouble)
-## <a name="overview"></a> Overview
+All images are published to **Google Container Registry (GCR)**, the single source of truth:
 
-WARP maintains a collection of docker images which are used as execution environments for various cloud-optimized data processing pipelines. Many of these image require specific sets of tools and dependencies to run and can be thought of as _custom_ images rather than traditional application images. 
-Building and maintaining these images can be challenging; this document provides a set of guidelines to assist in developing docker images for WARP.
-
-## <a name="goals"></a> Goals
-
-The following are some goals/guidelines we want to strive for when writing our Dockerfiles.
-
-### <a name="small"></a> Small images
-
-Building a smaller image offers advantages such as faster upload and download times along with reduced storage costs and minimized attack vector. Two of the easiest ways to minimize the size of your image is to use a small base image and to reduce the number of layers in your image.
-
-#### <a name="alpine"></a> Alpine base
-
-The easiest way to have a small image is to use an [Alpine](https://alpinelinux.org/) base image. Alpine linux, compared to Debian, RHEL etc., is designed specifically for security and resource efficiency, and lends itself perfectly to be used as a building block for Docker images.
-
-Along with being a small base, Alpine also has built in deletion of package index and provides [tini](https://github.com/krallin/tini) natively through APK.
-
-There are some instances where a Debian base image is unavoidable, specifically in the case where dependencies don't exist in APK. It is suggested that you only go to a Debian base as a last resort.
-
-
-##### :eyes: Example
-```dockerfile
-
-#OKAY, NOT GREAT - uses debian
-FROM python:debian
-
-RUN set -eux; \
-        apt-get update; \
-        apt-get install -y \
-            curl \
-            bash \
-    ; \
-# Must clean up cache manually with Debian
-    apt-get clean && rm -rf /var/lib/apt/list/*
-
-# GOOD - uses alpine
-FROM alpine:3.9
-
-RUN set -eux; \
-        apk add --no-cache \
-            curl \
-            bash \
+```text
+us.gcr.io/broad-gotc-prod/<image>
 ```
 
-#### <a name="platform"></a> Specifying image platform
+There is no Quay or other mirror.
 
-Docker images built on ARM-based machines such as the new M-series Macs may run into execution issues with our automated PR test suite.
-One way to avoid these issues is to use a `linux/amd64` base image by including the `--platform="linux/amd64` flag after the `FROM` keyword.
+## Versioning strategy
 
-##### :eyes: Example
-```dockerfile
-# Use the amd64 version of alpine
-FROM --platform="linux/amd64" alpine
+Images use **semantic tags** (never rolling tags like `latest`/`master`):
+
+```text
+us.gcr.io/broad-gotc-prod/<image>:<image-version>-<tool-version>-<unix-timestamp>
 ```
 
-#### <a name="minimal-run"></a> Minimal RUN steps
+- **`image-version`** — `major.minor.patch` of the image; bumped for image-level changes (base OS, system packages, baked-in scripts).
+- **`tool-version`** — version of the wrapped tool (e.g. `samtools` `1.19`).
+- **`unix-timestamp`** — keeps every tag unique and avoids Cromwell image-cache collisions.
 
-Having minimal `RUN`steps (ideally one) is another highly effective way to reduce the size of your image. Each instruction in a Dockerfile creates a [layer](https://docs.docker.com/storage/storagedriver/) and these layers are what add up to build the final image.
-When you use multiple `RUN` steps it creates additional unnecessary layers and bloats your image.
+Each image's `docker_versions.tsv` records every published tag; the **last line is the version currently used by WARP**. WARP pipelines pin images by **immutable `@sha256` digest**, so a pipeline always runs an exact image — see [How images are consumed by WARP](BUILDING.md#how-images-are-consumed-by-warp-digest-pinning).
 
-An alternative to having a single `RUN` step is to use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) which are effective when the application you are containerizing is just a statically linked binary. 
-Just to note, many of the images maintained in WARP require a handful of system-level dependencies and custom packages so multi-stages builds are typically not used.
+## Building images
 
-##### :eyes: Example
-```dockerfile
-
-# BAD - uses multiple RUN steps
-RUN set -eux
-RUN apk add --no-cache curl bash wget
-RUN wget https://www.somezipfile.com/zip
-RUN unzip zip
-
-# GOOD - uses single RUN step
-RUN set -eux; \
-        apk add --no-cache \
-            curl \
-            bash \
-    ; \
-    wget https://www.somezipfile.com/zip; \
-    unzip zip
-```
-
-### <a name="publicly"></a> Publicly accessible
-
-The pipelines that we maintain in WARP are designed for public use, ideally we would like our docker images to be publicly available as well. This would mean the following conditions must be true.
-
-* Anybody can pull our images
-* Anybody can build our images
-
-For anybody to be able to pull our images they must be hosted on a public container registry, we host all of our images in public repos on GCR (our 'official' location) and Quay (for discoverability).
-
-* GCR - `us.gcr.io/broad-gotc-prod`
-* Quay - `quay.io/broadinstitute/broad-gotc-prod`
-
-For anybody to be able to build our images, all functionality should be encapsulated in the Dockerfile. Any custom software packages, dependencies etc. have to be downloaded from public links within the Dockerfile, this obviously means that we should not be copying files from within the Broad network infrastructure into our images.
-
-### <a name="scanning"></a> Image scanning
-
-
-All images that we build are scanned for critical vulnerabilities on every pull request. For this we use a github-action that leverages [trivy](https://github.com/aquasecurity/trivy) for scanning. If you build a new image please add it to the action [here](../.github/workflows/trivy.yml).
-
-### <a name="semantic"></a> Semantic tagging
-
-
-We recommend against using rolling tags like `master` or `latest` when building images. Rolling tags make it hard to track down versions of images since the underlying image hash and content could be different across the same tags. Instead, we ask that you use a semantic tag that follows the convention below:
-
-##### `us.gcr.io/broad-gotc-prod/samtools:<image-version>-<samtools-version>-<unix-timestamp>`
-
-This example is for an image we use containing `samtools`. The 'image-version' in this case is the traditional `major.minor.patch` version of the image being built, which is updated when changes to the image (underlying OS, system level packages, etc.) unrelated to `samtools` are made. The 'samtools-version' here correlates with the specific version of `samtools` being used, having this information in the tag makes it easy for users to identify and not have to track down. Lastly, a unix timestamp in included to avoid any potential issues with Cromwell image caching.
-
-### <a name="process"></a> Proper process reaping
-
-
-Classic init systems like systemd are used to reap orphaned, zombie processes. Typically, these orphaned processes are reattached to the process at PID 1 which will reap them when they die. In a container this responsibility falls to process at PID 1 which is by default `/bin/sh`...this obviously will not handle process reaping. Because of this you run the risk of expending excess memory or resources within your container. A simple solution to this is to use `tini` in all of our images, a lengthy explanation of what this package does can be found [here](https://github.com/krallin/tini/issues/8).
-
-Luckily `tini` is available natively through APK so all you have to do is install it and set it as the default entrypoint!
-
-##### :eyes: Example
-```dockerfile
-
-FROM alpine:3.9
-
-RUN set -eux; \
-        apk add --no-cache \
-            tini
-
-ENTRYPOINT ["/sbin/tini" , "--"]
-```
-
-## <a name="build"></a> Build Scripts and README
-
-To make life easier when building and pushing our images we like to have an easy-to-use `docker_build.sh` that sits next to each Dockerfile. These scripts should have configurable inputs for the version of tools (samtools, picard, zcall, etc.) being used in the image. Additionally, we like to keep a record of the versions built and being used by writing the images to the accompanying `docker_versions.tsv`, this should be done automatically by your build script.
-
-For first time users of these images it is helpful to have a README which gives a high-level overview of the image.
-
-See the examples for samtools([docker_build](./broad/samtools/docker_build.sh), [docker_versions](./broad/samtools/docker_versions.tsv), [README](./broad/samtools/README.md))
-
-## Formatting
-
-Formatting our Dockerfiles consistently helps improve readability and eases maintenance headaches down the road. The following are a couple of tenants that we follow when writing our Dockerfiles:
-
-* ARGS, ENV, LABEL in that order
-* Always add versions of tools in the LABEL
-* Single RUN steps
-* Alphabetize package install
-* Clean up package index cache
-* Use ; instead of && for line continuation
-* Logically separate steps within RUN
-* Four spaces per tab indent
-* Short comments to describe each step
-* tini is always default entrypoint
-
-The following is a good example for our `verify_bam_id` image. This Dockerfile shows how to install packages, install tini and clean up cached index files for a debian base image.
-
-##### :eyes: Example
-```dockerfile
-# Have to use debian based image, many of the installed packages here are not available in Alpine
-FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian
-
-ARG GIT_HASH=c1cba76e979904eb69c31520a0d7f5be63c72253
-
-ENV TERM=xterm-256color \
-    BAMID_URL=https://github.com/Griffan/VerifyBamID/archive \
-    TINI_VERSION=v0.19.0
-
-LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
-        GIT_HASH=${GIT_HASH}
-
-WORKDIR /usr/gitc
-
-# Install dependencies
-RUN set -eux; \
-        apt-get update; \
-        apt-get install -y \
-            autoconf \
-            cmake \
-            g++ \
-            gcc \
-            git \
-            libbz2-dev \
-            libcurl4-openssl-dev \
-            libhts-dev \
-            libssl-dev  \
-            unzip \
-            wget \
-            zlib1g-dev \
-    ; \
-# Install BamID
-    wget ${BAMID_URL}/${GIT_HASH}.zip; \
-    unzip ${GIT_HASH}.zip; \
-    \
-    cd VerifyBamID-${GIT_HASH}; \
-    mkdir build;  \
-    cd build; \
-    CC=$(which gcc) CXX=$(which g++) cmake ..; \
-    \
-    cmake; \
-    make; \
-    make test; \
-    \
-    cd ../../; \
-    mv VerifyBamID-${GIT_HASH}/bin/VerifyBamID .; \
-    rm -rf ${GIT_HASH}.zip VerifyBamID-${GIT_HASH} \
-    ; \
-# Install tini
-    wget https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini -O /sbin/tini; \
-    chmod +x /sbin/tini \
-    ; \
-# Clean up cached files
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Set tini as default entrypoint
-ENTRYPOINT [ "/sbin/tini", "--" ]
-```
-
-## <a link="trouble"></a> Troubleshooting and running standalone
-
-The WARP dockers are designed to be run from their respective WDL pipelines. However, if you need to run a Docker independent of a WDL for testing or troubleshooting, you'll likely need to explicity instruct it to run a `bash` shell in the `run` command. An example of this is shown in the terminal command below: 
-
-```bash
-docker run -it --rm <docker url> bash
-```
-
-If you have any questions or would like some more guidance on writing Dockerfiles please file a [GitHub issue in WARP](https://github.com/broadinstitute/warp/issues/new).
+Images are built by CI: open a pull request that touches an image's directory and its `build-<tool>.yml` workflow builds and pushes it to GCR (tagged by branch). A `docker_build.sh` next to each Dockerfile supports local builds. Full details, plus the Dockerfile style guide and how to add a new image, are in **[BUILDING.md](BUILDING.md)**.
 
 ## Citing WARP and WARP-Tools
 
 When citing WARP and WARP-Tools, please use the following:
 
-Degatano, K.; Awdeh, A.; Dingman, W.; Grant, G.; Khajouei, F.; Kiernan, E.; Konwar, K.; Mathews, K.; Palis, K.; Petrillo, N.; Van der Auwera, G.; Wang, C.; Way, J.; Pipelines, W. WDL Analysis Research Pipelines: Cloud-Optimized Workflows for Biological Data Processing and Reproducible Analysis. Preprints 2024, 2024012131. https://doi.org/10.20944/preprints202401.2131.v1
+Degatano, K.; Awdeh, A.; Dingman, W.; Grant, G.; Khajouei, F.; Kiernan, E.; Konwar, K.; Mathews, K.; Palis, K.; Petrillo, N.; Van der Auwera, G.; Wang, C.; Way, J.; Pipelines, W. WDL Analysis Research Pipelines: Cloud-Optimized Workflows for Biological Data Processing and Reproducible Analysis. Preprints 2024, 2024012131. <https://doi.org/10.20944/preprints202401.2131.v1>

--- a/TOOL_README_TEMPLATE.md
+++ b/TOOL_README_TEMPLATE.md
@@ -1,0 +1,116 @@
+<!--
+WARP-Tools image README template.
+
+Copy this file to <image-dir>/README.md and fill in every section. Delete the
+HTML comments. Keep it accurate and runnable: every command should work if
+copy-pasted. Required sections: Synopsis, Inputs, Outputs, Usage, Task
+descriptions. The others are recommended; drop a section only if it genuinely
+does not apply (and say why). See 3rd-party-tools/scvi-scanvi/README.md for a
+worked example, and BUILDING.md for build/versioning conventions.
+-->
+
+# <Image Name>
+
+## Quick reference
+
+<!-- One copy-pasteable pull command (current tag from docker_versions.tsv) and a
+one-line description of what this image is. -->
+
+```bash
+docker pull us.gcr.io/broad-gotc-prod/<image>:<image-version>-<tool-version>-<unix-timestamp>
+```
+
+- **What is this image:** <one-sentence description of the image and its base OS>
+- **What is `<tool>`:** <one-sentence description of the wrapped tool, with a link to its upstream docs>
+
+## Synopsis
+
+<!-- 2-4 sentences: what the tool/scripts in this image do, and what role the
+image plays in WARP (which pipeline/step consumes it, and why it exists). -->
+
+## Image contents
+
+<!-- The base image and the key tools/libraries with their pinned versions.
+A short bullet list is fine. -->
+
+- Base image: `<base>`
+- `<tool>` `<version>`
+- `<library>` `<version>`
+- Scripts: `<script1>`, `<script2>` (see [Scripts](#scripts))
+
+## Versioning
+
+This image follows the WARP-Tools tag convention
+`us.gcr.io/broad-gotc-prod/<image>:<image-version>-<tool-version>-<unix-timestamp>`
+(see [BUILDING.md → Versioning strategy](../../BUILDING.md#versioning-strategy)).
+Past versions are tracked in [docker_versions.tsv](docker_versions.tsv); the last
+line is the version currently used by WARP. Inspect an image with:
+
+```bash
+docker inspect us.gcr.io/broad-gotc-prod/<image>:<tag>
+```
+
+## Scripts
+
+<!-- OPTIONAL: list each independent script (Python/C++/etc.) baked into the image
+and what it does. Omit if the image wraps a single binary with no custom scripts. -->
+
+| Script | Language | Purpose |
+| --- | --- | --- |
+| `<script.py>` | Python | <what it does> |
+
+## Inputs
+
+<!-- The inputs the tool/scripts consume: command-line arguments, input files and
+their formats. If there are multiple scripts/entrypoints, group by script. Be
+explicit about file formats (e.g. AnnData .h5ad, BAM, GTF) and required columns/fields. -->
+
+| Input | Type / format | Required | Description |
+| --- | --- | --- | --- |
+| `<--arg>` | `<type>` | yes/no | <description> |
+| `<input file>` | `<format>` | yes/no | <description> |
+
+## Outputs
+
+<!-- The files/artifacts produced, with formats and (if useful) where they are written. -->
+
+| Output | Format | Description |
+| --- | --- | --- |
+| `<output file>` | `<format>` | <description> |
+
+## Usage
+
+<!-- Runnable examples. Show the docker run invocation and the script/tool command(s).
+Include a minimal end-to-end example with representative arguments. -->
+
+Run an interactive shell in the image:
+
+```bash
+docker run --rm -it us.gcr.io/broad-gotc-prod/<image>:<tag> bash
+```
+
+Run the tool/script:
+
+```bash
+<command with representative arguments>
+```
+
+## Task descriptions
+
+<!-- How WARP consumes this image: which pipeline(s)/WDL task(s) use it, and how
+(e.g. "imports run_multi_model from /usr/local", or "invoked as `<binary> ...`").
+Link to the consuming pipeline. This is the bridge back to WARP. -->
+
+- **Pipeline:** [`<Pipeline>`](https://github.com/broadinstitute/warp/tree/develop/pipelines/wdl/<path>)
+- **Task(s):** <task name(s)> — <how the image is invoked / what functions are imported>
+
+## Requirements / dependencies
+
+<!-- OPTIONAL: notable runtime requirements (e.g. GPU, network access at runtime,
+large memory/disk), and how to install deps if running scripts standalone. -->
+
+## Troubleshooting
+
+To run the image independently of a WDL for testing, start a shell explicitly
+(`docker run -it --rm <image-url> bash`). See
+[BUILDING.md → Troubleshooting and running standalone](../../BUILDING.md#troubleshooting-and-running-standalone).


### PR DESCRIPTION
Add a GEX-only training entry point so the scANVI pipeline can train and annotate from the reference atlas using gene expression + reference alone, without ATAC data.

- Factor the shared SCVI/SCANVI training core out of run_multi_model into _concat_and_train_models(adatas, keys) to avoid drift between the multiome and GEX-only paths.
- run_gex_only_model(gex, ref) concatenates only GEX + reference, keeping the "rna_unannotated" modality key so downstream label propagation (gex.obs_names + '_rna_unannotated') is unchanged.
- Bump DOCKER_IMAGE_VERSION to 1.1.0.