### PR TITLE
[TSPS-1128] Update bcftools used by glimpse2 build (v 1.21 -> 1.24)

### DIFF
--- a/3rd-party-tools/glimpse2/Dockerfile
+++ b/3rd-party-tools/glimpse2/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /docker_build/
 RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-17-jre-headless curl python3
 
 # Download and build bcftools
-RUN wget https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.tar.bz2 && \
+RUN wget https://github.com/samtools/bcftools/releases/download/1.24/bcftools-1.24.tar.bz2 && \
 tar -xf bcftools-1.21.tar.bz2 && \
 rm bcftools-1.21.tar.bz2 && \
 cd bcftools-1.21 && \

--- a/3rd-party-tools/glimpse2/Dockerfile
+++ b/3rd-party-tools/glimpse2/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y openjd
 
 # Download and build bcftools
 RUN wget https://github.com/samtools/bcftools/releases/download/1.24/bcftools-1.24.tar.bz2 && \
-tar -xf bcftools-1.21.tar.bz2 && \
-rm bcftools-1.21.tar.bz2 && \
-cd bcftools-1.21 && \
+tar -xf bcftools-1.24.tar.bz2 && \
+rm bcftools-1.24.tar.bz2 && \
+cd bcftools-1.24 && \
 autoheader && \
 autoconf && \
 ./configure --enable-libcurl && \

--- a/3rd-party-tools/glimpse2/Dockerfile
+++ b/3rd-party-tools/glimpse2/Dockerfile
@@ -15,7 +15,7 @@ autoconf && \
 ./configure --enable-libcurl && \
 make install && \
 cd .. && \
-rm -r bcftools-1.21
+rm -r bcftools-1.24
 
 # Download picard (for updating sequence dictionary)
 RUN wget https://github.com/broadinstitute/picard/releases/download/3.4.0/picard.jar && \

--- a/3rd-party-tools/glimpse2/README.md
+++ b/3rd-party-tools/glimpse2/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.3.0-UPDATE-TO-FINAL`
+#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.3.0-8671138-1785933808`
 
 - __What is this image:__ This image is built using a local two-stage build script ([docker_build.sh](docker_build.sh)) for running GLIMPSE2 in imputation pipelines.
 - __What is GLIMPSE2:__ GLIMPSE2 is a set of tools for phasing and imputation of low-coverage sequencing datasets. See [here](https://odelaneau.github.io/GLIMPSE/) for more information.

--- a/3rd-party-tools/glimpse2/README.md
+++ b/3rd-party-tools/glimpse2/README.md
@@ -4,7 +4,7 @@
 
 Copy and paste to pull this image
 
-#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771`
+#### `docker pull us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.3.0-UPDATE-TO-FINAL`
 
 - __What is this image:__ This image is built using a local two-stage build script ([docker_build.sh](docker_build.sh)) for running GLIMPSE2 in imputation pipelines.
 - __What is GLIMPSE2:__ GLIMPSE2 is a set of tools for phasing and imputation of low-coverage sequencing datasets. See [here](https://odelaneau.github.io/GLIMPSE/) for more information.

--- a/3rd-party-tools/glimpse2/docker_build.sh
+++ b/3rd-party-tools/glimpse2/docker_build.sh
@@ -17,7 +17,7 @@ set -e
 
 # Variables and defaults
 # Update version when changes to Dockerfile are made
-DOCKER_IMAGE_VERSION=1.2.0
+DOCKER_IMAGE_VERSION=1.3.0
 TIMESTAMP=$(date +"%s")
 DIR=$(cd $(dirname $0) && pwd)
 

--- a/3rd-party-tools/glimpse2/docker_versions.tsv
+++ b/3rd-party-tools/glimpse2/docker_versions.tsv
@@ -1,3 +1,4 @@
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771
+us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.3.0-UPDATE-TO-FINAL

--- a/3rd-party-tools/glimpse2/docker_versions.tsv
+++ b/3rd-party-tools/glimpse2/docker_versions.tsv
@@ -1,4 +1,4 @@
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.0.0-2cee597-1778869818
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.1.0-c276764-1782839248
 us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.2.0-8671138-1784681771
-us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.3.0-UPDATE-TO-FINAL
+us.gcr.io/broad-gotc-prod/imputation-glimpse2:1.3.0-8671138-1785933808


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TSPS-1128

Updates bcftools from 1.21 to 1.24