### PR TITLE
TSPS-1024 add 1.2.0 version image for glimpse2

### DIFF
--- a/3rd-party-tools/glimpse2/README.md
+++ b/3rd-party-tools/glimpse2/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248`
+#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771`
 
 - __What is this image:__ This image is built using a local two-stage build script ([docker_build.sh](docker_build.sh)) for running GLIMPSE2 in imputation pipelines.
 - __What is GLIMPSE2:__ GLIMPSE2 is a set of tools for phasing and imputation of low-coverage sequencing datasets. See [here](https://odelaneau.github.io/GLIMPSE/) for more information.

--- a/3rd-party-tools/glimpse2/docker_build.sh
+++ b/3rd-party-tools/glimpse2/docker_build.sh
@@ -17,7 +17,7 @@ set -e
 
 # Variables and defaults
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.0.0
+DOCKER_IMAGE_VERSION=1.2.0
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 

--- a/3rd-party-tools/glimpse2/docker_versions.tsv
+++ b/3rd-party-tools/glimpse2/docker_versions.tsv
@@ -1,2 +1,3 @@
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248
+us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771


### PR DESCRIPTION
This PR adds a glimpse docker image that contains the optimizations made to Glimpse 2.  This are changes we want to incorportate for our scale testing and generally for future versions of low pass.

Glimpse repo commit this is built from - 867113849925f3100bf8ff125e2b9eb1eff51b37 - https://github.com/odelaneau/GLIMPSE/commit/867113849925f3100bf8ff125e2b9eb1eff51b37

GHA building this image - https://github.com/broadinstitute/warp-tools/actions/runs/29881804693

Jira ticket - https://broadworkbench.atlassian.net/browse/TSPS-1024