### PR TITLE
TSPS-972 add version 1.1.0 for the glimpse docker image

### DIFF
--- a/3rd-party-tools/glimpse2/README.md
+++ b/3rd-party-tools/glimpse2/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2a1a895-1777494633`
+#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248`
 
 - __What is this image:__ This image is built using a local two-stage build script ([docker_build.sh](docker_build.sh)) for running GLIMPSE2 in imputation pipelines.
 - __What is GLIMPSE2:__ GLIMPSE2 is a set of tools for phasing and imputation of low-coverage sequencing datasets. See [here](https://odelaneau.github.io/GLIMPSE/) for more information.

--- a/3rd-party-tools/glimpse2/docker_versions.tsv
+++ b/3rd-party-tools/glimpse2/docker_versions.tsv
@@ -1,1 +1,2 @@
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818
+us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248


### PR DESCRIPTION
This is to incorporate the vcf streaming fix from glimpse.  This docker image is being used in https://github.com/broadinstitute/warp/pull/1875.

commit hash from the glimpse repo - https://github.com/odelaneau/GLIMPSE/commit/c2767645eaaab0d1ac0acec4307b552f2960feb0

GHA creating the image - https://github.com/broadinstitute/warp-tools/actions/runs/28462378994


JIRA ticket: https://broadworkbench.atlassian.net/browse/TSPS-972