### PR TITLE
TSPS-1049 New image containing gatk, bcftools, gcloud (used in Glimpse SV QC wdl)

### DIFF
--- a/.github/workflows/build-gatk-bcftools-gcloud.yml
+++ b/.github/workflows/build-gatk-bcftools-gcloud.yml
@@ -1,0 +1,59 @@
+name: GATK BCFtools gcloud CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "develop" and "master" branch
+  pull_request:
+    branches: [ "develop", "master" ]
+    paths:
+      - '3rd-party-tools/gatk-bcftools-gcloud/**'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker Image Tag (default: branch_name)'
+
+env:
+  PROJECT_NAME: WARP 3rd Party Tools
+  # Github repo name
+  REPOSITORY_NAME: ${{ github.event.repository.name }}
+  # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
+  DOCKER_REGISTRY: us.gcr.io
+  GCR_PATH: broad-gotc-prod/gatk-bcftools-gcloud
+  TAG: ${{ github.event.inputs.image_tag || github.head_ref || github.ref_name }}
+
+  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # The job that builds our container
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: 3rd-party-tools/gatk-bcftools-gcloud
+    # Map a step output to a job output
+    outputs:
+      imagePath: ${{ steps.saveImagePath.outputs.url }}
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}
+    - name: Check working directory'
+      run: |
+        echo "Current directory: "
+        pwd
+        ls -lht
+    # Save the image path to an output
+    - id: 'saveImagePath'
+      run: echo "url=${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}" >> $GITHUB_OUTPUT
+    # Log into the Google Docker registry
+    - id: 'Auth'
+      name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.DOCKER_REGISTRY }}
+        username: _json_key
+        password: ${{ secrets.GCR_CI_KEY }}
+    # Push the image to the Google Docker registry
+    - name: Push image
+      run: "docker push ${DOCKER_REGISTRY}/${GCR_PATH}:${TAG}"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,6 +17,7 @@ jobs:
         - 3rd-party-tools/arrays-picard-private
         - 3rd-party-tools/dragmap
         - 3rd-party-tools/gatk
+        - 3rd-party-tools/gatk-bcftools-gcloud
         - 3rd-party-tools/illumina-iaap-autocall
         - 3rd-party-tools/picard-python
         - 3rd-party-tools/verify-bam-id

--- a/3rd-party-tools/gatk-bcftools-gcloud/Dockerfile
+++ b/3rd-party-tools/gatk-bcftools-gcloud/Dockerfile
@@ -1,0 +1,80 @@
+# Adding a platform tag to ensure that images built on ARM-based machines doesn't break pipelines
+FROM --platform="linux/amd64" eclipse-temurin:8-jdk-alpine
+
+ARG BCFTOOLS_VERSION=1.24 \
+        GATK4_VERSION=4.2.6.1
+
+ENV TERM=xterm-256color \
+    GATK4_URL=https://github.com/broadinstitute/gatk/releases/download/${GATK4_VERSION}/gatk-${GATK4_VERSION}.zip \
+    PATH=$PATH:/usr/gitc/gatk4:/root/google-cloud-sdk/bin
+
+LABEL MAINTAINER="Broad Institute DSDE <dsde-engineering@broadinstitute.org>" \
+        BCFTOOLS_VERSION=${BCFTOOLS_VERSION} \
+        GATK4_VERSION=${GATK4_VERSION}
+
+WORKDIR /usr/gitc
+
+# Install dependencies
+RUN set -eux; \
+        apk add --no-cache \
+            autoconf \
+            automake \
+            bash \
+            bzip2-dev \
+            curl \
+            curl-dev \
+            g++ \
+            gcc \
+            make \
+            musl-dev \
+            python3 \
+            tini \
+            unzip \
+            wget \
+            xz-dev \
+            zlib-dev \
+    ; \
+# Install GATK
+    mkdir gatk4; \
+    mkdir temp; \
+    cd temp; \
+    \
+    wget ${GATK4_URL}; \
+    unzip gatk-${GATK4_VERSION}.zip; \
+    cp -r gatk-${GATK4_VERSION}/* /usr/gitc/gatk4/; \
+    chmod +x /usr/gitc/gatk4/gatk; \
+    \
+    cd ..; \
+    rm -r temp \
+    ; \
+# Install BCFtools
+    wget https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2; \
+    tar xf bcftools-${BCFTOOLS_VERSION}.tar.bz2; \
+    cd bcftools-${BCFTOOLS_VERSION}; \
+    \
+    ./configure; \
+    make; \
+    make install; \
+    \
+    cd ../; \
+    rm -r bcftools-${BCFTOOLS_VERSION}; \
+    rm bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
+    ; \
+# Install HTSlib
+    wget https://github.com/samtools/samtools/releases/download/${BCFTOOLS_VERSION}/samtools-${BCFTOOLS_VERSION}.tar.bz2; \
+    tar xf samtools-${BCFTOOLS_VERSION}.tar.bz2; \
+    cd samtools-${BCFTOOLS_VERSION}/htslib-${BCFTOOLS_VERSION}; \
+    \
+    ./configure; \
+    make; \
+    make install; \
+    \
+    cd ../..; \
+    rm -r samtools-${BCFTOOLS_VERSION}; \
+    rm samtools-${BCFTOOLS_VERSION}.tar.bz2 \
+    ; \
+# Install gcloud CLI
+    curl -sSL https://sdk.cloud.google.com | bash
+
+# Set tini as default entrypoint
+ENTRYPOINT [ "/sbin/tini", "--" ]

--- a/3rd-party-tools/gatk-bcftools-gcloud/README.md
+++ b/3rd-party-tools/gatk-bcftools-gcloud/README.md
@@ -1,0 +1,83 @@
+# GATK BCFtools gcloud
+
+## Quick reference
+
+Copy and paste to pull this image (see [docker_versions.tsv](docker_versions.tsv) for the current tag once published)
+
+```bash
+docker pull us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:<image-version>-<gatk4-version>-<bcftools-version>-<unix-timestamp>
+```
+
+- **What is this image:** A lightweight Alpine-based image bundling GATK4, BCFtools, and the Google Cloud CLI (`gcloud`/`gsutil`) in a single execution environment for WDL tasks that need all three.
+- **What is `GATK`:** GATK (Genome Analysis Toolkit) is the industry standard for identifying SNPs and indels in germline DNA and RNAseq data. See [here](https://gatk.broadinstitute.org/hc/en-us) for more information.
+- **What is `BCFtools`:** A suite of tools for variant calling and manipulating BCFs and VCFs. See [here](https://github.com/samtools/bcftools) for more information.
+- **What is `gcloud`:** The Google Cloud CLI, providing `gcloud` and `gsutil` for interacting with Google Cloud Storage and other GCP services from within a task. See [here](https://cloud.google.com/sdk/gcloud) for more information.
+
+## Synopsis
+
+This image combines [gatk](../gatk) and the BCFtools portion of [bcftools-vcftools](../bcftools-vcftools) with the Google Cloud CLI so that a single WDL task can run GATK4, BCFtools, and `gcloud`/`gsutil` commands without needing to localize/delocalize files through a separate task. It's intended for pipeline steps that mix variant-calling/manipulation with direct GCS access (e.g. streaming a file from a bucket mid-task).
+
+## Image contents
+
+- Base image: `eclipse-temurin:8-jdk-alpine`
+- `gatk4` `4.2.6.1`
+- `bcftools` `1.24`
+- `htslib` `1.24`
+- Google Cloud CLI (`gcloud`, `gsutil`)
+
+## Versioning
+
+This image follows the WARP-Tools tag convention
+`us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:<image-version>-<gatk4-version>-<bcftools-version>-<unix-timestamp>`
+(see [BUILDING.md → Versioning strategy](../../BUILDING.md#versioning-strategy)).
+Past versions are tracked in [docker_versions.tsv](docker_versions.tsv); the last
+line is the version currently used by WARP. Inspect an image with:
+
+```bash
+docker inspect us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:<tag>
+```
+
+## Usage
+
+Run an interactive shell in the image:
+
+```bash
+docker run --rm -it us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:<tag> bash
+```
+
+### GATK4
+
+```bash
+$ docker run --rm -it \
+    -v /gatk-files:/gatk-files \
+    us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:<tag> gatk --java-options "-Xms2000m -Xmx2500m" \
+    PrintReads \
+    -I /gatk-files/input_bam \
+    --interval-padding 500 \
+    -L /gatk-files/interval_list \
+    -O /gatk-files/local.sharded.bam
+```
+
+### BCFtools
+
+```bash
+$ docker run --rm -it \
+    us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:<tag> bcftools
+```
+
+### gcloud / gsutil
+
+```bash
+$ docker run --rm -it \
+    us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:<tag> gsutil ls gs://<bucket>/
+```
+
+## Task descriptions
+
+- **Pipeline:** TBD — fill in once a WARP pipeline task is wired to this image.
+
+## Troubleshooting
+
+To run the image independently of a WDL for testing, start a shell explicitly
+(`docker run -it --rm <image-url> bash`). See
+[BUILDING.md → Troubleshooting and running standalone](../../BUILDING.md#troubleshooting-and-running-standalone).

--- a/3rd-party-tools/gatk-bcftools-gcloud/docker_build.sh
+++ b/3rd-party-tools/gatk-bcftools-gcloud/docker_build.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+# Update version when changes to Dockerfile are made
+DOCKER_IMAGE_VERSION=1.0.0
+TIMESTAMP=$(date +"%s")
+DIR=$(cd $(dirname $0) && pwd)
+
+# Registries and tags
+GCR_URL="us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud"
+
+# GATK4 version
+GATK4_VERSION="4.2.6.1"
+
+# BCFTools version
+BCFTOOLS_VERSION="1.24"
+
+# Necessary tools and help text
+TOOLS=(docker gcloud)
+HELP="$(basename "$0") [-h|--help] [-v4|--version4] [-b|--bcf] [-t|--tools] -- script to build the GATK/BCFtools/gcloud image and push to GCR
+
+where:
+    -h|--help Show help text
+    -v4|--version4 Version of GATK4 to use (default: GATK4=$GATK4_VERSION)
+    -b|--bcf Version of BCFTOOLS to use (default: BCFTOOLS_VERSION=${BCFTOOLS_VERSION})
+    -t|--tools Show tools needed to run script
+    "
+
+function main(){
+    for t in "${TOOLS[@]}"; do which $t >/dev/null || ok=no; done
+        if [[ $ok == no ]]; then
+            echo "Missing one of the following tools: "
+            for t in "${TOOLS[@]}"; do echo "$t"; done
+            exit 1
+        fi
+
+    while [[ $# -gt 0 ]]
+    do
+    key="$1"
+    case $key in
+        -v4|--version4)
+        GATK4_VERSION="$2"
+        shift
+        shift
+        ;;
+        -b|--bcf)
+        BCFTOOLS_VERSION="$2"
+        shift
+        shift
+        ;;
+        -h|--help)
+        echo "$HELP"
+        exit 0
+        ;;
+        -t|--tools)
+        for t in "${TOOLS[@]}"; do echo $t; done
+        exit 0
+        ;;
+        *)
+        shift
+        ;;
+    esac
+    done
+
+    IMAGE_TAG="$DOCKER_IMAGE_VERSION-$GATK4_VERSION-$BCFTOOLS_VERSION-$TIMESTAMP"
+
+    echo "building and pushing GCR Image - $GCR_URL:$IMAGE_TAG"
+    docker build -t "$GCR_URL:$IMAGE_TAG" \
+        --build-arg GATK4_VERSION="$GATK4_VERSION" \
+        --build-arg BCFTOOLS_VERSION="$BCFTOOLS_VERSION" \
+        --no-cache $DIR
+    docker push "$GCR_URL:$IMAGE_TAG"
+
+    echo -e "$GCR_URL:$IMAGE_TAG" >> "$DIR/docker_versions.tsv"
+    echo "done"
+}
+
+main "$@"

--- a/3rd-party-tools/gatk-bcftools-gcloud/docker_versions.tsv
+++ b/3rd-party-tools/gatk-bcftools-gcloud/docker_versions.tsv
@@ -1,0 +1,2 @@
+DOCKER_VERSION
+us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:1.0.0-4.2.6.1-1.24-1787155398


### PR DESCRIPTION
https://github.com/broadinstitute/warp/pull/1928 added a QC wdl for SV imputation inputs, and references a docker image (us.gcr.io/broad-gotc-prod/gatk-bcftools-gcloud:1.0.0-4.2.6.1-1.24-1787155398) built using the code on this PR.

Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-1049