### PR TITLE
scANVI finalize_output: add data_modality, relabel library_preparatio…

### DIFF
--- a/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
+++ b/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
@@ -374,8 +374,8 @@ def finalize_output(scanvi_output):
         "disease__ontology_label": "normal",
         "organ": "UBERON_0000955",
         "organ__ontology_label": "brain",
-        "library_preparation_protocol": "EFO_0030059",
-        "library_preparation_protocol__ontology_label": "Simultaneous profiling of gene expression and open chromatin from the same cell.",
+        "library_preparation_protocol": "Chromium Single Cell Multiome ATAC + Gene Expression",
+        "data_modality": "Simultaneous profiling of gene expression and open chromatin from the same cell.",
         "sex": "unknown"
     }
 

--- a/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
+++ b/3rd-party-tools/scvi-scanvi/multiome_label_transfer.py
@@ -374,7 +374,8 @@ def finalize_output(scanvi_output):
         "disease__ontology_label": "normal",
         "organ": "UBERON_0000955",
         "organ__ontology_label": "brain",
-        "library_preparation_protocol": "Chromium Single Cell Multiome ATAC + Gene Expression",
+        "library_preparation_protocol": "EFO_0030059",
+        "library_preparation_protocol__ontology_label": "10x multiome",
         "data_modality": "Simultaneous profiling of gene expression and open chromatin from the same cell.",
         "sex": "unknown"
     }


### PR DESCRIPTION
…n_protocol

Move the multiome description ('Simultaneous profiling of gene expression and open chromatin from the same cell.') into a new data_modality obs field, and set library_preparation_protocol to 'Chromium Single Cell Multiome ATAC + Gene Expression' (replacing the prior EFO_0030059 id + library_preparation_protocol__ontology_label pair).