### PR TITLE
[TSPS-1132] Fix GCR path in bcftools-vcftools build script

### DIFF
--- a/3rd-party-tools/bcftools-vcftools/README.md
+++ b/3rd-party-tools/bcftools-vcftools/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:2.0.0-1.24-0.1.17-1784569943`
+#### `us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943`
 
 - __What is this image:__ This image is a lightweight alpine-based image for running BCFtools and VCFtools for the [Imputation pipeline](../../../../pipelines/broad/arrays/imputation/Imputation.wdl) and the ImputationBeagle pipeline.
 - __What are BFCtools and VCFtools:__ BCFtools and VCFtools are a suite of tools for variant calling and manipulating BCFs and VCFs. See [here](https://github.com/samtools/vcftools) and [here](https://vcftools.github.io/man_latest.html) more information.
@@ -14,15 +14,15 @@ Copy and paste to pull this image
 
 The Imputation BCFtools VCFtools image uses the following convention for versioning:
 
-#### `us.gcr.io/broad-gotc-prod/samtools:<image-version>-<bcftools-version>-<vcftools-version>-<unix-timestamp>` 
+#### `us.gcr.io/broad-gotc-prod/bcftools-vcftools:<image-version>-<bcftools-version>-<vcftools-version>-<unix-timestamp>` 
 
 We keep track of all past versions in [docker_versions](docker_versions.tsv) with the last image listed being the currently used version in WARP.
 
 You can see more information about the image, including the tool versions, by running the following command:
 
 ```bash
-$ docker pull us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:2.0.0-1.24-0.1.17-1784569943
-$ docker inspect us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:2.0.0-1.24-0.1.17-1784569943
+$ docker pull us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943
+$ docker inspect us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943
 ```
 
 ## Usage
@@ -31,12 +31,12 @@ $ docker inspect us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:2.0.0-1.24-0.1.17-
 
 ```bash
 $ docker run --rm -it \
-    us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:2.0.0-1.24-0.1.17-1784569943 bcftools
+    us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943 bcftools
 ```
 
 ### Display VCFtools default menu
 
 ```bash
 $ docker run --rm -it \
-    us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:2.0.0-1.24-0.1.17-1784569943 vcftools
+    us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943 vcftools
 ```

--- a/3rd-party-tools/bcftools-vcftools/docker_build.sh
+++ b/3rd-party-tools/bcftools-vcftools/docker_build.sh
@@ -7,7 +7,7 @@ TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 
 # Registries and tags
-GCR_URL="us.gcr.io/broad-gotc-prod/imputation-bcf-vcf"
+GCR_URL="us.gcr.io/broad-gotc-prod/bcftools-vcftools"
 # QUAY_URL="quay.io/broadinstitute/gotc-prod-imputation_bcf_vcf"
 
 #BCFTOOLS version

--- a/3rd-party-tools/bcftools-vcftools/docker_versions.tsv
+++ b/3rd-party-tools/bcftools-vcftools/docker_versions.tsv
@@ -8,4 +8,4 @@ us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.4-1.10.2-0.1.16-1646091598
 us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.5-1.10.2-0.1.16-1649948623
 us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.6-1.10.2-0.1.16-1663946207
 us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:1.0.7-1.10.2-0.1.16-1669908889
-us.gcr.io/broad-gotc-prod/imputation-bcf-vcf:2.0.0-1.24-0.1.17-1784569943
+us.gcr.io/broad-gotc-prod/bcftools-vcftools:2.0.0-1.24-0.1.17-1784569943


### PR DESCRIPTION
Jira - https://broadworkbench.atlassian.net/browse/TSPS-1132

It seems few years ago the GHA that builds bcftools-vcftools had updated the GCR path to `us.gcr.io/broad-gotc-prod/bcftools-vcftools` but the `docker_build.sh` script was still pointing to `us.gcr.io/broad-gotc-prod/imputation-bcf-vcf`. 

This PR updates GCR path to bcftools-vcftools as the last push to `imputation-bcf-vcf` was Dec 2022 while `bcftools-vcftools` has pushes in last few years. 