### PR TITLE
adding mitochondria single sample inputs

### DIFF
--- a/3rd-party-tools/aou_mito_single_sample/NUMTv3_all385.hg38.interval_list
+++ b/3rd-party-tools/aou_mito_single_sample/NUMTv3_all385.hg38.interval_list
@@ -1,0 +1,3752 @@
+@HD	VN:1.5	SO:unsorted
+@SQ	SN:chr1	LN:248956422	M5:6aef897c3d6ff0c78aff06ac189178dd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2	LN:242193529	M5:f98db672eb0993dcfdabafe2a882905c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3	LN:198295559	M5:76635a41ea913a405ded820447d067b0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4	LN:190214555	M5:3210fecf1eb92d5489da4346b3fddc6e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5	LN:181538259	M5:a811b3dc9fe66af729dc0dddf7fa4f13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6	LN:170805979	M5:5691468a67c7e7a7b5f2a3a683792c29	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7	LN:159345973	M5:cc044cc2256a1141212660fb07b6171e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8	LN:145138636	M5:c67955b5f7815a9a1edfaa15893d3616	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9	LN:138394717	M5:6c198acf68b5af7b9d676dfdd531b5de	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr10	LN:133797422	M5:c0eeee7acfdaf31b770a509bdaa6e51a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11	LN:135086622	M5:1511375dc2dd1b633af8cf439ae90cec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12	LN:133275309	M5:96e414eace405d8c27a6d35ba19df56f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr13	LN:114364328	M5:a5437debe2ef9c9ef8f3ea2874ae1d82	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14	LN:107043718	M5:e0f0eecc3bcab6178c62b6211565c807	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15	LN:101991189	M5:f036bd11158407596ca6bf3581454706	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16	LN:90338345	M5:db2d37c8b7d019caaf2dd64ba3a6f33a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17	LN:83257441	M5:f9a0fb01553adb183568e3eb9d8626db	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18	LN:80373285	M5:11eeaa801f6b0e2e36a1138616b8ee9a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19	LN:58617616	M5:85f9f4fc152c58cb7913c06d6b98573a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr20	LN:64444167	M5:b18e6c531b0bd70e949a7fc20859cb01	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21	LN:46709983	M5:974dc7aec0b755b19f031418fdedf293	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22	LN:50818468	M5:ac37ec46683600f808cdd41eac1d55cd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrX	LN:156040895	M5:2b3a55ff7f58eb308420c8a9b11cac50	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrY	LN:57227415	M5:ce3e31103314a704255f3cd90369ecce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrM	LN:16569	M5:c68f52674c9fb33aef52dcf399755519	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270706v1_random	LN:175055	M5:62def1a794b3e18192863d187af956e6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270707v1_random	LN:32032	M5:78135804eb15220565483b7cdd02f3be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270708v1_random	LN:127682	M5:1e95e047b98ed92148dd84d6c037158c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270709v1_random	LN:66860	M5:4e2db2933ea96aee8dab54af60ecb37d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270710v1_random	LN:40176	M5:9949f776680c6214512ee738ac5da289	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270711v1_random	LN:42210	M5:af383f98cf4492c1f1c4e750c26cbb40	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270712v1_random	LN:176043	M5:c38a0fecae6a1838a405406f724d6838	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270713v1_random	LN:40745	M5:cb78d48cc0adbc58822a1c6fe89e3569	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270714v1_random	LN:41717	M5:42f7a452b8b769d051ad738ee9f00631	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270715v1_random	LN:161471	M5:b65a8af1d7bbb7f3c77eea85423452bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270716v1_random	LN:153799	M5:2828e63b8edc5e845bf48e75fbad2926	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_GL000221v1_random	LN:155397	M5:3238fb74ea87ae857f9c7508d315babb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_GL000008v2_random	LN:209709	M5:a999388c587908f80406444cebe80ba3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_GL000208v1_random	LN:92689	M5:aa81be49bf3fe63a79bdc6a6f279abf6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_KI270717v1_random	LN:40062	M5:796773a1ee67c988b4de887addbed9e7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_KI270718v1_random	LN:38054	M5:b0c463c8efa8d64442b48e936368dad5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_KI270719v1_random	LN:176845	M5:cd5e932cfc4c74d05bb64e2126873a3a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_KI270720v1_random	LN:39050	M5:8c2683400a4aeeb40abff96652b9b127	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270721v1_random	LN:100316	M5:9654b5d3f36845bb9d19a6dbd15d2f22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_GL000009v2_random	LN:201709	M5:862f555045546733591ff7ab15bcecbe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_GL000225v1_random	LN:211173	M5:63945c3e6962f28ffd469719a747e73c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270722v1_random	LN:194050	M5:51f46c9093929e6edc3b4dfd50d803fc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_GL000194v1_random	LN:191469	M5:6ac8f815bf8e845bb3031b73f812c012	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270723v1_random	LN:38115	M5:74a4b480675592095fb0c577c515b5df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270724v1_random	LN:39555	M5:c3fcb15dddf45f91ef7d94e2623ce13b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270725v1_random	LN:172810	M5:edc6402e58396b90b8738a5e37bf773d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270726v1_random	LN:43739	M5:fbe54a3197e2b469ccb2f4b161cfbe86	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270727v1_random	LN:448248	M5:84fe18a7bf03f3b7fc76cbac8eb583f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16_KI270728v1_random	LN:1872759	M5:369ff74cf36683b3066a2ca929d9c40d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_GL000205v2_random	LN:185591	M5:458e71cd53dd1df4083dc7983a6c82c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270729v1_random	LN:280839	M5:2756f6ee4f5780acce31e995443508b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270730v1_random	LN:112551	M5:48f98ede8e28a06d241ab2e946c15e07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270731v1_random	LN:150754	M5:8176d9a20401e8d9f01b7ca8b51d9c08	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270732v1_random	LN:41543	M5:d837bab5e416450df6e1038ae6cd0817	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270733v1_random	LN:179772	M5:f1fa05d48bb0c1f87237a28b66f0be0b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270734v1_random	LN:165050	M5:1d17410ae2569c758e6dd51616412d32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270735v1_random	LN:42811	M5:eb6b07b73dd9a47252098ed3d9fb78b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270736v1_random	LN:181920	M5:2ff189f33cfa52f321accddf648c5616	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270737v1_random	LN:103838	M5:2ea8bc113a8193d1d700b584b2c5f42a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270738v1_random	LN:99375	M5:854ec525c7b6a79e7268f515b6a9877c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270739v1_random	LN:73985	M5:760fbd73515fedcc9f37737c4a722d6a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrY_KI270740v1_random	LN:37240	M5:69e42252aead509bf56f1ea6fda91405	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270302v1	LN:2274	M5:ee6dff38036f7d03478c70717643196e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270304v1	LN:2165	M5:9423c1b46a48aa6331a77ab5c702ac9d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270303v1	LN:1942	M5:2cb746c78e0faa11e628603a4bc9bd58	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270305v1	LN:1472	M5:f9acea3395b6992cf3418b6689b98cf9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270322v1	LN:21476	M5:7d459255d1c54369e3b64e719061a5a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270320v1	LN:4416	M5:d898b9c5a0118e76481bf5695272959e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270310v1	LN:1201	M5:af6cb123af7007793bac06485a2a20e9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270316v1	LN:1444	M5:6adde7a9fe7bd6918f12d0f0924aa8ba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270315v1	LN:2276	M5:ecc43e822dc011fae1fcfd9981c46e9c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270312v1	LN:998	M5:26499f2fe4c65621fd8f4ecafbad31d7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270311v1	LN:12399	M5:59594f9012d8ce21ed5d1119c051a2ba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270317v1	LN:37690	M5:cd4b1fda800f6ec9ea8001994dbf6499	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270412v1	LN:1179	M5:7bb9612f733fb7f098be79499d46350c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270411v1	LN:2646	M5:fc240322d91d43c04f349cc58fda3eca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270414v1	LN:2489	M5:753e02ef3b1c590e0e3376ad2ebb5836	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270419v1	LN:1029	M5:58455e7a788f0dc82034d1fb109f6f5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270418v1	LN:2145	M5:1537ec12b9c58d137a2d4cb9db896bbc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270420v1	LN:2321	M5:bac954a897539c91982a7e3985a49910	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270424v1	LN:2140	M5:747c8f94f34d5de4ad289bc604708210	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270417v1	LN:2043	M5:cd26758fda713f9c96e51d541f50c2d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270422v1	LN:1445	M5:3fce80eb4c0554376b591699031feb56	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270423v1	LN:981	M5:bdf5a85c001731dccfb150db2bfe58ac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270425v1	LN:1884	M5:665a46879bbb48294b0cfa87b61e71f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270429v1	LN:1361	M5:ee8962dbef9396884f649e566b78bf06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270442v1	LN:392061	M5:796289c4cda40e358991f9e672490015	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270466v1	LN:1233	M5:530b7033716a5d72dd544213c513fd12	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270465v1	LN:1774	M5:bb1b2323414425c46531b3c3d22ae00d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270467v1	LN:3920	M5:db34e0dc109a4afd499b5ec6aaae9754	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270435v1	LN:92983	M5:1655c75415b9c29e143a815f44286d05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270438v1	LN:112505	M5:e765271939b854dd6826aa764e930c87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270468v1	LN:4055	M5:0a603090f06108ed7aff75df0767b822	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270510v1	LN:2415	M5:cd7348b3b5d9d0dfef6aed2af75ce920	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270509v1	LN:2318	M5:1cdeb8c823d839e1d1735b5bc9a14856	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270518v1	LN:2186	M5:3fd898b62ca859f50fb8b83e7706352b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270508v1	LN:1951	M5:7d42a358d472b9cbdfdf30c8742473d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270516v1	LN:1300	M5:1cbaaafbbf016906a5bf5886f5a0ecb7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270512v1	LN:22689	M5:ba1021c82d1230af856f59079e2f71b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270519v1	LN:138126	M5:8d754e9c9afd904fba0a2cd577fcc9a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270522v1	LN:5674	M5:070b4678e22501029c2e3297115216bc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270511v1	LN:8127	M5:907ca34a4a2a6673632ebaf513a4c1a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270515v1	LN:6361	M5:dd7527ee8e0bdb0a43ca0b2a5456c8c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270507v1	LN:5353	M5:311894d0a815eb07c5cac49da851cb4a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270517v1	LN:3253	M5:913440c38d95c618617ca69bb9296170	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270529v1	LN:1899	M5:4caf890f2586daab8e4b2e2db904f05f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270528v1	LN:2983	M5:d75c9235f0b8c449fc4352997c56b086	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270530v1	LN:2168	M5:04549369e1197c626669a10164613635	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270539v1	LN:993	M5:19e3a982e67eafef39c5a3e4163f1e17	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270538v1	LN:91309	M5:d60b72221cc7af871f2c757577e4c92a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270544v1	LN:1202	M5:e62a14b14467cdf48b5a236c66918f0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270548v1	LN:1599	M5:866b0db8e9cf66208c2c064bd09ce0a2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270583v1	LN:1400	M5:b127e2e6dbe358ff192b271b8c6ee690	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270587v1	LN:2969	M5:36be47659719f47b95caa51744aa8f70	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270580v1	LN:1553	M5:1df30dae0f605811d927dcea58e729fc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270581v1	LN:7046	M5:9f26945f9f9b3f865c9ebe953cbbc1a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270579v1	LN:31033	M5:fe62fb1964002717cc1b034630e89b1f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270589v1	LN:44474	M5:211c215414693fe0a2399cf82e707e03	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270590v1	LN:4685	M5:e8a57f147561b361091791b9010cd28b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270584v1	LN:4513	M5:d93636c9d54abd013cfc0d4c01334032	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270582v1	LN:6504	M5:6fd9804a7478d2e28160fe9f017689cb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270588v1	LN:6158	M5:37ffa850e69b342a8f8979bd3ffc77d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270593v1	LN:3041	M5:f4a5bfa203e9e81acb640b18fb11e78e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270591v1	LN:5796	M5:d6af509d69835c9ac25a30086e5a4051	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270330v1	LN:1652	M5:c2c590706a339007b00c59e0b8937e78	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270329v1	LN:1040	M5:f023f927ae84c5cc48dc4dce11ba90f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270334v1	LN:1368	M5:53afe12d1371f250a3d1de655345d374	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270333v1	LN:2699	M5:57baf650c47bba9b3a8b7c6d0fb55ad6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270335v1	LN:1048	M5:eb27188639503b524d2659a23b8262ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270338v1	LN:1428	M5:301ef75a6b2996d745eb3464bd352b57	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270340v1	LN:1428	M5:56b462bac20d385cdfcde0155fe4c3a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270336v1	LN:1026	M5:69ad2d85d870c8b0269434581e86e30e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270337v1	LN:1121	M5:16fc8d71a2662a6cfec7bdeec3d810c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270363v1	LN:1803	M5:6edd17a912f391022edbc192d49f2489	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270364v1	LN:2855	M5:6ff66a8e589ca27d93b5bac0e5b13a87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270362v1	LN:3530	M5:bc82401ffd9a5ae711fa0ea34da8d2f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270366v1	LN:8320	M5:44a0b65b7ba6bcff37eca202e7d966ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270378v1	LN:1048	M5:fc13bda7dbd914c92fb7e49489d1350f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270379v1	LN:1045	M5:3218bef25946cd95de585dfc7750f63b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270389v1	LN:1298	M5:2c9b08c57c27e714d4d5259fd91b6983	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270390v1	LN:2387	M5:7a64d89ea14990c16d20f4d6e7283e10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270387v1	LN:1537	M5:22a12462264340c25e912b8485cdfa91	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270395v1	LN:1143	M5:7c03ca4756c1620f318fb189214388d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270396v1	LN:1880	M5:9069bed3c2efe7cc87227d619ad5816f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270388v1	LN:1216	M5:76f9f3315fa4b831e93c36cd88196480	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270394v1	LN:970	M5:d5171e863a3d8f832f0559235987b1e5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270386v1	LN:1788	M5:b9b1baaa7abf206f6b70cf31654172db	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270391v1	LN:1484	M5:1fa5cf03b3eac0f1b4a64948fd09de53	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270383v1	LN:1750	M5:694d75683e4a9554bcc1291edbcaee43	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270393v1	LN:1308	M5:3724e1d70677d6b5c4bcf17fd40da111	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270384v1	LN:1658	M5:b06e44ea15d0a57618d6ca7d2e6ac5d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270392v1	LN:971	M5:59b3ca8de65fb171683f8a06d3b4bf0d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270381v1	LN:1930	M5:2a9297cfd3b3807195ab9ad07e775d99	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270385v1	LN:990	M5:112a8b1df94ef0498a0bfe2d2ea5cc23	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270382v1	LN:4215	M5:e7085cdcee6ad62f359744e13d3209fc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270376v1	LN:1136	M5:59e8fc80b78d62325082334b43dffdba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270374v1	LN:2656	M5:dbc92c9a92e558946e58b4909ec95dd5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270372v1	LN:1650	M5:53a9d5e8fd28bce5da5efcfd9114dbf2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270373v1	LN:1451	M5:b174fe53be245a840cd6324e39b88ced	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270375v1	LN:2378	M5:d678250c97e9b94aa390fa46e70a6d83	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270371v1	LN:2805	M5:a0af3d778dfeb7963e8e6d84c0c54fba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270448v1	LN:7992	M5:0f40827c265cb813b6e723da6c9b926b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270521v1	LN:7642	M5:af5bef7cefec7bd7efa729ac6c5be088	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000195v1	LN:182896	M5:5d9ec007868d517e73543b005ba48535	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000219v1	LN:179198	M5:f977edd13bac459cb2ed4a5457dba1b3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000220v1	LN:161802	M5:fc35de963c57bf7648429e6454f1c9db	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000224v1	LN:179693	M5:d5b2fc04f6b41b212a4198a07f450e20	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270741v1	LN:157432	M5:86eaea8a15a3950e37442eaaa5c9dc92	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000226v1	LN:15008	M5:1c1b2cd1fccbc0a99b6a447fa24d1504	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000213v1	LN:164239	M5:9d424fdcc98866650b58f004080a992a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270743v1	LN:210658	M5:3b62d9d3100f530d509e4efebd98502c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270744v1	LN:168472	M5:e90aee46b947ff8c32291a6843fde3f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270745v1	LN:41891	M5:1386fe3de6f82956f2124e19353ff9c1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270746v1	LN:66486	M5:c470486a0a858e14aa21d7866f83cc17	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270747v1	LN:198735	M5:62375d812ece679c9fd2f3d08d4e22a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270748v1	LN:93321	M5:4f6c6ab005c852a4352aa33e7cc88ded	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270749v1	LN:158759	M5:c899a7b4e911d371283f3f4058ca08b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270750v1	LN:148850	M5:c022ba92f244b7dc54ea90c4eef4d554	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270751v1	LN:150742	M5:1b758bbdee0e9ca882058d916cba9d29	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270752v1	LN:27745	M5:e0880631848337bd58559d9b1519da63	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270753v1	LN:62944	M5:25075fb2a1ecada67c0eb2f1fe0c7ec9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270754v1	LN:40191	M5:fe9e16233cecbc244f06f3acff3d03b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270755v1	LN:36723	M5:4a7da6a658955bd787af8add3ccb5751	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270756v1	LN:79590	M5:2996b120a5a5e15dab6555f0bf92e374	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270757v1	LN:71251	M5:174c73b60b41d8a1ef0fbaa4b3bdf0d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000214v1	LN:137718	M5:46c2032c37f2ed899eb41c0473319a69	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KI270742v1	LN:186739	M5:2f31c013a4a8301deb8ab7ed1ca1cd99	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000216v2	LN:176608	M5:725009a7e3f5b78752b68afa922c090c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_GL000218v1	LN:161147	M5:1d708b54644c26c7e01c2dad5426d38c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270762v1_alt	LN:354444	M5:b0397179e5a92bb7a3300b68e45a9f72	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270766v1_alt	LN:256271	M5:e3f36479d0e07abbd0d47babdc76e19d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270760v1_alt	LN:109528	M5:f2ea4b127c54df13f53a2b2b5a358087	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270765v1_alt	LN:185285	M5:628b663499df4f5de7dbdd56943bdb6e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_GL383518v1_alt	LN:182439	M5:978987018f1a910273ebcc387e038de8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_GL383519v1_alt	LN:110268	M5:349e96f115f829409bd1087b5fb684ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_GL383520v2_alt	LN:366580	M5:52e97087cc76c9fd73d4815c1e379ee0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270764v1_alt	LN:50258	M5:36d9e8a04906213f8c1d4cf81fc4f83f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270763v1_alt	LN:911658	M5:2f651e42b9fd434c2310be375fe8645e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270759v1_alt	LN:425601	M5:8477794d60329af9bd00cd9277981a59	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270761v1_alt	LN:165834	M5:3909a76846aa6ed534ba6be66a60cc81	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270770v1_alt	LN:136240	M5:38181b04426519779c84cf9a8927cf00	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270773v1_alt	LN:70887	M5:aa8b8ec2dd7776e643699db29ac85d74	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270774v1_alt	LN:223625	M5:a6d8be44258a4b8e3b55ffaccbd3b444	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270769v1_alt	LN:120616	M5:537f266cfc0ba05dfb532658fb592eb0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_GL383521v1_alt	LN:143390	M5:8c6f0a214ddbfbd52be574a566e4b21a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270772v1_alt	LN:133041	M5:7cc5209d7e796e90bd024204c04a9b7f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270775v1_alt	LN:138019	M5:79c3c0ad56276d3eff8cb747b57973a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270771v1_alt	LN:110395	M5:3739c7d552cfc62c495704f4f2d61330	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270768v1_alt	LN:110099	M5:5f6d54708a2fd0e4592319c2c91850a7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_GL582966v2_alt	LN:96131	M5:485c442c93fe19514153702f0c84d952	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_GL383522v1_alt	LN:123821	M5:df3e809f9a87f792218db18db51f6ad4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270776v1_alt	LN:174166	M5:87fe3336a33a4aa9c04ff7991aa78a11	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270767v1_alt	LN:161578	M5:160c7bb94aa35c1d61c27aadf1727862	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_JH636055v2_alt	LN:173151	M5:42f48ed9d46aded55795ef64e4713d55	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270783v1_alt	LN:109187	M5:3a60aafd707904d4da9c1c090a7cf0ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270780v1_alt	LN:224108	M5:2c050e6aeecf29b54469dea8c5631057	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_GL383526v1_alt	LN:180671	M5:620913159e2fbd4e931ac120e3c584c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270777v1_alt	LN:173649	M5:9673b29322cf16da2d295778229c1772	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270778v1_alt	LN:248252	M5:f0053d7b401730af8c34cd7d20dd0a91	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270781v1_alt	LN:113034	M5:c94ff451868540e0399bf62acb24e1dd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270779v1_alt	LN:205312	M5:3eec883e9656d4c4d96ea1e6d3c118ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270782v1_alt	LN:162429	M5:ceaa7d4ca7d4b80ba9a8d9e48223de2a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270784v1_alt	LN:184404	M5:35980922a4773cefc710c08134d16772	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270790v1_alt	LN:220246	M5:07cf7caef89c4677af575c370a1ebbb0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_GL383528v1_alt	LN:376187	M5:2948653361f974fbed3e26a4dfbf332c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270787v1_alt	LN:111943	M5:e315d4f96ad548f1af1935d97f2af9df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_GL000257v2_alt	LN:586476	M5:03c6c36060cd6c9f9b4fd0b096ff40e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270788v1_alt	LN:158965	M5:463baeb6369579e0d387371989492dc0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_GL383527v1_alt	LN:164536	M5:6d728406957c5c7fb158dbdb7efef2b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270785v1_alt	LN:119912	M5:4932c3e044a1e3731cd4de290f6492b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270789v1_alt	LN:205944	M5:3c9ef00afbe249de4934eeac37d64233	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270786v1_alt	LN:244096	M5:107c6b17f17b5d24936663fe8e70cd2a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270793v1_alt	LN:126136	M5:0c6c632ce75031c86e3054c34d3b9b49	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270792v1_alt	LN:179043	M5:3677eaca510b7e7c5f30ec8382a09d24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270791v1_alt	LN:195710	M5:3a62433e49995583fc44e640241a60bf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_GL383532v1_alt	LN:82728	M5:eb61b6b3f9374b05ce68ae4a393cf5ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_GL949742v1_alt	LN:226852	M5:20d5046bbd2a21729fdd64fa94bdd5a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270794v1_alt	LN:164558	M5:9808234a2843375d92d4c34e262373b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_GL339449v2_alt	LN:1612928	M5:1b6fa375fdf382778e6645d822d12254	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_GL383530v1_alt	LN:101241	M5:adcb4048e465b6b949990853e436a136	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270796v1_alt	LN:172708	M5:6b125232b8842fafd4179203620fa2be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_GL383531v1_alt	LN:173459	M5:9161d10779b02fa44b841136ef9e499c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270795v1_alt	LN:131892	M5:6670fafb8f6ceb4f46392f3178f29666	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL000250v2_alt	LN:4672374	M5:740358c10fbb870c86a7e44226bbdb3a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KI270800v1_alt	LN:175808	M5:3ed7e87ce250a8466359176e96d6a6a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KI270799v1_alt	LN:152148	M5:80fd907ae0e4d20ad13960cb92ab6d45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL383533v1_alt	LN:124736	M5:7d1a65603558094937299ff10e8714af	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KI270801v1_alt	LN:870480	M5:bd0c66e2085cf16906ebc6b130862bd6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KI270802v1_alt	LN:75005	M5:c66357c9b0909ee32c75286796602ce3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KB021644v2_alt	LN:185823	M5:332d693d4f2026747d670e52836694ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KI270797v1_alt	LN:197536	M5:2b76b3d07dc4cb2992e7125c19e32594	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KI270798v1_alt	LN:271782	M5:7f074e537d58c543d116ce2c45bb0966	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270804v1_alt	LN:157952	M5:9babd3431c32811769c782703f7b8c3d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270809v1_alt	LN:209586	M5:26d14130d09dc093446dd31e8f0be76c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270806v1_alt	LN:158166	M5:b55d6ad642408486735aede89d70c0c5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_GL383534v2_alt	LN:119183	M5:c6ff49147dedce02366d6ade10580611	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270803v1_alt	LN:1111570	M5:986e63220694b8c91bad1d6d990f6c83	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270808v1_alt	LN:271455	M5:52ce11809c32fe22003c5039e407d3e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270807v1_alt	LN:126434	M5:4da184771ac6a8644e6df506bbd8a35e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270805v1_alt	LN:209988	M5:d3a95141230a470a930f685fbce90a04	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270818v1_alt	LN:145606	M5:5f8af0060f092d941cbe9d873ccc1d41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270812v1_alt	LN:282736	M5:93b572cdabe748641570fa2ed3391222	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270811v1_alt	LN:292436	M5:dacc0b0ef9fae890a1741dca03ba7d5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270821v1_alt	LN:985506	M5:bbdee492e8852d313be96b6340fbfb1c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270813v1_alt	LN:300230	M5:c91599edb1c553cf527c7f3ba754bb20	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270822v1_alt	LN:624492	M5:2cd6749ad4385747595c0b41440cb41d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270814v1_alt	LN:141812	M5:84d9d4bbbac92a40b13809e501ff92fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270810v1_alt	LN:374415	M5:369545bbf4f206fd1175a84da12b38fc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270819v1_alt	LN:133535	M5:29d6d49a19ae259feb012f492ab83ce0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270820v1_alt	LN:36640	M5:d3b4609d5f29708fc33023259e4b775a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270817v1_alt	LN:158983	M5:d6e6a3ac3c2f5afe16c2cfb2e813b30c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270816v1_alt	LN:305841	M5:60bb5379ab4d817058300ef606b9fee6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270815v1_alt	LN:132244	M5:8be72bf872ff1edfc3f43cd9b7d0b9b3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_GL383539v1_alt	LN:162988	M5:12406aad3f3da31bda9c21a1aa0e16b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_GL383540v1_alt	LN:71551	M5:23aea04f46682e2a2be1a5ff3934a9fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_GL383541v1_alt	LN:171286	M5:0c787911df2449cbba8609bebf897ecb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_GL383542v1_alt	LN:60032	M5:12a3180640a49f33c960eb12ca61a6c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr9_KI270823v1_alt	LN:439082	M5:ad4baa1567e313eda0aad427008e10cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr10_GL383545v1_alt	LN:179254	M5:c27dc6fea378fecf178a44682257c25e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr10_KI270824v1_alt	LN:181496	M5:af40e32c32de290cfe497a110ff3bdfa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr10_GL383546v1_alt	LN:309802	M5:ed6fb45e0a25c31903cbb0f78d9d487e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr10_KI270825v1_alt	LN:188315	M5:3119d196965ee9cae7aeda77131076f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270832v1_alt	LN:210133	M5:2b63a3f97e490e807587639807d26293	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270830v1_alt	LN:177092	M5:dbe0c94a39d4a91469ffa6e509b3f191	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270831v1_alt	LN:296895	M5:b0f755388212c03651b6fdc7531c3fd2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270829v1_alt	LN:204059	M5:6bc1308e442a1662ae27952f126b7c01	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_GL383547v1_alt	LN:154407	M5:7b556f03729e304a286c8d7ef0f0c10e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_JH159136v1_alt	LN:200998	M5:8ac9fb9d942dba38bfd30f8d767f4bba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_JH159137v1_alt	LN:191409	M5:b293c854ddcbc316cb1d449bca46fbb3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270827v1_alt	LN:67707	M5:86017dee76a03e3dc3c8833018101fae	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270826v1_alt	LN:186169	M5:a903d85efe5aa37dac36160bddeeac87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_GL877875v1_alt	LN:167313	M5:3dd30a7638c3a3c518fc15571546b1be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_GL877876v1_alt	LN:408271	M5:5c3a364520bf7ed46894abdce8f6e032	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_KI270837v1_alt	LN:40090	M5:e749a70a94624f09e134600d122c130d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_GL383549v1_alt	LN:120804	M5:60a7c1711d7f23fd7311a7e4f96896f7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_KI270835v1_alt	LN:238139	M5:b163c6fa013f6cb75b01088689f1a67f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_GL383550v2_alt	LN:169178	M5:d61d9a153c3fd556b48e1c511a6145e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_GL383552v1_alt	LN:138655	M5:c28f12c6ee0dec4cc6995766a710960c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_GL383553v2_alt	LN:152874	M5:89b111e38005345de92036b249ab6080	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_KI270834v1_alt	LN:119498	M5:3ad1c94c00299533f6acd33ea2f04df1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_GL383551v1_alt	LN:184319	M5:d96719c32333013a51c4d6d3261f984f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_KI270833v1_alt	LN:76061	M5:8c9988aa66d02708e3e57663902fc664	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_KI270836v1_alt	LN:56134	M5:28a69648439a2c02d46750eee929b20d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr13_KI270840v1_alt	LN:191684	M5:d90a653d7ac3171c8fb762d0012249f7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr13_KI270839v1_alt	LN:180306	M5:b97ea581776626ac41b69f851a85a456	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr13_KI270843v1_alt	LN:103832	M5:563c8412eb284fc5321af590a4c9ab9d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr13_KI270841v1_alt	LN:169134	M5:6ac8a99077817e6bc9be36327b8aa18e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr13_KI270838v1_alt	LN:306913	M5:baf90eafb4ed6330cb151c1d5538f721	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr13_KI270842v1_alt	LN:37287	M5:231dd4484df464129d3120986fe2af73	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270844v1_alt	LN:322166	M5:b64acbff6218bd210676141e4e678a82	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270847v1_alt	LN:1511111	M5:9d380ae26e2edb178ef0121021f7a7ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270845v1_alt	LN:180703	M5:51b3fa9f43d11aeb91b3debb33496d22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr14_KI270846v1_alt	LN:1351393	M5:1ee28b84d30d13e03341b382995b05bc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270852v1_alt	LN:478999	M5:5104fe22193b4bd04166ecb401beb06a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270851v1_alt	LN:263054	M5:64217994ed61c2feb5412ecc5a7a37b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270848v1_alt	LN:327382	M5:d61e4262335c4884ad97dc5d73782870	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_GL383554v1_alt	LN:296527	M5:4a3d54bda53308ca941d6d0e794b05cb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270849v1_alt	LN:244917	M5:7966604eef1b897ee97e8dce9e79b18e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_GL383555v2_alt	LN:388773	M5:c904b1792869ae0565acbbdc19b9522f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270850v1_alt	LN:430880	M5:5371d98deea30e91051e3efd20016b76	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16_KI270854v1_alt	LN:134193	M5:0e126949f4b012d27f55aed5f1c4ca84	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16_KI270856v1_alt	LN:63982	M5:515d2b9de600d584473c20bea079f34c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16_KI270855v1_alt	LN:232857	M5:436afa974458133c013b037d4a2dc1c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16_KI270853v1_alt	LN:2659700	M5:5e28daf08ffeafb037b6e97ba3c959e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16_GL383556v1_alt	LN:192462	M5:bed6a2667e8452a176e93e921e0c21f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr16_GL383557v1_alt	LN:89672	M5:0989118882ce9c38635e2809e5bf71c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_GL383563v3_alt	LN:375691	M5:fcd64ac83b2ebb57f50931c9d6fc0a31	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270862v1_alt	LN:391357	M5:f2efc8dc887a8c0101053fa14491e07f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270861v1_alt	LN:196688	M5:808750bf9b346e0a731a1bffac75a01e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270857v1_alt	LN:2877074	M5:f5ca1bb91881efefa473c983f9519561	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_JH159146v1_alt	LN:278131	M5:384b5b32f0ea2cfd15ac268a2ce07909	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_JH159147v1_alt	LN:70345	M5:4bf63957bfa1ecdbbab483d4c0ce6682	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_GL383564v2_alt	LN:133151	M5:fc2eb07543a6ecb0a27d9fa12cd91cfc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_GL000258v2_alt	LN:1821992	M5:8bd6071029f2dbc5ab9d2d912bf5c953	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_GL383565v1_alt	LN:223995	M5:063358c8e7f81361b959efab7b3f15cc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270858v1_alt	LN:235827	M5:69fbdc82c5ef837f574d0b3c8b9c647f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270859v1_alt	LN:108763	M5:8d28bd3b1a63fa9a945051f28e087668	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_GL383566v1_alt	LN:90219	M5:a0f25165c6537c9861cc1231f710e99f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270860v1_alt	LN:178921	M5:91e560df1ad6c58e7e1739178b8c7209	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_KI270864v1_alt	LN:111737	M5:04e6ca7eabe96be35a18eb4c0675071d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_GL383567v1_alt	LN:289831	M5:d9015dd9a0916a98ed8ab99fd3cdd012	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_GL383570v1_alt	LN:164789	M5:08366c03855961f13b1d5e65920ccf74	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_GL383571v1_alt	LN:198278	M5:40015159c7da8f06875bb558587e3f07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_GL383568v1_alt	LN:104552	M5:e9aba11d18125a2bce2b1e5915e9a904	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_GL383569v1_alt	LN:167950	M5:8d13c3e7cbb2b7e1a3225c5a54fe8f44	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_GL383572v1_alt	LN:159547	M5:8fc7aaa775b43df3d77c9782a140a981	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_KI270863v1_alt	LN:167999	M5:2e691a3fc5108cc7decde377ef398fde	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270868v1_alt	LN:61734	M5:2dfd26bf8f217b858edc062be1846db5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270865v1_alt	LN:52969	M5:b95ce15823c60ab83ec7a984f3dc9ebc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL383573v1_alt	LN:385657	M5:5404455aab275489bc8e6c9fb3ead5cb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL383575v2_alt	LN:170222	M5:dd8730d9d33765ff135fcfadb8810280	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL383576v1_alt	LN:188024	M5:8d4496a682182f8273a2fad665fcf4a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL383574v1_alt	LN:155864	M5:0386df1d3476e6649f919195cc072fc7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270866v1_alt	LN:43156	M5:d205b57d55e89546400e0f1e230a8a53	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270867v1_alt	LN:233762	M5:3d8464a9e183031ea70e0e12fa231163	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949746v1_alt	LN:987716	M5:d76e635e75bc038782fb3d0c195d33fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr20_GL383577v2_alt	LN:128386	M5:f00c218d09df83c8b515a6b5591fe30c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr20_KI270869v1_alt	LN:118774	M5:2b8065d3bdbac6664d7f35c25d049113	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr20_KI270871v1_alt	LN:58661	M5:29e7c064fe54ab6b7fd8accb0363821b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr20_KI270870v1_alt	LN:183433	M5:779f6fd5220eddc54631e80b94bb905a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21_GL383578v2_alt	LN:63917	M5:d512f47a48fc477e7232d3b46f2bda86	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21_KI270874v1_alt	LN:166743	M5:45c435343bfd1d94c4ff17689faf507d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21_KI270873v1_alt	LN:143900	M5:22bc49cad0dda4ec9d79ffd619be94d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21_GL383579v2_alt	LN:201197	M5:631f76952802048256225746f1a14a89	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21_GL383580v2_alt	LN:74653	M5:b0cfe93a0987bda7488445b3c37b2516	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21_GL383581v2_alt	LN:116689	M5:1c9b893acb0fb6a6d9ff1915ce9004ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr21_KI270872v1_alt	LN:82692	M5:e8daa648582ccb498c469d4f6dcf4140	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270875v1_alt	LN:259914	M5:8a27dfcd4c4ae0239e3207b9994d8331	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270878v1_alt	LN:186262	M5:07e6bd13f82b45996b0165c0a2c0ebb2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270879v1_alt	LN:304135	M5:9fb8076a6ca93af66b2878d5cf07ebb0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270876v1_alt	LN:263666	M5:507bafbc0e637e7e5854acab4d2b7de7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270877v1_alt	LN:101331	M5:b6724c024308122f0d19c875771d571e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_GL383583v2_alt	LN:96924	M5:03ed78804fcfe33fb202c22d20e1ed05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_GL383582v2_alt	LN:162811	M5:1919a95f3ea48fde56ba925295086028	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrX_KI270880v1_alt	LN:284869	M5:e4ed2d1ef2ee71f00075ed9537aab284	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrX_KI270881v1_alt	LN:144206	M5:6370851c900248567c9bc5bee75089ab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270882v1_alt	LN:248807	M5:9a4ca55b5d44458dc5a1682ac6483738	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270883v1_alt	LN:170399	M5:79916aa2c6a7669500b59ddd7b4eccec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270884v1_alt	LN:157053	M5:28517f9e5682de5e74b42ba7c84a9d41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270885v1_alt	LN:171027	M5:b5fc4688af8411394923dbcf6a85b85d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270886v1_alt	LN:204239	M5:fae7fb0677c513b24e8027969233140f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270887v1_alt	LN:209512	M5:3c672b8b13188d46ed1ea6806fdc9662	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270888v1_alt	LN:155532	M5:325a22a47ae227dda0c8704cf4725601	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270889v1_alt	LN:170698	M5:680f4977d9743df71085eacbff34769b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270890v1_alt	LN:184499	M5:8862bbaae8fc895769859a6e89d19601	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270891v1_alt	LN:170680	M5:0b1dd9ea37a3772563fb7298ad1f3857	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr1_KI270892v1_alt	LN:162212	M5:24ba517f0feae1b6a95e1c65c21282be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270894v1_alt	LN:214158	M5:0bfafe4b4a536ed3e5b77a89408d7534	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr2_KI270893v1_alt	LN:161218	M5:d701ebc3d24a0056dc6b9418ba4e15c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270895v1_alt	LN:162896	M5:4d08672ade726bd914e62a36d734da0c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270896v1_alt	LN:378547	M5:751a447059436d9d5987f8417b2e2bd2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270897v1_alt	LN:1144418	M5:5a8582c4943187c1a842801cf17d3706	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr5_KI270898v1_alt	LN:130957	M5:9919f71320ac92b1abb42e2aedea84ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL000251v2_alt	LN:4795265	M5:e51d466e4a702acf3c9c5ffdc1ee0c51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr7_KI270899v1_alt	LN:190869	M5:b42d6c28bfd9049414fb9d2617528db4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270901v1_alt	LN:136959	M5:3d60ee1215e273e0c0267ad063614015	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270900v1_alt	LN:318687	M5:80404f3147bd316898e6b5281f32c073	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270902v1_alt	LN:106711	M5:f100803823a7cde3694698028e4c515c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270903v1_alt	LN:214625	M5:5ce11ce469afc974c3024b30033dc5d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr12_KI270904v1_alt	LN:572349	M5:6d8ebe7fb3dd3be62e34a1d2982e6f46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270906v1_alt	LN:196384	M5:eb8157203f051ef7cfcab1f4647f22c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr15_KI270905v1_alt	LN:5161414	M5:31c97360f2a53ab92bd8d6db1b1a410d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270907v1_alt	LN:137721	M5:f5a65eb09de3017536d1b7c0b2237fbd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270910v1_alt	LN:157099	M5:4eef5dbfe56e13c810780221b0f6426d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270909v1_alt	LN:325800	M5:6a46afe4c5e257b556f25c37a09fc024	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_JH159148v1_alt	LN:88070	M5:bd147af8e713f365ff05352eb8a4508f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr17_KI270908v1_alt	LN:1423190	M5:ef3f9ebebe7ad9f9690daedeae8a74f8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_KI270912v1_alt	LN:174061	M5:3a8acbc0c5c751ccad11263a608715fa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr18_KI270911v1_alt	LN:157710	M5:930ee72eaddcaf1355220cd39539c326	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949747v2_alt	LN:729520	M5:10169e6e86933b2bf74797be020fc857	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KB663609v1_alt	LN:74013	M5:54abe159678a84e88ceb2d5271027628	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrX_KI270913v1_alt	LN:274009	M5:a4d4a5e5b5da1e65f007116b2797a4f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270914v1_alt	LN:205194	M5:086e17b28e2ac14e602c5dae2c358364	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270915v1_alt	LN:170665	M5:a5c43ab0e4289f3951e65fd57419782a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270916v1_alt	LN:184516	M5:45199873c7617fab0ba00e85a43ddbeb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270917v1_alt	LN:190932	M5:1595cb5d2e776d8a505a06db45ea2c04	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270918v1_alt	LN:123111	M5:e79cb3af945f28de17d744bf24cde080	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270919v1_alt	LN:170701	M5:a25ce4a282c7ead76bb2468a9a56d082	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270920v1_alt	LN:198005	M5:009fb96b4ee6d64732dac95a1f380f41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270921v1_alt	LN:282224	M5:4e9f360581e618964d379d67e3b51f90	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270922v1_alt	LN:187935	M5:7b6dc564b92bed8df5de2c1fa8de0986	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270923v1_alt	LN:189352	M5:5b0339dbf41b0301512639781d44d546	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270924v1_alt	LN:166540	M5:944759f109cad94523d1f3918ac0b382	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr4_KI270925v1_alt	LN:555799	M5:08b3f5ff9beac37e3bbc50767cf3b43b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL000252v2_alt	LN:4604811	M5:0c2ee784f397289b1713ad133fd93d39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr8_KI270926v1_alt	LN:229282	M5:58a00f9d6216734f0bf36a0f2294c246	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr11_KI270927v1_alt	LN:218612	M5:159fb3a622d456897c41d93f4627d169	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949748v2_alt	LN:1064304	M5:21fd288470eea03e7424729134f472f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr22_KI270928v1_alt	LN:176103	M5:efcf7ce77388977478ffe2757b8f8430	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270929v1_alt	LN:186203	M5:9f8d51d9c1ec4887cd55a1d0d8e61469	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270930v1_alt	LN:200773	M5:2c5abf84ad91658f7262dff7ade3e7b1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270931v1_alt	LN:170148	M5:36b9336df72c820b6efa95567a5aaf28	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270932v1_alt	LN:215732	M5:4a92a470a7851edf0c238a74814dece5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270933v1_alt	LN:170537	M5:413442cc380f0bb8f15b33bc25149af1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL000209v2_alt	LN:177381	M5:0e7a0f548f1f770b4272be1bd8b018fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270934v1_alt	LN:163458	M5:43c32fd3aae0eee20305d3d735e7bbb4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL000253v2_alt	LN:4677643	M5:a5cdd062ee0d61ea6b3c5166e79b472e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949749v2_alt	LN:1091841	M5:cf8641cadcdb22174c55a5d9d5c46036	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270935v1_alt	LN:197351	M5:8175b26fd25c1671efd5af96e8b44835	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL000254v2_alt	LN:4827813	M5:ad357767de6beef959952d39200522ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949750v2_alt	LN:1066390	M5:c48b453696107dc7105bce3857e1cbc6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270936v1_alt	LN:164170	M5:64f7f27938eb4c80140f34e3d2aed483	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL000255v2_alt	LN:4606388	M5:bceeb4190283066a6d0891562b41d164	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949751v2_alt	LN:1002683	M5:1615d0a6f8a5ff11274ba2e00b9487a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr3_KI270937v1_alt	LN:165607	M5:39b5207a79f67fb863be3b2a5bed0963	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_GL000256v2_alt	LN:4929269	M5:a80b1b3c21ac7e7b7acf75178ae3d83c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949752v1_alt	LN:987100	M5:7d007a35ff02e56325881c68bb17b565	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr6_KI270758v1_alt	LN:76752	M5:9d0d4a56d72f18d39c7a1094deb177a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_GL949753v2_alt	LN:796479	M5:19162055ca3e800f14797b6cd37c1d4c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chr19_KI270938v1_alt	LN:1066800	M5:9363b56f7b34fb35ab3400b1093f431a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrEBV	LN:171823	M5:6743bd63b3ff2b5b8985d8933c53290a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707606v1_decoy	LN:2200	M5:20c768ac79ca38077e5012ee0e5f8333	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707607v1_decoy	LN:3033	M5:444cb839a910d9af9b5c5f013cb31063	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707608v1_decoy	LN:3112	M5:bc263c9aacc51dabcb0ac4987c416a0a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707609v1_decoy	LN:1642	M5:ec7a95a8f6e3d63152c0b1f46601e2ee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707610v1_decoy	LN:1393	M5:441a56ef62eccbc2ec6d0384fe40367e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707611v1_decoy	LN:1103	M5:a5378db83cbffb5f31da4a549152cf80	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707612v1_decoy	LN:1039	M5:4ac166fdb188d87a64b59e346fc040cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707613v1_decoy	LN:1619	M5:af5b7705364129a1fdf718e223e8dfb3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707614v1_decoy	LN:3122	M5:67860fb1c59453dbaf2bc21834f76ff1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707615v1_decoy	LN:1934	M5:e8773170190290d21bf5c7bac36c73ee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707616v1_decoy	LN:3111	M5:9792c2376ee383fa1d0763ff6b391fd7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707617v1_decoy	LN:2545	M5:7d9f68ca65f2e9029ef8c2d352b6068d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707618v1_decoy	LN:2295	M5:dfec4823eafc51fe89a1c8a61a7861a2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707619v1_decoy	LN:1551	M5:f0f821c64e2f1339f4452cfabcd1a247	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707620v1_decoy	LN:2046	M5:9e54f11658064725f046e3ffc7f5166e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707621v1_decoy	LN:1222	M5:4053fd7005d4e430ff32b9b0c9dda52d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707622v1_decoy	LN:1535	M5:393bc14f66f0af8c20fdd93b1a3dc78c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707623v1_decoy	LN:3784	M5:5da25a3d7060acf52ce5d2084d8922cc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707624v1_decoy	LN:1329	M5:18daae4566bfb62823b548ab88fa894a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707625v1_decoy	LN:1238	M5:8a05b8842f52e87406e28162b8fa7249	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707626v1_decoy	LN:5623	M5:e6705349b3e2839fcd382596f831045d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707627v1_decoy	LN:5821	M5:cafc12fed95e40d4c1b441ad93f0493a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707628v1_decoy	LN:2960	M5:1e0a770fe11a74301ab4535bd9be16c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707629v1_decoy	LN:1848	M5:5288216fe388c6966e89e6f8a3a5118e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707630v1_decoy	LN:2315	M5:1cab33f8538d939c751e2b2d9b01957a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707631v1_decoy	LN:1945	M5:099f236a02fe8e80d7f135727589bce1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707632v1_decoy	LN:1424	M5:a2e305f020577c5f7806c411f995402c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707633v1_decoy	LN:1274	M5:967deda0c966a0bcd27c6e047e18e7f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707634v1_decoy	LN:1007	M5:093928d5a51ad63c286ec229982828ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707635v1_decoy	LN:1414	M5:270f3e796a1b7c345e83762fa735bfe1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707636v1_decoy	LN:1725	M5:f00ca03da369b2dcf101bda70773022b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707637v1_decoy	LN:5354	M5:ecf9ac0af0f7009b8b4e5fa639e7fc97	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707638v1_decoy	LN:2189	M5:5a928a8e7ad5ec7808ae7dbcc7ba72d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707639v1_decoy	LN:1294	M5:692623b127f6621794d92bfc65f198f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707640v1_decoy	LN:1831	M5:23d5c8473f768ca2c6a3eed843fc2cf2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707641v1_decoy	LN:1647	M5:09778e8253cf377911db86530bec54a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707642v1_decoy	LN:2943	M5:6759f7bb4098b6eb0ec14f5c63369661	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707643v1_decoy	LN:2857	M5:a6d7044f6c244253ec1e142bbb35d859	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707644v1_decoy	LN:1030	M5:e3e8c02e17ebf79c0e90ce41a16ccedb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707645v1_decoy	LN:1070	M5:26882fb498a5b281266a48f82726a7c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707646v1_decoy	LN:1735	M5:b120aeee1c12ed6986a9743badfcc505	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707647v1_decoy	LN:1982	M5:d1d012b49d3cb20db627f6dd65326217	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707648v1_decoy	LN:1564	M5:a4fae6ab9f74c3f1b2c0f8352e9a3519	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707649v1_decoy	LN:1775	M5:4bcea8af13f18547fe066845bdc1c120	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707650v1_decoy	LN:1540	M5:b4256e83f91ba0174562138c3b466a45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707651v1_decoy	LN:2013	M5:f7d9c80ab1716aee1a2237dce70b768a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707652v1_decoy	LN:1176	M5:4af9bb8c4125407fb9f03e5fc7798528	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707653v1_decoy	LN:1890	M5:854efc081d295baa5a1efa0fe1f9bb3a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707654v1_decoy	LN:3644	M5:5c90649c1bc38e0b333381ac593252bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707655v1_decoy	LN:2785	M5:407de1fa7cb87b88317888d98ea56599	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707656v1_decoy	LN:1017	M5:f521affa49ef813fea48a8f5b1fa8e13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707657v1_decoy	LN:1068	M5:478f244a134bc02c1c51f63009626864	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707658v1_decoy	LN:1007	M5:f4ce5e4a861ab83037e05e271e74497b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707659v1_decoy	LN:2605	M5:5c8b18731c2eeda273e0caaf2e878654	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707660v1_decoy	LN:8410	M5:b581d341cdf7f17875e60e3da33c398b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707661v1_decoy	LN:5534	M5:fd57c53936fe1011e42fc08ef3ff65c5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707662v1_decoy	LN:2173	M5:5ca2d18676a26044b213465e1e6ac206	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707663v1_decoy	LN:1065	M5:07cb60b1a2ff813eed23c7cc4128baa7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707664v1_decoy	LN:8683	M5:ac12df9c6d81003f812323327f937147	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707665v1_decoy	LN:2670	M5:366d796fda2fe9f8baadd88deddf9dca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707666v1_decoy	LN:2420	M5:b5c696c469b2e831e8a5e8e87c6813e8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707667v1_decoy	LN:2189	M5:1f055f8a1a1f8c356b45cfcbd6db6713	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707668v1_decoy	LN:2093	M5:839cff5bd33068228bd1031bf8be9a64	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707669v1_decoy	LN:1184	M5:ad69f6deb582834c638527c565c4de2e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707670v1_decoy	LN:1205	M5:aa9070a191ece87a421285b5be2e8b68	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707671v1_decoy	LN:2786	M5:28c96decb9c1d76b9a76b1ee75e2421d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707672v1_decoy	LN:2794	M5:4d547ee98d0678f832df5c46f91604aa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707673v1_decoy	LN:19544	M5:2d2080522d0d729d94c7d73eda00c62a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707674v1_decoy	LN:2848	M5:9182728e5875ee5cfba2c524c997fcbe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707675v1_decoy	LN:10556	M5:021a0164c68fd77f51bead9e2c4e9cea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707676v1_decoy	LN:9066	M5:c8c71f6c1f2612fed812e69c737ca6ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707677v1_decoy	LN:7267	M5:0e929202e653306730239e7dbea8a861	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707678v1_decoy	LN:2462	M5:21e3c2e28a7980351470a14a0d48160c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707679v1_decoy	LN:1774	M5:9f0f7ecdb5b097f83aab97fff76127d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707680v1_decoy	LN:1297	M5:3eab486a1f41712d26b8c251ad9dbff1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707681v1_decoy	LN:4379	M5:04aec18ad103fe46337c6643d0eaca0c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707682v1_decoy	LN:4208	M5:b413a0a980c7752db350c74c5f97937b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707683v1_decoy	LN:4068	M5:80a8f28af2c872b62345c85f6217dea7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707684v1_decoy	LN:2940	M5:774582f989e0cda16927addcf0ece955	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707685v1_decoy	LN:3938	M5:cd0020e224ec3edc01ecdfd648f4099d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707686v1_decoy	LN:2072	M5:879ef8f0e126b3f557a0170b71459c6e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707687v1_decoy	LN:1136	M5:69aff37696b0d4542e56fcf9ad9af43c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707688v1_decoy	LN:4248	M5:d301756f721c9141f1216e52fa4003da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707689v1_decoy	LN:5823	M5:f29516cc0ba82ac48516c65b100b2255	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707690v1_decoy	LN:3715	M5:a154584ab9547c044251e469591cfd94	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707691v1_decoy	LN:4885	M5:ab7f60b71af56c68e4a0f56174c90e4e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707692v1_decoy	LN:4813	M5:e8f5365670fcf6e3612d2e77ba943aaf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707693v1_decoy	LN:2899	M5:3cf4cd0669a4fc846ef0aa0aac7cb739	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707694v1_decoy	LN:1228	M5:38a9e18c0e3208c8b593dc4fdf118a9c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707695v1_decoy	LN:3119	M5:ba7aa2faa9f2fad7ad94f0acd152e6f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707696v1_decoy	LN:3828	M5:4b39179f8d3eefee8f4865bf6d11dd9c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707697v1_decoy	LN:1186	M5:0b3eecab59c656d96325f01e70a906c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707698v1_decoy	LN:1908	M5:708018246fdce7d4b8f47502bfdbc3a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707699v1_decoy	LN:2795	M5:001979586db1b719cca6d3dc0e50e71c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707700v1_decoy	LN:3703	M5:5c692cc6be5262461fdbba8574e6ff40	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707701v1_decoy	LN:6722	M5:378424a19c93bf19eb0f565cba923eb1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707702v1_decoy	LN:6466	M5:1b5a6efaa31d7974dffe73fc4bb88349	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707703v1_decoy	LN:2235	M5:c045d23c4c9497849b45c45423f705ec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707704v1_decoy	LN:2871	M5:b44844f0650f1953d042b7b0c9740cb0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707705v1_decoy	LN:4632	M5:6c1d769d4a84500b2eefafe1cf460164	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707706v1_decoy	LN:4225	M5:d37d4a4d41be60f45aa967ecac1a0c5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707707v1_decoy	LN:4339	M5:ffcd631ed0bf56e54cd72ed51c70fa3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707708v1_decoy	LN:2305	M5:6ebdd668b564460303637164213d0dff	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707709v1_decoy	LN:3273	M5:3531b30c5833b2f37585aeabefeafe36	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707710v1_decoy	LN:5701	M5:943eba7b0fd71418d0ef4ab2bdcc3f14	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707711v1_decoy	LN:4154	M5:8e6daf77c80fc9e8710c6732e9d72918	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707712v1_decoy	LN:1243	M5:65e4a30840d6420ebc8b7681d38ae431	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707713v1_decoy	LN:1308	M5:d9aafcd2c4b12f82a113eb5418d120ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707714v1_decoy	LN:2922	M5:4904d632dac614c608b8b7e3478dc3f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707715v1_decoy	LN:3044	M5:15707c34a9803e1349a621fef2605913	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707716v1_decoy	LN:2888	M5:68339f161a66b364c5e9ffed664272f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707717v1_decoy	LN:1742	M5:1fd1325fe768dfe31d9199ee60b60206	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707718v1_decoy	LN:4969	M5:454864584e92f6e195416ac9f9a8ee38	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707719v1_decoy	LN:3270	M5:10feb2ed6ea7480290058dfc77385541	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707720v1_decoy	LN:6028	M5:ab8f184e44faa3d93d59d9e3beba3acc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707721v1_decoy	LN:1105	M5:97e3e0ba281c40270062097594c95b2c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707722v1_decoy	LN:2884	M5:983f9666298bffa6bb3bc09593f83ab7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707723v1_decoy	LN:1124	M5:d1d03191a7579c36409ca1686af957c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707724v1_decoy	LN:1454	M5:648298f5e7a06c49b911d520d02036f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707725v1_decoy	LN:2565	M5:507d9e32ff14b42ffc67abc3e66f8420	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707726v1_decoy	LN:2149	M5:2cc36819133158e39f0ec48e7cadeb08	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707727v1_decoy	LN:2630	M5:2ce79b6f499673a5546b3b608cc6d262	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707728v1_decoy	LN:14625	M5:5c193cc3e52b61477ff6efd7d6bf1168	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707729v1_decoy	LN:7431	M5:a6530e653f0ed096c60f6d44f83a5ac3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707730v1_decoy	LN:5776	M5:8131fcdd109e0c725a9cd0f4dc240efa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707731v1_decoy	LN:4820	M5:e86dbde0af3f5ba60b0ca212f4e51b75	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707732v1_decoy	LN:1227	M5:326c77e23881e6196b8441b3a96fc1d5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707733v1_decoy	LN:7503	M5:c633c411b0c6959cc08d71120f604c30	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707734v1_decoy	LN:9652	M5:97472a33b38a6285aadc3ea8e200a0c1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707735v1_decoy	LN:1091	M5:8eb7237ab5103bf046f0b4fd8956e506	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707736v1_decoy	LN:2467	M5:90141a455f60c4f02dc064d0200707c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707737v1_decoy	LN:1270	M5:40c2e03cacd0e24267f2f495997de86f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707738v1_decoy	LN:4365	M5:5a1da2ab0c8d8ec4e368ecdcb314a951	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707739v1_decoy	LN:4284	M5:62bdd88183d94495bcb948a7c17e045c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707740v1_decoy	LN:10282	M5:d20046e860cc9e220ba67181d6317b0c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707741v1_decoy	LN:5601	M5:8eedf1585943eb4a63b18a14c9d60e08	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707742v1_decoy	LN:4758	M5:453aaa1ccce2e7bcd76462fc6fb82810	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707743v1_decoy	LN:1624	M5:6b23b3de3fd00f6eae35fa84c9f0a1f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707744v1_decoy	LN:4024	M5:a5fc63b6fa7d72420c481475f1a9b25b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707745v1_decoy	LN:1276	M5:1aa689253b47a87a0497755453cc3064	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707746v1_decoy	LN:5083	M5:4df51fadbde93b81c9ce73ae34ad299d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707747v1_decoy	LN:2075	M5:b020b9e14b2329811d8020661a1b223b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707748v1_decoy	LN:3553	M5:3aae97b73e2f50aa215741927751caf2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707749v1_decoy	LN:7010	M5:5f573deb341bf1ebc60148d185f3863b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707750v1_decoy	LN:4718	M5:c90f362bf73d35d5b7ecc0df55b8e7f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707751v1_decoy	LN:3546	M5:0a4232c675b33b2779a9f54185a01bf8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707752v1_decoy	LN:2873	M5:dffaf05b9fdcf311b6631694c9a7f721	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707753v1_decoy	LN:2144	M5:f62da5d7fb084c6276e9144911369e38	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707754v1_decoy	LN:2243	M5:c01ba9f403c104a17c7a56c2e246402b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707755v1_decoy	LN:5343	M5:fc0967e1b54e87ee9e6649ee9e135bfd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707756v1_decoy	LN:4877	M5:7cddadbee2311357be0a6cbc21b7c3ac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707757v1_decoy	LN:3034	M5:8bbd8d0206582bdd7ff0d98834c11701	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707758v1_decoy	LN:2826	M5:d1fe878facfdb974e00aa366bf3f6574	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707759v1_decoy	LN:1221	M5:f538752a6b30c7db1def6888006fdf82	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707760v1_decoy	LN:1169	M5:45388eebdbbcd5727ecb94a69d2b09dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707761v1_decoy	LN:2319	M5:880e2410158ce2b1647e1b9d4e80632e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707762v1_decoy	LN:3450	M5:1a94da832f9b0b1e2cf7e642869d2b68	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707763v1_decoy	LN:2674	M5:98597e188d3ba588151f6808ded88a91	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707764v1_decoy	LN:3912	M5:5b188ee33158e7afbe044f110d28e434	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707765v1_decoy	LN:6020	M5:487d6332ace17c42a8f64aa9adf10de4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707766v1_decoy	LN:2303	M5:05f988a4a7180849c6c81602c29279eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707767v1_decoy	LN:2552	M5:4f8579ec6353f301ef8362afb14c9e1c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707768v1_decoy	LN:3656	M5:dd57001db92b45e0677136beb49e978d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707769v1_decoy	LN:1591	M5:cae5200b9ceb32d63e9183210ec694c1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707770v1_decoy	LN:1209	M5:fde0c42984e1da0ba9aada4b168c4913	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707771v1_decoy	LN:3176	M5:e48eeb05bf1913704ee94aad24e95e39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707772v1_decoy	LN:8915	M5:e41a1182f28ef302e03876ec46b7ba76	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707773v1_decoy	LN:4902	M5:61cb73463b0096ce7f34215a0e9c7d2b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707774v1_decoy	LN:3324	M5:d0d739ef87156a3f1b0083d560547169	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707775v1_decoy	LN:5997	M5:b23670b667f938d11721f9239ce46676	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707776v1_decoy	LN:2618	M5:51e373cda128d4d44cf38c8c0057966c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707777v1_decoy	LN:10311	M5:c35ba91babc524c1b3270599ece90957	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707778v1_decoy	LN:2440	M5:f3bed9c00d53e9777a38a27156dd1659	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707779v1_decoy	LN:12444	M5:bf5be5d1c5a27ad4ae37d468d9bf5990	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707780v1_decoy	LN:5691	M5:2813badf81db953a968eb7d49bc2882f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707781v1_decoy	LN:2717	M5:0a1557b49527e901599bd44d72da8e1b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707782v1_decoy	LN:5277	M5:4061182ba5da9755a2a25e68a304ac01	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707783v1_decoy	LN:4373	M5:3eef41e80ceccdcb21b9dba8a2cbca5a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707784v1_decoy	LN:3224	M5:ef2e57d4220e2cf9680eb6cb27022a8e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707785v1_decoy	LN:2631	M5:3ae2eacb39d96c2b69c8036fa48550e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707786v1_decoy	LN:5385	M5:cba39df25869787d7270324f4c2e11be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707787v1_decoy	LN:3678	M5:ee5041cbefd1339ffe625fe56a2ad8fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707788v1_decoy	LN:1412	M5:cd5878fb701bca2a77f7f0479ada562a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707789v1_decoy	LN:1443	M5:098268af4ad1b71ed7dbf4648ea026a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707790v1_decoy	LN:1098	M5:437c3cf69fd5e7568ba6cd5302f1b0e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707791v1_decoy	LN:3240	M5:b4243a9c38158ab50bf873d91a699467	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707792v1_decoy	LN:1915	M5:44e6058f98843778f5708a68a650bd10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707793v1_decoy	LN:4667	M5:1664dafd7db46e3d2e9257978a3c0282	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707794v1_decoy	LN:7219	M5:69855847368a4c0722753f3097f73427	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707795v1_decoy	LN:3277	M5:21882b529bd5fd85dd805de6c51c1d58	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707796v1_decoy	LN:3473	M5:386834c5cf2dacec8dc5f75898909eb2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707797v1_decoy	LN:4243	M5:4d8a0b4dee134f88bc4604b841d38ec4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707798v1_decoy	LN:17599	M5:6ab64c474c333b7a8e0aaf72d39306a2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707799v1_decoy	LN:5095	M5:f1c458ebccd70c843cec05e23921bbf6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707800v1_decoy	LN:2237	M5:0feef89c01eacd296069717f5c7a7c71	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707801v1_decoy	LN:2901	M5:27662470b962dfea212da33f14909142	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707802v1_decoy	LN:2666	M5:1eb4be22c4e6d37a91facfb3025520b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707803v1_decoy	LN:5336	M5:db6d33944d47e02a8df7cda94a1e996c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707804v1_decoy	LN:4383	M5:bd1e2dc89c9dd82b43d3787afc9abe47	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707805v1_decoy	LN:5446	M5:4103eb12b8c3ebec9cd8fe2f49b6d1e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707806v1_decoy	LN:6252	M5:9218b0dc97e8ccb069eba3e9d676a995	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707807v1_decoy	LN:4616	M5:4d717a57114c8f1b9b4ffb96edcd6615	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707808v1_decoy	LN:3021	M5:eaaf056266a70e2a7be4db848d68672d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707809v1_decoy	LN:3667	M5:4c8c58d51417cec07e970c76f7b280d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707810v1_decoy	LN:4563	M5:4bd16dfab458c175a83a781d1b602d8a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707811v1_decoy	LN:1120	M5:f63cbec018752a7584fd25ba859e6807	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707812v1_decoy	LN:3845	M5:47464e332307f876b9138d74f8726752	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707813v1_decoy	LN:2272	M5:c5516af17e36a2e09f21f2f4120377e6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707814v1_decoy	LN:4764	M5:5d190274f9c28c4642fe1f75b5e3c9f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707815v1_decoy	LN:5410	M5:c87029fcb5e0f94edf755e7b6b18f89e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707816v1_decoy	LN:7150	M5:e2a7085047a795f4ee89232573d43df7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707817v1_decoy	LN:1762	M5:2bf3e07e17fb50802f7da42c78322860	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707818v1_decoy	LN:1207	M5:db2fca33bf9e3730c72e754f7e536e79	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707819v1_decoy	LN:1331	M5:b96ffe2a3a7a75977f2286d021069bc7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707820v1_decoy	LN:8307	M5:89d9580408ce4fde62950344c2daa448	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707821v1_decoy	LN:2276	M5:2a9fffb25e3ccf46680306388d4c2e6a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707822v1_decoy	LN:2575	M5:8e5278c0a004efc105d35744a6aed334	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707823v1_decoy	LN:3970	M5:ef86294088659e3b6c564f7a2c94abd2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707824v1_decoy	LN:1352	M5:af1ddf1aad7bb03a0c72d325e8e9a52c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707825v1_decoy	LN:3040	M5:673e8681ea9b0fe7b4b74a011c7780e7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707826v1_decoy	LN:2070	M5:83ff186bce877c493f356e110486b13a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707827v1_decoy	LN:2913	M5:156af338c90535ad8ddbebc3cc2b8e06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707828v1_decoy	LN:2389	M5:dec17b4db1503252e0d25e88839aef19	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707829v1_decoy	LN:1835	M5:495cf270e534859f024d452fa5714a83	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707830v1_decoy	LN:4807	M5:9d8e879d40a82477b244fe7baf4f1603	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707831v1_decoy	LN:2201	M5:661353dc86a8b62e524ea43ee3f39c6e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707832v1_decoy	LN:1265	M5:e33ce5ec06d99813aca09515f057e64e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707833v1_decoy	LN:1961	M5:93e5f197aa47e632cdc4f4f9a06504c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707834v1_decoy	LN:1064	M5:28a2c878efec380df24a5544738eda91	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707835v1_decoy	LN:1932	M5:bf3bff12edc1fb4331c341b1b2044e32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707836v1_decoy	LN:3213	M5:d47bed4a51e112b3d415b77d354290ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707837v1_decoy	LN:1178	M5:2a4f6a9f9df49215bb56bfbe5d6e1990	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707838v1_decoy	LN:2926	M5:5f28eba962c1026228afdff4fad6ade4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707839v1_decoy	LN:1038	M5:b42a95db827e89510d3dcdeac5fba1c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707840v1_decoy	LN:3298	M5:54dc58ad6f4d92475e298f41206a1118	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707841v1_decoy	LN:8992	M5:176684391390b0afaccaac0eecdb9560	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707842v1_decoy	LN:6698	M5:b309273a9a78c30bcd5a5573742fd06e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707843v1_decoy	LN:4880	M5:3ad4a232fe303ab7c09600c91b6c406b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707844v1_decoy	LN:1766	M5:85cb4f0b6ab4d7dcec41ef37ca81ead2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707845v1_decoy	LN:3532	M5:fa5f7bc4de1539f23d5610c26d69ed49	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707846v1_decoy	LN:2297	M5:2bda3374523a39aa9c8766059468392e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707847v1_decoy	LN:1234	M5:23e58f01c32ab1539dc5738c36b70940	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707848v1_decoy	LN:1205	M5:c9b75dbdb9a2d4ee4648ed7fb537fb0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707849v1_decoy	LN:2790	M5:20b3eef55d3dad7a5dbcd68268dad36c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707850v1_decoy	LN:2006	M5:67d720cd69f97ad773cdcb3ccde8d47e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707851v1_decoy	LN:4593	M5:7c836d280ec9794d222476d02e21b416	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707852v1_decoy	LN:1579	M5:ab4542b394c8e1133f8eba10d896cb44	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707853v1_decoy	LN:9597	M5:9d6b74ff3ae40b1134f4b1f1eabe16ff	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707854v1_decoy	LN:10451	M5:ec7353db2ae0657678d29512a5b78b59	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707855v1_decoy	LN:3219	M5:b522f004eb3c1bdf17fe74e82e23ff88	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707856v1_decoy	LN:2300	M5:7a18b1dc033c5a406a5f752e8a7d5a6d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707857v1_decoy	LN:5985	M5:28c60286011df7faa5b7167d8dc7a5f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707858v1_decoy	LN:2959	M5:682104fe067bc0a5e18763b5d0eae010	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707859v1_decoy	LN:1340	M5:3b47b99a35fcc0a437518350a37c97c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707860v1_decoy	LN:3148	M5:cc961e4253553c5534e478b629b89930	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707861v1_decoy	LN:2242	M5:beedf4d2ae00fca7cc2cd7e9d4ce6012	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707862v1_decoy	LN:16513	M5:968c6df8aaaaa1015e74f591e4722ed5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707863v1_decoy	LN:7821	M5:9c8e1c87e1b58622c67edbf732b7ce9c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707864v1_decoy	LN:2159	M5:37c9ce7cb170bed17a0deb982f64fefc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707865v1_decoy	LN:2114	M5:8b637137aa5f04b43be61da029e5f818	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707866v1_decoy	LN:4109	M5:1d5a765b813cd25ff873c52ca2b47f05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707867v1_decoy	LN:1544	M5:c2744b7344993ebcf11d21cb098cace1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707868v1_decoy	LN:1005	M5:241518a7a0343d82a0d99b1dc00e5d79	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707869v1_decoy	LN:8632	M5:010737c4caab4d5e629753ad40bee3bf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707870v1_decoy	LN:1012	M5:88b3e83459db1925338cff6156325503	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707871v1_decoy	LN:4728	M5:dcab24555bd79f11062bd6e856a1db4a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707872v1_decoy	LN:2165	M5:aff31850364e11f37ba76baa5b7164d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707873v1_decoy	LN:7591	M5:b034989a9fb62216a2547cd1206f4185	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707874v1_decoy	LN:5202	M5:1e514f0c86c918e80fa4b29c206cb8cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707875v1_decoy	LN:4241	M5:da66844cc4d4846716264b16f77233a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707876v1_decoy	LN:4131	M5:60562638c91c3b3655e2ab9544600425	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707877v1_decoy	LN:2272	M5:d672677153fa65839a94ae64d9284d49	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707878v1_decoy	LN:2085	M5:d1bc85197aa7215a4b0248a74c19b399	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707879v1_decoy	LN:4346	M5:1999b7a1b498a212e212e60377adb20d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707880v1_decoy	LN:1208	M5:ea9da47963d703e465aaff5693250f76	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707881v1_decoy	LN:4543	M5:e84492cd2aa22936e00b280fcaca8212	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707882v1_decoy	LN:2772	M5:bed5000e1788ade3ad5a8541cf1c1671	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707883v1_decoy	LN:2490	M5:3d040ea1d7a17b15bf44f59b8e66c98c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707884v1_decoy	LN:4568	M5:bd5a8cfffb4d5bab0900b4fa1fbf9390	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707885v1_decoy	LN:1776	M5:f0f2b210ad8e779eec5a4ba478c83ef7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707886v1_decoy	LN:2699	M5:91fad31e963c9f7821cf37705e55f40e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707887v1_decoy	LN:3534	M5:f6d25106c5942148df4207ebc4a60371	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707888v1_decoy	LN:2424	M5:4857413cb43abc01f2f0c2d56e196332	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707889v1_decoy	LN:1747	M5:e1946468f8d77d4ac72dd72fe8ce04f8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707890v1_decoy	LN:1088	M5:698423687f8bc007b40065a2658b7360	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707891v1_decoy	LN:1143	M5:3dbbd76127230ad72adb348524c250da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707892v1_decoy	LN:2530	M5:8909228bbdb37a62a906447c5b24616a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707893v1_decoy	LN:8049	M5:a4e81d020fe37025f26c26aa8241f26d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707894v1_decoy	LN:1366	M5:69423d07e5d284b7ad365c144aec6f4e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707895v1_decoy	LN:4284	M5:da455b511b9da89b4527ee045c5fe231	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707896v1_decoy	LN:33125	M5:10522217e43c9d9228b02fc14c418df3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707897v1_decoy	LN:2137	M5:962521d05f6b98894c65d3669ba66008	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707898v1_decoy	LN:3840	M5:561d50151a7132f385be0617165bcecb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707899v1_decoy	LN:3087	M5:46cc4f61d95475ad4c963e9bfeb206fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707900v1_decoy	LN:2041	M5:cea01cf71468a810b970138149139764	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707901v1_decoy	LN:3344	M5:ef03bb9d9f28ee51bfc7291ee41812e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707902v1_decoy	LN:2921	M5:dcc9f313bc6e72cc000ac62e62e975f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707903v1_decoy	LN:6581	M5:6346aa1b0e3055e121b9cdccb04a53fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707904v1_decoy	LN:3968	M5:ed15d6545609df15a0758922f36c9f87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707905v1_decoy	LN:2339	M5:af66f6d8d03e1c43cef4284aef73ed96	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707906v1_decoy	LN:1243	M5:bec4227b2724132e7ac912e4532bcf8d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707907v1_decoy	LN:7776	M5:a9e8cc852787e0a7dea34bd16fd28b35	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707908v1_decoy	LN:19837	M5:63f4cfca34f0fcd66c826ccc8c6d6cbd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707909v1_decoy	LN:1737	M5:0eb45f3727a363ec209755519593220a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707910v1_decoy	LN:1098	M5:bda7161c475d6f7bae40ce030d70fe87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707911v1_decoy	LN:1893	M5:80bef2e1b21000a202a974145a551fe4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707912v1_decoy	LN:1281	M5:96d1e0d5628111d9566a6da789c6204b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707913v1_decoy	LN:1527	M5:ad42dca85dd0540c9229a86997665245	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707914v1_decoy	LN:2055	M5:c7f0324e70cef84566fa5453dcb23f5d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707915v1_decoy	LN:2527	M5:f7d3cdbc2f96d05bc8ff741d46f2f687	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707916v1_decoy	LN:3275	M5:d9702219a1b8982c63cc1d6238368ab2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707917v1_decoy	LN:1265	M5:6df0a4af8c86a2528464f45af7cbaccf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707918v1_decoy	LN:2623	M5:5c6afdd9afcdaae5399f684978746b65	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707919v1_decoy	LN:4850	M5:aed47145c2269b8c33a71652002e351f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707920v1_decoy	LN:3584	M5:47dcd6ad41f139cfd6b9a02581cad11c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707921v1_decoy	LN:2561	M5:33902e088970543e1715ee99abdcf7b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707922v1_decoy	LN:3041	M5:313f5e86963d937b91534f4895c3a590	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707923v1_decoy	LN:1409	M5:6af5cfeb86bc84ecdcfb91e994b4bdbb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707924v1_decoy	LN:4596	M5:3415bc1f3a762bb7077c328b9e9e723c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707925v1_decoy	LN:11555	M5:10cf29455a308a0380471d6bce16f4a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707926v1_decoy	LN:1266	M5:ed2740c08c55e9dbdd3cf9db469d0df6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707927v1_decoy	LN:1079	M5:7d006b7ffa2791321663578e50f456f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707928v1_decoy	LN:1087	M5:e6a75cbd458016b1643e76ecc570d33a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707929v1_decoy	LN:1226	M5:21256ce4fdadc803045a9b8f60dfe16b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707930v1_decoy	LN:1131	M5:2f7c4c54c98b465c14120d32e5d60362	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707931v1_decoy	LN:1199	M5:68471da27aefc5565f37a51052c09c8a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707932v1_decoy	LN:1084	M5:ff5f2aa407bb1f0573a4d815fb69f917	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707933v1_decoy	LN:2038	M5:1b9a682cbf0c31fe8f29a4aa0bbef274	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707934v1_decoy	LN:1070	M5:f8c939429a099c8eaead4319b5ecd2b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707935v1_decoy	LN:1312	M5:00ead3e9dd86f6d5e7d499e285b509b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707936v1_decoy	LN:4031	M5:9175dddf96d1e576065b2465c6e2b567	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707937v1_decoy	LN:7445	M5:f83991a23f7bca6045f72a0bf34ecf13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707938v1_decoy	LN:1770	M5:d7487b3fc5cbe693cdcd5ef883b5f00d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707939v1_decoy	LN:5600	M5:5fc39cbf76db7d0c1d56123a313a22c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707940v1_decoy	LN:1882	M5:f239e0af7db0be33b82e8e4dc2405165	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707941v1_decoy	LN:1170	M5:e7c47b0be4905c7dcf70b8659a334abb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707942v1_decoy	LN:1300	M5:1beccd3ea3988863bad1b7614a1db1e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707943v1_decoy	LN:5325	M5:54c4ba54e1ad9eebc7832dfb6cf778fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707944v1_decoy	LN:2043	M5:669c152c4b3e10d1f61d5afb2cf22bcc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707945v1_decoy	LN:1072	M5:d9416b21be3f6603426526a22e7e558e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707946v1_decoy	LN:2463	M5:ce498b9d34e1447317c0d5d27aa0f911	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707947v1_decoy	LN:1010	M5:4183a38dcef3c56b79dcf7eae090e37f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707948v1_decoy	LN:1432	M5:c261bf235424d74a7b1d8624bb8d6ec2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707949v1_decoy	LN:1162	M5:26aeb5ffbd148e35fa48fee69317843f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707950v1_decoy	LN:1095	M5:2c795c49d9b77f2b5c0ef5c97e76ae46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707951v1_decoy	LN:1118	M5:a0c0ea97493f7c511c5b0af1e8913e92	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707952v1_decoy	LN:1383	M5:fcc78a7bf9b47bb52730911e285ad0f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707953v1_decoy	LN:2289	M5:ba3eede08e65f36da588370a142cc02a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707954v1_decoy	LN:1648	M5:de71b9c9ca48f28bc0c9d13c5139ce68	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707955v1_decoy	LN:2203	M5:4c9964a811b62ea018169d81ba474499	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707956v1_decoy	LN:3270	M5:316a59db52a456d6aa5e140e1b1c8794	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707957v1_decoy	LN:11499	M5:cd3bb1a0e33bc1aafb51df407fcf16df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707958v1_decoy	LN:2474	M5:5909618b2a56c4db15b017bfff248a13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707959v1_decoy	LN:2294	M5:bfd4a30a41e5e647cba935da2e8a63de	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707960v1_decoy	LN:1238	M5:8025797164ec304ff940e4ad94643c70	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707961v1_decoy	LN:3410	M5:02a40e206c78446d368b6001622aa540	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707962v1_decoy	LN:1523	M5:7f11ba71c0814d0ca2b3839d55de672d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707963v1_decoy	LN:62955	M5:d620b771cabe5b2cc4b943ffa6d69a68	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707964v1_decoy	LN:6282	M5:fc00ea543316aed78deefeac0eaf8727	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707965v1_decoy	LN:3836	M5:97e94c098f92403b805a0a60f9475542	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707966v1_decoy	LN:6486	M5:a977897a46254d42ed9a60e6ed5d9d20	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707967v1_decoy	LN:15368	M5:220b351d87053eb9b844bc6e6e5182a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707968v1_decoy	LN:9572	M5:060b9bb36bc05042b371bfbfc6618e3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707969v1_decoy	LN:6413	M5:b25e652840d89c9eef74c04703958f9f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707970v1_decoy	LN:4104	M5:d103bed226a1a7b95d98a8d61e39f70d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707971v1_decoy	LN:12943	M5:8a88d2df497490f21c8c2b796544f699	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707972v1_decoy	LN:4650	M5:93e792bf92036380920f5d06321cafe3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707973v1_decoy	LN:3080	M5:127f70f3cf2cf09e8c7a399c471acf75	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707974v1_decoy	LN:3134	M5:a0447f79285905c6b9f2202fdb83f838	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707975v1_decoy	LN:6211	M5:931aa6a0b0412241d93c942acba0c103	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707976v1_decoy	LN:1126	M5:c068c96f088fa2ef7cfe6a805c22121a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707977v1_decoy	LN:1101	M5:e86b95e84b7662e5e6e509be83db4b41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707978v1_decoy	LN:1101	M5:d46f001c034076f4a3687b647a980623	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707979v1_decoy	LN:2648	M5:fe4d1437f61ce0406d36a071f4e7293a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707980v1_decoy	LN:2973	M5:9c4cb203ab1d6a54a7ed36d116c60853	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707981v1_decoy	LN:2520	M5:3ccf197ae78ce07e23eef5e3c31fb576	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707982v1_decoy	LN:2318	M5:6e5cf7df1252379ee351fb2386bcc144	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707983v1_decoy	LN:2606	M5:64cc9674054ed4f7cdf0701da89de296	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707984v1_decoy	LN:2205	M5:e5814756cacf0c02827237dcd24155a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707985v1_decoy	LN:2929	M5:6a2895e9dda391590b1db42aea33e330	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707986v1_decoy	LN:3869	M5:9640cfef88fffced10f0edaf20dbda2a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707987v1_decoy	LN:1117	M5:60f8230f4e335416aa92256695cbcf46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707988v1_decoy	LN:2960	M5:b0447a959fdacb8b553c3684184cf036	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707989v1_decoy	LN:1009	M5:75d4d43433fa532ce2da4a724ee25c42	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707990v1_decoy	LN:4048	M5:f0720d93745203f7d155f219ab83b618	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707991v1_decoy	LN:2193	M5:fede10b713c7d561d4872feb26040c3a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_KN707992v1_decoy	LN:1830	M5:1bac13a3ad2592a344e18bf8de117574	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000001v1_decoy	LN:25139	M5:9b27ee6060931ae7d17e451b7739e547	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000002v1_decoy	LN:18532	M5:9955447b0a6444031f1d68c821fcea22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000003v1_decoy	LN:15240	M5:b635cbc1fc3962e93bc1427bc678396e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000004v1_decoy	LN:13739	M5:7fa6d2a124f7c9bfeb030b859269f78f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000005v1_decoy	LN:11297	M5:44c68451b1d90987e31184e887a24455	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000006v1_decoy	LN:10074	M5:ddeeb2059f6f27dee5330cb501a11446	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000007v1_decoy	LN:9891	M5:30b47b3ef6b82a46ccfec6573b0c6c10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000008v1_decoy	LN:9774	M5:f0bed43412c69b6db572994c9d5d9cd4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000009v1_decoy	LN:9727	M5:0cab8d3c0896fb15383dc8aaef1a1f9a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000010v1_decoy	LN:9358	M5:aba5595273a0e4398df3a8323523d10c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000011v1_decoy	LN:8920	M5:fc623f57c6ad9441d3750c0f51722a0b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000012v1_decoy	LN:8479	M5:6dca96b0605fddf041e27a9f4beed770	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000013v1_decoy	LN:8312	M5:f34a4b1860ec9fbd1acc736a3a174193	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000014v1_decoy	LN:8261	M5:6deaa38e9033c12ed1ad7f62191a3e04	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000015v1_decoy	LN:8131	M5:c3df1d07395395fb96b81e27ef3dcf61	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000016v1_decoy	LN:8051	M5:f732550392ca9c30b42b4c6acd5d9263	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000017v1_decoy	LN:7832	M5:03557dc0d8d0509da30549dc16031c51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000018v1_decoy	LN:7710	M5:942aca2604695877a0a642916aafd2b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000019v1_decoy	LN:7702	M5:c6c2453adbb040df0ea58395995ebae1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000020v1_decoy	LN:7479	M5:5b348e642370fdd96c7f2a306318869e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000021v1_decoy	LN:7368	M5:0693c472fdc0225c133374a15973bec3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000022v1_decoy	LN:7162	M5:6629bbc8b7d3fa10074025773e597c29	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000023v1_decoy	LN:7065	M5:6b413d9f61a68a7ce1ea620aebb3be6d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000024v1_decoy	LN:7019	M5:14f555be268a0666a71794d0515cd6d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000025v1_decoy	LN:6997	M5:470d24c11b0ea5dbd4329912231aba50	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000026v1_decoy	LN:6994	M5:1a45d626e4f7add376267b1e77bcc942	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000027v1_decoy	LN:6979	M5:6890d5c807ceff3e680405d80c19b990	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000028v1_decoy	LN:6797	M5:6cde21bfadb3f954f76aba8775f5b89f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000029v1_decoy	LN:6525	M5:091fdeaa7841b60f964f1a9cedc12bd0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000030v1_decoy	LN:6246	M5:7c23df0bfe1cc7d18d52be126f396cca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000031v1_decoy	LN:5926	M5:5555324457dbc04a20ac656a15cce856	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000032v1_decoy	LN:5914	M5:67d2d8955ebee73fe7f8f3764e4158f7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000033v1_decoy	LN:5898	M5:de8113c2b1586e776f28207cd56cec1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000034v1_decoy	LN:5879	M5:1c6aa8f142642d8cf57f4f7029a20061	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000035v1_decoy	LN:5834	M5:29c393ec5d6804ee5dc06b435ffc02f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000036v1_decoy	LN:5743	M5:2f131c59606d7cb8cf6c6c495ce84aa4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000037v1_decoy	LN:5577	M5:20bd1281fc32355adf567b4e0ff160a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000038v1_decoy	LN:5413	M5:3d2ed60178406278eb02030b7c0cc328	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000039v1_decoy	LN:5250	M5:62ebce054cc44d5c32625c44fa1e5ff5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000040v1_decoy	LN:5246	M5:7cf464d2ec26fa4cea2bfd25f995969c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000041v1_decoy	LN:5118	M5:ad3a1c8041863a52b7fa6d6d56ce0d3b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000042v1_decoy	LN:5058	M5:bce45aec79ec4861d8442ec3d738761b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000043v1_decoy	LN:4959	M5:f653839b5c54df56a1a2fdd7ceb42db8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000044v1_decoy	LN:4853	M5:3505d16e35e056be0892167f5a564661	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000045v1_decoy	LN:4828	M5:d43e63bb33a6cb65d5cdd1ca31e94c19	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000046v1_decoy	LN:4819	M5:db9c73fa0d581cecaf0175aab4a0fc7c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000047v1_decoy	LN:4809	M5:1b157b5c5c208470638b188e23b55a59	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000048v1_decoy	LN:4710	M5:ad9552980f4f1bf74b72740d14d2f5ac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000049v1_decoy	LN:4680	M5:5bb4ddca04b26e3afd0bf218f2947a7e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000050v1_decoy	LN:4645	M5:6a821c450a9bcf89dfccaa62d46212cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000051v1_decoy	LN:4514	M5:bab340cdaa58e6d32ad1138612c84e07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000052v1_decoy	LN:4439	M5:3cd292c1df3855202250324272a95b5b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000053v1_decoy	LN:4416	M5:73c9659871560313e754f9363053d56c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000054v1_decoy	LN:4409	M5:8ab5d2ce8c35201fa585fdf6f4ae670c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000055v1_decoy	LN:4392	M5:e2b0cc1cca4b7ed60f85199816696690	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000056v1_decoy	LN:4359	M5:ad16965c23d8e07c823a47e9b098f162	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000057v1_decoy	LN:4319	M5:3bfb10064835da4e9caf7e8deb1857f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000058v1_decoy	LN:4290	M5:947253137780def5c1c0db12039bdeca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000059v1_decoy	LN:4242	M5:2a6de19fbea3d44dbf76c71f1778b47e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000060v1_decoy	LN:4228	M5:8b1e73bd29fd4c77bb54fb586721b1a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000061v1_decoy	LN:4222	M5:8576a97cd4f61cd6455b423f14eaed92	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000062v1_decoy	LN:4216	M5:d885db4b883ae34dd53ed184783c2144	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000063v1_decoy	LN:4210	M5:1bfa5c8aecb62137e83c3274991deceb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000064v1_decoy	LN:4206	M5:48398977c32247e425a6a85f97026636	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000065v1_decoy	LN:4102	M5:f7d638a8f28d1c9842128b1225325947	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000066v1_decoy	LN:4101	M5:78254b10a1884b61ecbfc72be3ad38d7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000067v1_decoy	LN:4083	M5:19683f0eb0d378e403a918d10931eb76	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000068v1_decoy	LN:3967	M5:2519be1b425e386f50cf02ec88f8f903	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000069v1_decoy	LN:3955	M5:7c186eab354093fe3b26a9e757407fca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000070v1_decoy	LN:3945	M5:4cf91327091051082a0ff114dd170f21	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000071v1_decoy	LN:3930	M5:d97123bfd4ea271ec354c170d89d80d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000072v1_decoy	LN:3929	M5:147eecc4607f1ae7fd1dff1c0f98ca25	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000073v1_decoy	LN:3924	M5:84bdf303142b233c179ecef62ab58b07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000074v1_decoy	LN:3919	M5:648c37f3fa6e7d658440858761213e7c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000075v1_decoy	LN:3908	M5:36f5d13bc1a3b72a21c0a4b68148d469	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000076v1_decoy	LN:3892	M5:052f146ade5330135e5381db9c779f75	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000077v1_decoy	LN:3890	M5:22c368b726169405e1f364115fc2356a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000078v1_decoy	LN:3859	M5:85a6fde3123e4ae2ef854e83b790e55d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000079v1_decoy	LN:3846	M5:21dfcbee386bf64a6e7639d212fe4ba0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000080v1_decoy	LN:3835	M5:7f8ace0d7314cec254a8ff5addedb0f7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000081v1_decoy	LN:3830	M5:d40bb66c2d194acad4d612db8d34e1b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000082v1_decoy	LN:3828	M5:c6c7826a848a366317f63f5db5dabe87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000083v1_decoy	LN:3825	M5:632e853a99e258e0ae002c0c03aa7caa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000084v1_decoy	LN:3821	M5:67720b3ea8a4c3be301aa0519627e306	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000085v1_decoy	LN:3809	M5:8ee2faad62aedf582f3c33635df47f84	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000086v1_decoy	LN:3801	M5:dbd8292192827196a4c3d545bfb9b67c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000087v1_decoy	LN:3799	M5:15066eea555ea13dca8b28620db8ae45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000088v1_decoy	LN:3737	M5:83437130e836bac50aba2aa79fa9d80c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000089v1_decoy	LN:3701	M5:16d790e451ef2c33018834904a04c177	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000090v1_decoy	LN:3698	M5:4045cd2ec9d306542cc3804aab489587	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000091v1_decoy	LN:3692	M5:3a1e6d05d94debffbe6070b59627d610	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000092v1_decoy	LN:3686	M5:f2bcad40026ed9d729d9c31034159300	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000093v1_decoy	LN:3677	M5:50536f98dd2e44e8a77c5f9d289ad87c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000094v1_decoy	LN:3664	M5:65fd750160fcf7b7944c8e015e46a443	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000095v1_decoy	LN:3613	M5:3257e4358f19507804bfac363c932664	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000096v1_decoy	LN:3611	M5:d10add8e30105013e264b6feede833e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000097v1_decoy	LN:3606	M5:c78427ed0c2856bbf8131bd73e54c3f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000098v1_decoy	LN:3584	M5:81a78209d26627e698602af1848e2b03	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000099v1_decoy	LN:3581	M5:90e3913247adb7b30059e051bbcefe4c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000100v1_decoy	LN:3543	M5:3dd50a694f9e6011fc694fab191cb759	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000101v1_decoy	LN:3528	M5:0eefcbd5209d0d32ccf640f76a69f676	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000102v1_decoy	LN:3527	M5:0bc37681f399eec3b3b7dcbf22498b37	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000103v1_decoy	LN:3496	M5:c04b909a1562f77654eceacd0b8a935f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000104v1_decoy	LN:3493	M5:fb84ec004fe99371b9b2d74bfb8570ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000105v1_decoy	LN:3484	M5:e07ccdf102c986c26b2bda46045943b2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000106v1_decoy	LN:3435	M5:4be97b9bc8d65dffe17f17ef9f801240	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000107v1_decoy	LN:3391	M5:0878850e674ca72172a37319b9321acb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000108v1_decoy	LN:3374	M5:5b7dd688c7eafb7b418766bdab494a84	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000109v1_decoy	LN:3371	M5:fb407b611c6eab3bb1609123cbeb47c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000110v1_decoy	LN:3361	M5:4851563bcd9e0f7af3768f20f33bb22a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000111v1_decoy	LN:3351	M5:24701a0d266ed39e5bfd3757bbfa218e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000112v1_decoy	LN:3340	M5:d10fcebc376b84a0e301d97eff284137	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000113v1_decoy	LN:3320	M5:05f2acb99e398b98f272d297727f28d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000114v1_decoy	LN:3282	M5:d20adc7c458920890e8c1c56717c60b3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000115v1_decoy	LN:3278	M5:9baab7452d6c49d97acd68acc83ab547	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000116v1_decoy	LN:3260	M5:b2b6112ec6f9d22a7842f78e37d6a3b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000117v1_decoy	LN:3258	M5:edb413acc1f07788b1a55b647c56997c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000118v1_decoy	LN:3253	M5:1143d3e269aa80abfae249b7c653814c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000119v1_decoy	LN:3247	M5:8d905fa140b8fded3a9560d24a32cfe9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000120v1_decoy	LN:3230	M5:8c96125639143835c0e5b29884855e8a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000121v1_decoy	LN:3224	M5:6314311a75a1832245fb87dd86655de8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000122v1_decoy	LN:3216	M5:80770770768ebb238cb4572d674e1579	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000123v1_decoy	LN:3212	M5:63a4964026424edcd64a0e174de5c51a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000124v1_decoy	LN:3194	M5:c68922465f39c47a5ebcf4767811e41e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000125v1_decoy	LN:3189	M5:9e4ae67a2bea0ce8335cfb82e125cc2c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000126v1_decoy	LN:3177	M5:94806d6a47b3781ed8e5004a2c577255	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000127v1_decoy	LN:3176	M5:419d834659cd952516de6d9dcae8c3b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000128v1_decoy	LN:3173	M5:050df236c1fa3a63c31f33b73308c168	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000129v1_decoy	LN:3170	M5:61f6339992ffab5d3091b4a3b3baead8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000130v1_decoy	LN:3166	M5:1fc75a1345ce98d6f25ba4d916b5d7f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000131v1_decoy	LN:3163	M5:c262387ff17ca2ee56fb368575275676	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000132v1_decoy	LN:3143	M5:790557e383cdc852732e3da2c6b6c615	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000133v1_decoy	LN:3137	M5:ea2bf77f700236081cf8eb7aa0d9a909	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000134v1_decoy	LN:3116	M5:a8ae3ccc9f17c0f0edcacc5079219d51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000135v1_decoy	LN:3106	M5:89002d8689e45952391a7984d69df23d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000136v1_decoy	LN:3093	M5:2dc162e245d6ff81936bc650004ec8cb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000137v1_decoy	LN:3079	M5:38068261005ed014603a09dac9438db7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000138v1_decoy	LN:3053	M5:bb3a8eab3c8ea2aa961e65ec5e1d91da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000139v1_decoy	LN:3051	M5:87d0e9b49ecda7ba160f80012ca40de3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000140v1_decoy	LN:3015	M5:303ba1d7f1155342056b491810358e6b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000141v1_decoy	LN:3012	M5:c7a07f27a9874d99e33c27c2a2280cd2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000142v1_decoy	LN:3009	M5:d88319790f0a837a02a625cfdb6c1971	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000143v1_decoy	LN:2997	M5:2b912adb843e4f2d90726c884ca7ab4b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000144v1_decoy	LN:2997	M5:f6bf68bca6151666f29be31cb16f1c0d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000145v1_decoy	LN:2983	M5:3473d9484854e710526e0c7ccc80b5bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000146v1_decoy	LN:2979	M5:90d61da24b116c2bacb63747666a326b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000147v1_decoy	LN:2967	M5:c84a0386ea78dc84323f55723fc42ef1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000148v1_decoy	LN:2967	M5:a2b48635d63117baec9f7dbeae644928	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000149v1_decoy	LN:2966	M5:0b15201439291bf53043abb6dcdab743	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000150v1_decoy	LN:2954	M5:f36be073b0668fe6c56206c0a9bcf742	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000151v1_decoy	LN:2952	M5:0aa12dea5cdf7b9dea2d56a71e233dab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000152v1_decoy	LN:2934	M5:70eafae03cdb824f956cc77cc9b342ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000153v1_decoy	LN:2918	M5:d7711561e6c2a87e3771c3ce9e28ffaa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000154v1_decoy	LN:2895	M5:b40089d10ae6fb3b2a90a260a6469229	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000155v1_decoy	LN:2887	M5:9be2679cff5e171c42de84446d6fedfa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000156v1_decoy	LN:2879	M5:100d6fd294d6998c7928887ba353f441	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000157v1_decoy	LN:2878	M5:e081c58ad4b64da9af95ca27932e7ebb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000158v1_decoy	LN:2872	M5:0469343a7677dac01c66bf219aa0611d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000159v1_decoy	LN:2868	M5:fbc27037c78cd3b3982d7f792147d4ec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000160v1_decoy	LN:2866	M5:33497edef237132c3e3efe7304d5a685	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000161v1_decoy	LN:2865	M5:65371a3805dd2779f5807f1849df8a2f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000162v1_decoy	LN:2864	M5:7e9448d377e58534ce56c68cd97278d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000163v1_decoy	LN:2859	M5:93dbbd6f23a68673abfe169d241204a2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000164v1_decoy	LN:2854	M5:c468c0f380889b274a988802cc95f8ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000165v1_decoy	LN:2830	M5:bb1fb10e20767215b036dbad18b92018	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000166v1_decoy	LN:2828	M5:9f9279b092a64e7648f91091e5112414	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000167v1_decoy	LN:2824	M5:774c1242a9fec9c39b231e3a4244c48f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000168v1_decoy	LN:2819	M5:5e794be8f02e6190282545c4a587a131	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000169v1_decoy	LN:2813	M5:f7e3bb8a09ce56ebcb9638b710cd2ce3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000170v1_decoy	LN:2809	M5:8fb1846cc5b62db20428a2bf2bfaded5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000171v1_decoy	LN:2802	M5:9bd40f006580d92c066ff544ddc22d8d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000172v1_decoy	LN:2791	M5:5f91fa423cf6ea436c30cddd27d2f7b2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000173v1_decoy	LN:2783	M5:698dd6fdb96a0f8653015f1bf3406d29	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000174v1_decoy	LN:2778	M5:3aae745709a336cef318bd095be7bf93	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000175v1_decoy	LN:2777	M5:14ba8c26038f60c5a103e430e7fba5e5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000176v1_decoy	LN:2770	M5:467d903833c580a48fa311a7a15c61c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000177v1_decoy	LN:2769	M5:beb768213f5d753b7f6a857687fb1c9b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000178v1_decoy	LN:2767	M5:2d998199f83204c294ff1e618648e88a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000179v1_decoy	LN:2763	M5:9244414120396c3b53b847abfd80bc74	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000180v1_decoy	LN:2745	M5:8657cb328a0d649107216245ce042ff3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000181v1_decoy	LN:2742	M5:9a35552497474ad6e9b35b843c759b60	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000182v1_decoy	LN:2736	M5:4fdea3271d6795c56d47fc6d54f11972	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000183v1_decoy	LN:2729	M5:5da3445ac176ed7cca1131267e6dfb95	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000184v1_decoy	LN:2726	M5:9cc9d79dd54416be6fc2b500d4ca8223	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000185v1_decoy	LN:2719	M5:8d898d7f057764e7d11b7121f8cfb366	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000186v1_decoy	LN:2715	M5:0bd839a4a62fe7568bf02c2bdf660047	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000187v1_decoy	LN:2708	M5:0bcff7297c716264bc76813a0516ad12	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000188v1_decoy	LN:2704	M5:0ceefe5f0373922aa642a3180f917c9d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000189v1_decoy	LN:2692	M5:a1ed1d3ee4d5cc17aae0d9d0fa0775b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000190v1_decoy	LN:2691	M5:43df7d9d35f2d15ff844b2f4564338dd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000191v1_decoy	LN:2690	M5:b7809dc0c98369b8235b36dfbd7e2ae3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000192v1_decoy	LN:2687	M5:a61002b74d916bbe06d09eb62cdb9144	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000193v1_decoy	LN:2677	M5:02cb7169934dce464116e8644638b22d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000194v1_decoy	LN:2668	M5:0e691a59ae468d427df06bdb2e34e315	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000195v1_decoy	LN:2668	M5:4e1222dfcb9ce80e3a7544e3af791e70	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000196v1_decoy	LN:2663	M5:5e4092300f7a24534a4fc2afe6c68b5f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000197v1_decoy	LN:2655	M5:8bf68a2085f6903253894b5ac2be0d10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000198v1_decoy	LN:2644	M5:035eac523101444b286c852a129bb0f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000199v1_decoy	LN:2642	M5:518ada0e1f2b63c0a99a0154b584120d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000200v1_decoy	LN:2632	M5:40870ec46cc59053e01def95871a68eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000201v1_decoy	LN:2632	M5:af03b437e04ad5f5cc86e2a67adee8ff	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000202v1_decoy	LN:2628	M5:fa043c52050897ca77e0b475bc77776f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000203v1_decoy	LN:2623	M5:0761598e68213207c0d256d5e7e1bcbb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000204v1_decoy	LN:2622	M5:502e3af12800de14f86b2cfd3de9bd2a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000205v1_decoy	LN:2619	M5:74fb4a710fd8bb14104c1cbde54ee247	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000206v1_decoy	LN:2605	M5:73c6a5d1feb99a88b122655b4dcdd742	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000207v1_decoy	LN:2603	M5:2d1e488c4ee483df72211d2762b1b7cc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000208v1_decoy	LN:2601	M5:c72de668308e8c098888b96b543703d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000209v1_decoy	LN:2598	M5:33dd6c20ea4712d7d3b200db8f026cbf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000210v1_decoy	LN:2597	M5:cd6c72af3776b51a1619b01b5eff8bc8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000211v1_decoy	LN:2596	M5:40ba1e4b99e2625ec5a5cc4038fa9a06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000212v1_decoy	LN:2594	M5:fe8d3058e4af4e6063be2c2f955b2bfb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000213v1_decoy	LN:2586	M5:2ae32263b19fd8541852cb566f82be30	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000214v1_decoy	LN:2585	M5:873a6619e50330ccdcebeb56cf56b70a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000215v1_decoy	LN:2583	M5:13d7b02826997cd3db01ccfc712000ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000216v1_decoy	LN:2578	M5:f891eed2ad267879c435cbc346ebfaec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000217v1_decoy	LN:2569	M5:17baf081bd68afecee4fb26591fb7d44	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000218v1_decoy	LN:2569	M5:b543771b65b36e55866a9191f68deb0e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000219v1_decoy	LN:2551	M5:cd59a6042156743484b01e429d67dcb9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000220v1_decoy	LN:2548	M5:822737a44cc33c2db164829922cdb96a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000221v1_decoy	LN:2548	M5:cfc1c1a98c1e72f1193cf3bdbd7d6e22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000222v1_decoy	LN:2546	M5:4b897ac33360cfc5dda50c492edd5264	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000223v1_decoy	LN:2545	M5:3e5f015ea4c3e8e3f4aa413fc8e33ff7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000224v1_decoy	LN:2534	M5:8a161ea48715e813fd05aa43c1e4524a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000225v1_decoy	LN:2533	M5:fb3804f1f8c9b481a5684e24912cdb2e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000226v1_decoy	LN:2522	M5:4a6ae65ea92c112f656b5d39d76a7741	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000227v1_decoy	LN:2522	M5:4b56d4e6c02a6e93eace0b35a8e81178	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000228v1_decoy	LN:2515	M5:38e333d2fbaeea1196ff289ff007b136	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000229v1_decoy	LN:2513	M5:6948ea45d0167313b03bb520dece25ab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000230v1_decoy	LN:2507	M5:ae1256f74ac53ab9f03548cd40e2fe8e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000231v1_decoy	LN:2504	M5:615e1e7e5b15386539deb06dd4e70457	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000232v1_decoy	LN:2497	M5:2601507db41c0111c04735355c122721	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000233v1_decoy	LN:2471	M5:204b14540e382d6178cbf75d805ad164	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000234v1_decoy	LN:2465	M5:8bf3deb57ae47354c0f07b477420f838	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000235v1_decoy	LN:2464	M5:ef6b06a889077e9b0c4ae3b5eeaf21cb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000236v1_decoy	LN:2459	M5:cf22036ebb20e5c07502642f1d926f55	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000237v1_decoy	LN:2457	M5:64a6bc4d08e4f9e0d6ba8cce58b7f505	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000238v1_decoy	LN:2450	M5:e83868519a491203921eb9f7286a5e98	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000239v1_decoy	LN:2435	M5:8292756d8d376c15256d12d69951d1ac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000240v1_decoy	LN:2434	M5:e850a25d74b1a7564101247ce3b1fb7c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000241v1_decoy	LN:2432	M5:b0696db696f0e45c6909f75d3f17ab87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000242v1_decoy	LN:2427	M5:4a78bf09eb53eaefba5d6406f424579a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000243v1_decoy	LN:2421	M5:6751a1f3f80e5a43badc5b9a986fa49a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000244v1_decoy	LN:2420	M5:b8c086bba1ed8bc4eb0ea05e7031664e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000245v1_decoy	LN:2414	M5:4ae74a7c8879b7eadc4ff52f6c247436	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000246v1_decoy	LN:2404	M5:cd50b4acbe112fb299328b26c243aad7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000247v1_decoy	LN:2403	M5:0a7f0ec7ad3711a0173947d4768d9193	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000248v1_decoy	LN:2402	M5:cf164664d17746b996c1b51b7a1b2d1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000249v1_decoy	LN:2397	M5:d5f7a437c859d40100bf3a757b38ea7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000250v1_decoy	LN:2395	M5:fdf94cbe463685fab85e81430541c656	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000251v1_decoy	LN:2394	M5:9e100dfb362640d77d73adb06f63c206	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000252v1_decoy	LN:2388	M5:0f0f93cc335a9faecc119d22738a778e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000253v1_decoy	LN:2382	M5:af0841d63c2d4ca67c11f8e2f0c0b42b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000254v1_decoy	LN:2381	M5:948e4e6ebbce9d82413e86c3c96d684f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000255v1_decoy	LN:2380	M5:46be4a58c4b132b788bd04a3c51f0108	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000256v1_decoy	LN:2368	M5:722aeea650c487dc132f37322a5b5eb7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000257v1_decoy	LN:2364	M5:44995a3c81d834bd8bbceda57ee73d51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000258v1_decoy	LN:2363	M5:a71f07406eabc3a412250ac21c446ba3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000259v1_decoy	LN:2348	M5:99b15b0bac8cbd7497c5ca04a721c657	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000260v1_decoy	LN:2339	M5:0768f34e39c5c97c1639fd42b72fec1d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000261v1_decoy	LN:2335	M5:974a3d6e7628eaf95db035d99f046379	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000262v1_decoy	LN:2332	M5:9a0e708d8a88bfa96a75e98604a273b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000263v1_decoy	LN:2331	M5:60412161b03d0c2f2ce5659369ee368e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000264v1_decoy	LN:2330	M5:5593063ebd79eae9ac5a5a5ba9095b7e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000265v1_decoy	LN:2323	M5:6042dc9c77f44643d41e68ea0cda385f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000266v1_decoy	LN:2319	M5:ba867aa03d1617be8f801a89c1530937	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000267v1_decoy	LN:2314	M5:a29f663eddf36e84b6cb6faff0f62309	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000268v1_decoy	LN:2308	M5:659c8649b3dbe0dd672045a5ed7fa3b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000269v1_decoy	LN:2306	M5:e10dadf09b67626744c1c39c1fea5fe4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000270v1_decoy	LN:2296	M5:81f921a9ec2bd029889721432b22d4d5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000271v1_decoy	LN:2287	M5:095a5e8a3ae51b66207f518822bf71a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000272v1_decoy	LN:2279	M5:47fde7cc81a14c0c6be4ccbfa3312015	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000273v1_decoy	LN:2276	M5:35e9863bbef84bef6634eb206bc66c15	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000274v1_decoy	LN:2273	M5:9e8590286f229ad55bf921bb4d7236f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000275v1_decoy	LN:2262	M5:f184b3c6054e080672a50e932da0aafe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000276v1_decoy	LN:2254	M5:06e878f736f352fe167cc033f030b492	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000277v1_decoy	LN:2252	M5:af9e9099df9fd3abe01d3ab305c9d65b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000278v1_decoy	LN:2245	M5:8f7d8cb82a282dc326d4bd286895492d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000279v1_decoy	LN:2239	M5:ae67f16bc2c56baec5093246804b3df5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000280v1_decoy	LN:2223	M5:bffd2399ce899d9fa674d826311500f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000281v1_decoy	LN:2220	M5:926bf451304bc000be7146acb11c393e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000282v1_decoy	LN:2218	M5:adcddfbd560a42060c45d80c751787c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000283v1_decoy	LN:2215	M5:706580b59cf8322b639309fc6110d094	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000284v1_decoy	LN:2213	M5:7145c3c0ac2cc197f7d0fc0fb18d6c1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000285v1_decoy	LN:2203	M5:0c6c215de5d00669ece9d0d461b7b5c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000286v1_decoy	LN:2200	M5:a724f88e94788f5e1738a038d67d8d7b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000287v1_decoy	LN:2197	M5:fd0cdd36334762ca58e7b82b6ebf802d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000288v1_decoy	LN:2194	M5:441ebd8ba7d0673bebf054e6ce9b405e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000289v1_decoy	LN:2183	M5:df57267be3acda36409e42dd3c0da306	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000290v1_decoy	LN:2179	M5:8bc6beaec162ccebf341b6c46ebaf3fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000291v1_decoy	LN:2177	M5:d0d5b33e946654d9b23402cef3f10822	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000292v1_decoy	LN:2177	M5:bc189c463b5d9bae5c71afa304910390	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000293v1_decoy	LN:2177	M5:c74d19e91cd80fb55bc91184bdc0eac4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000294v1_decoy	LN:2168	M5:c828de6bd73d4226b924cbe268ab5d35	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000295v1_decoy	LN:2160	M5:33980619d2c675019c4fb26681973f1f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000296v1_decoy	LN:2155	M5:40e793695b37b027d9d893448ad20eac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000297v1_decoy	LN:2144	M5:55b3946760e337f7fa9358993879d5d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000298v1_decoy	LN:2143	M5:5c8fe70b46ce7d299039403820af18c0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000299v1_decoy	LN:2136	M5:7a28362f930fcd9a245cc239750dd1d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000300v1_decoy	LN:2134	M5:285c47826e725f4442c18898156ac4fa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000301v1_decoy	LN:2129	M5:b4ad7d61b3d8b5b5f03100792231b056	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000302v1_decoy	LN:2128	M5:a6fd1741e7a81251829a88549717a433	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000303v1_decoy	LN:2125	M5:c95f162916242e94c057ec50e3f666e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000304v1_decoy	LN:2125	M5:cf878bbb13f4cb8f6ad2f6134d4152f8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000305v1_decoy	LN:2122	M5:ffc29d2524335853c556eac4b936ac47	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000306v1_decoy	LN:2111	M5:13ad53d0306dcdc84cfbe5af890ffa7f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000307v1_decoy	LN:2106	M5:2705f017f46d301002f0ccf08933080c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000308v1_decoy	LN:2094	M5:dc17db769fee486df656f8334528abba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000309v1_decoy	LN:2093	M5:61b8e15e0c011168970bf67fa28a893c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000310v1_decoy	LN:2088	M5:4a0f2b01b92451953bcb14f94874625a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000311v1_decoy	LN:2086	M5:560b32a4aa380573107a95fe8344fcbd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000312v1_decoy	LN:2086	M5:f4a368ddba66f5647c78853a2080c7e1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000313v1_decoy	LN:2084	M5:90b16478fad5417ff33d03ed3cdb9897	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000314v1_decoy	LN:2080	M5:eb02520ddd2b898796bf56257623ff11	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000315v1_decoy	LN:2079	M5:214af8bfae249648407394750763140c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000316v1_decoy	LN:2076	M5:b2439d0b325e4cd30b1869e8e17005f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000317v1_decoy	LN:2071	M5:d8e3a93de5b5c8fa58e8785c44e165f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000318v1_decoy	LN:2066	M5:03ab659ca0a3d031ed57f5b71c40b7bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000319v1_decoy	LN:2061	M5:b7df3a4252d3ed398842dacc1ef5119d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000320v1_decoy	LN:2055	M5:3225edb2d4dc98b7b0cfd91afeacdba1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000321v1_decoy	LN:2053	M5:d0f66764a23cc8c03b6e0b1b8dcd2aec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000322v1_decoy	LN:2040	M5:a53241c8700359fdfc69eff381d88829	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000323v1_decoy	LN:2036	M5:8b83d6b87f9d9045336bfe2d4f2d638f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000324v1_decoy	LN:2035	M5:641af824694766c85122b263dc1b3649	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000325v1_decoy	LN:2034	M5:7f2f9c9fa94f3acab772792c44b4c167	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000326v1_decoy	LN:2032	M5:1f32623318d9221ee867209755a538bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000327v1_decoy	LN:2029	M5:053ea4692acbe04aa98a6f331417531f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000328v1_decoy	LN:2025	M5:930554d67c2f289a7f2bbcce35c88e75	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000329v1_decoy	LN:2021	M5:b3cda19a888b02b135de2538d4a74936	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000330v1_decoy	LN:2018	M5:abfba957d4a6107fa109f1dd5a572de9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000331v1_decoy	LN:2015	M5:0ccdc46d98d147f9b6bb6808f723d28c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000332v1_decoy	LN:2009	M5:634f88805091cb15be16b1af5e720775	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000333v1_decoy	LN:2007	M5:957b5291471bee32d4771292a611cfa9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000334v1_decoy	LN:2005	M5:6d2a28c1dcd5377a19f5768b3fa75ad2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000335v1_decoy	LN:2003	M5:7fcaa8fce3cf7cda00a42df29b938b6c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000336v1_decoy	LN:2001	M5:e28b02249a274e4b98551241e243fcbc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000337v1_decoy	LN:2001	M5:4718723746d62e7eed277db09d01884a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000338v1_decoy	LN:2000	M5:7071be152f29ebf4ec4cfede2d44d70a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000339v1_decoy	LN:1996	M5:21924fac8b9023e37be232641581d24c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000340v1_decoy	LN:1992	M5:462035d8f8260ac9d68132b5ac63ceea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000341v1_decoy	LN:1985	M5:80c971eec06361d4428c1c731da5d2eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000342v1_decoy	LN:1981	M5:6f5d885e4d0a0476e309c004c8d7116c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000343v1_decoy	LN:1977	M5:07b50b0be202b0e56fae3ff7b729fcf1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000344v1_decoy	LN:1971	M5:ec1eccee490917513ffa0844c16cd648	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000345v1_decoy	LN:1968	M5:a44124ee81131e9ba181e4d57343b933	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000346v1_decoy	LN:1962	M5:a46b7187d8afab3b6711d2b57dbb649e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000347v1_decoy	LN:1961	M5:391b9551b7df1ea41abd51c70c6391ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000348v1_decoy	LN:1960	M5:2272602c288691975c385900ff1871d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000349v1_decoy	LN:1960	M5:92f15826c95eeb01e4b619c7b646a17a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000350v1_decoy	LN:1954	M5:98742b24ea14c25494dc15620ed8d346	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000351v1_decoy	LN:1952	M5:5d5e3c8f90d84b8f2e912de53d0250a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000352v1_decoy	LN:1947	M5:f5e22c20cf8f7956480ff337ad36be24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000353v1_decoy	LN:1944	M5:cd921451a9fcf4ec5d06cb74cee21605	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000354v1_decoy	LN:1943	M5:eba8670102e02d674c11f1779a39338e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000355v1_decoy	LN:1941	M5:79a20867ab6678a0eb6a1bddd2d467f7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000356v1_decoy	LN:1937	M5:e17159dcd1117f3bb92bebb710740ba2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000357v1_decoy	LN:1934	M5:9266a855ef31e94c5f77d277055f2125	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000358v1_decoy	LN:1929	M5:11b07e8db80b814bbcd4814bebafc177	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000359v1_decoy	LN:1924	M5:e9df9c6169849c4d69eb8a286f274eab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000360v1_decoy	LN:1924	M5:5152172dba1a32a5529708855c21201b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000361v1_decoy	LN:1923	M5:22f23fe69e62cdfb4304b679a6916bad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000362v1_decoy	LN:1921	M5:b5eaf4b290ab9cf157680d65e640a5a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000363v1_decoy	LN:1918	M5:9dedcf6b3a849e4c681f05753c2597d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000364v1_decoy	LN:1915	M5:a1c06309d5103a00f8c5cf1847f58856	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000365v1_decoy	LN:1915	M5:7a8b1fa154de78062577f95bcbf9cd7d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000366v1_decoy	LN:1914	M5:6db99643422d9ef62392ced193881137	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000367v1_decoy	LN:1912	M5:61c61bda79ca84060bd63c678715b83c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000368v1_decoy	LN:1910	M5:64edcf78348cea32c4e946329efd3ff9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000369v1_decoy	LN:1907	M5:9266a29087762dab9b2c3f0065838122	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000370v1_decoy	LN:1904	M5:f753bc41e46a7b0a9a9c63055a0553fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000371v1_decoy	LN:1897	M5:df2a02d92f1a99000001bd1979b387b1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000372v1_decoy	LN:1891	M5:1664892a75f937da1e68f5c28f0be6f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000373v1_decoy	LN:1890	M5:ad597d36bffdf82ff75f444e98be4928	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000374v1_decoy	LN:1888	M5:570f07c26f0d742b21502cff22b7d2cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000375v1_decoy	LN:1888	M5:a85dc5b82df805bdd2ee38b94de6133c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000376v1_decoy	LN:1885	M5:d5cfea6c2a90821c0bac19bb1b81c97b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000377v1_decoy	LN:1881	M5:cdcde92ccd92dd4531ee3ccae640577b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000378v1_decoy	LN:1879	M5:fa3996c5e3cb86b5904ad5ab423f06ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000379v1_decoy	LN:1877	M5:4659566201687f420c913a424ff09d62	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000380v1_decoy	LN:1876	M5:e619de3bcb3f53147ec25a74324350be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000381v1_decoy	LN:1876	M5:7d297256bbb1ec6cdc08e447670e69d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000382v1_decoy	LN:1874	M5:bd4b0fff3b0f9b3c27bc270d80d2d91f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000383v1_decoy	LN:1872	M5:d337922792c71f4bb3ec1c522519d7cd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000384v1_decoy	LN:1869	M5:95a4dae294e133dca09afd04559a3d82	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000385v1_decoy	LN:1866	M5:38b2fbf522a772de9e5971e2c248d773	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000386v1_decoy	LN:1865	M5:a2b125ab6d06ffdfbfde0a2899a63d38	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000387v1_decoy	LN:1865	M5:eeb193e267c0aad102b5a8c55b899094	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000388v1_decoy	LN:1865	M5:a21001e6acebfcf03c2f187db59bca58	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000389v1_decoy	LN:1862	M5:e1aa83bd329fed4cea1a31c2b26605cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000390v1_decoy	LN:1862	M5:e80fe8b2857e4e57c40cff1a604ca905	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000391v1_decoy	LN:1859	M5:e85c5d8da9312ccb56a4ecb47e7cb397	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000392v1_decoy	LN:1856	M5:d1448f2aeede93e71be4fa57f641c1ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000393v1_decoy	LN:1856	M5:dcbc9c61d537f450dd4fae3b11f71d19	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000394v1_decoy	LN:1854	M5:a427d47a812c6fe6c9d26190b4b83f7d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000395v1_decoy	LN:1850	M5:876c26621463a5218a5953d9be4d0810	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000396v1_decoy	LN:1849	M5:4797d275b03add54ab91c5b8c318a7e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000397v1_decoy	LN:1849	M5:707d492cfa678968ded0e2306392504a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000398v1_decoy	LN:1847	M5:06eb26d8459f3e43735ded45aa07a2e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000399v1_decoy	LN:1839	M5:1ec1c61f264cc1ec9596dab78ea77adc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000400v1_decoy	LN:1834	M5:c268a5b922576efd86cb97619df6fb55	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000401v1_decoy	LN:1821	M5:37647f03de6c012f655cbffbfbe570b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000402v1_decoy	LN:1815	M5:edf2017fafb77c03c7f392ec8489ffae	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000403v1_decoy	LN:1811	M5:60131480b353a90b21d6a47f52a7d1eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000404v1_decoy	LN:1808	M5:b4009abb588476a2593dd27cef872705	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000405v1_decoy	LN:1808	M5:ef9e792232f15cf2b18c4d4a7ce99253	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000406v1_decoy	LN:1807	M5:09de8b5234448cff4c1e3defd30ee794	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000407v1_decoy	LN:1807	M5:212f6e4df329ece3ab38c483cdf02535	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000408v1_decoy	LN:1802	M5:291bcca126e0b971eaa6fde409109815	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000409v1_decoy	LN:1801	M5:12ba0451f91998e31fd25003c892102b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000410v1_decoy	LN:1800	M5:d47cda8c33b62a63e40f02664d4811d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000411v1_decoy	LN:1795	M5:7f941c23c25bebc1937eae96aa5e98d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000412v1_decoy	LN:1794	M5:1354d0a5f0d586b01f493802f991dd7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000413v1_decoy	LN:1792	M5:7b03b07cb1cf327205fb693d3ace8a42	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000414v1_decoy	LN:1788	M5:36d568b75f9e3cf031e037043ac02384	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000415v1_decoy	LN:1786	M5:393fd0366a1270f611866e1fb5af3cc1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000416v1_decoy	LN:1782	M5:2652e35a4315660b304c6b7522e5f7d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000417v1_decoy	LN:1782	M5:c7c0bd282280cb9eb969940cc3b68acf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000418v1_decoy	LN:1781	M5:5a9a78f89d320fbabd4693bd232704a8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000419v1_decoy	LN:1781	M5:75304d27b61d40a759bd36190202926a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000420v1_decoy	LN:1779	M5:95cf227ee90e6dced27e307b52d240fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000421v1_decoy	LN:1777	M5:c1fd358a71fe269cee210b27840c272e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000422v1_decoy	LN:1764	M5:5db13804da88f18750e478f6682b83a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000423v1_decoy	LN:1762	M5:bcf551251490bd2c7ab5a99232bbbcf0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000424v1_decoy	LN:1755	M5:c8de78702f0a0471f26cfe586a8d9263	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000425v1_decoy	LN:1749	M5:9c843f2e59ba4aeed3517c0aa36ed8c0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000426v1_decoy	LN:1747	M5:431f95d76dc16b369e6765e38ae92ee1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000427v1_decoy	LN:1746	M5:1641a71638dd63211280e6bef22e6a4b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000428v1_decoy	LN:1745	M5:98de780057460a078034b25725bad406	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000429v1_decoy	LN:1744	M5:16ceb3de9929ccc268d4aeacb8f20439	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000430v1_decoy	LN:1742	M5:6c61a88798f9fe78567c879793385c29	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000431v1_decoy	LN:1740	M5:e2ecdbd050ed1413eb2a07f7d9ebc8c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000432v1_decoy	LN:1740	M5:7f1d544cca143be6dd353cf3efb80028	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000433v1_decoy	LN:1736	M5:18493fcfd6ea161acd237867aa7337cd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000434v1_decoy	LN:1735	M5:afe0292acad0a1460fbad00971606090	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000435v1_decoy	LN:1732	M5:5bba5da58b43755bdc14ab286a8a5cee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000436v1_decoy	LN:1732	M5:680818b10726c68c5917f48456528d0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000437v1_decoy	LN:1730	M5:836c13c8ad60355227f91a1b5308ea33	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000438v1_decoy	LN:1727	M5:f5fb0c58f9b4fa60b1eeccee56f0cd56	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000439v1_decoy	LN:1722	M5:9a47086cf6334392302ea1713fb68c57	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000440v1_decoy	LN:1718	M5:dcc0114d2cbd5f165da52b4610aeb6b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000441v1_decoy	LN:1716	M5:59cfde6a838acc68c55e5a781f1308fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000442v1_decoy	LN:1710	M5:cf384ae5b546344ace5aa4d662c6ac0a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000443v1_decoy	LN:1708	M5:4df6e9cabebe481359ac95881b277f74	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000444v1_decoy	LN:1707	M5:971971b7547432d52662e516989b1596	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000445v1_decoy	LN:1706	M5:9c926b3b414cdf578a7af119dc3d32bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000446v1_decoy	LN:1705	M5:91d17f22298838daf727563421004b33	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000447v1_decoy	LN:1704	M5:64c4b3b7b16fb06e268d70c576c18be7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000448v1_decoy	LN:1699	M5:e50192f7290b158ee82f04623e78180f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000449v1_decoy	LN:1698	M5:938f5fb6e35906afc6601c756e85684e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000450v1_decoy	LN:1697	M5:670cd517d0cef208acfe5f83f4f08e40	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000451v1_decoy	LN:1697	M5:29b287f217fd519ac38852bf9f3b89cd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000452v1_decoy	LN:1695	M5:42ba5d9b4331876409b5509b694d32f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000453v1_decoy	LN:1695	M5:a98d7b845be68d05f42b70b19d87ecbf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000454v1_decoy	LN:1693	M5:bda60eb625bdf4d5f8b0cb6ccb975c1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000455v1_decoy	LN:1687	M5:27bc09a272621c3414cbe34cd809347d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000456v1_decoy	LN:1686	M5:6f0aa7beab754a13ff566057d0641ae0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000457v1_decoy	LN:1680	M5:8cba844ac8cc6321dba7652815bbd94d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000458v1_decoy	LN:1679	M5:e2f908a05a86ddbda11acd668b7487e6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000459v1_decoy	LN:1679	M5:5a0c260602a6ab3fa76f49157966cf4b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000460v1_decoy	LN:1678	M5:54a34fdfb08cb07c1f51c8be679c6339	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000461v1_decoy	LN:1674	M5:ced48cb3354e7f24d532fefc85a96319	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000462v1_decoy	LN:1674	M5:4467091f25a983fc0f7d9d88bd351993	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000463v1_decoy	LN:1671	M5:7cbbe8ba7b64b120b467c953851a7eb4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000464v1_decoy	LN:1669	M5:a3cdd6c546af035a3c9830a67c0bb056	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000465v1_decoy	LN:1665	M5:1e245fa1bc113bab6305d0fc3cad2112	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000466v1_decoy	LN:1663	M5:b1a1b5888971729811d7fcf9b06665e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000467v1_decoy	LN:1657	M5:8a989e9803993317d80157778c71da54	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000468v1_decoy	LN:1653	M5:bc73c770766d2b8deb017d234f5d7387	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000469v1_decoy	LN:1652	M5:9559e20eaa71db947eb9645779c2c2e8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000470v1_decoy	LN:1650	M5:60a6f98d6f706aa9554c7b6ed3de2716	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000471v1_decoy	LN:1649	M5:ce3eddf63b3aea572dd8e0b762b90829	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000472v1_decoy	LN:1649	M5:aeab25a6fcaf97cdcb319dff1550df0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000473v1_decoy	LN:1640	M5:7a4f3084ac2ed72ea4f5e60260c77948	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000474v1_decoy	LN:1638	M5:5c4753a4d69db9ff02e858c8ddbb8911	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000475v1_decoy	LN:1636	M5:8970166c6ade7a2f8106159d5ee5c857	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000476v1_decoy	LN:1632	M5:67037d44662f2487a2e39e76ea3fef94	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000477v1_decoy	LN:1631	M5:3455484eacb9d4eaa7ed63b96b087c85	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000478v1_decoy	LN:1630	M5:c20fcc553e42922058f9f0e839f527ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000479v1_decoy	LN:1627	M5:cf02dff4c16e81e47d1cc5ffdbf1b4ae	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000480v1_decoy	LN:1624	M5:93392bdc58b6376d5da876bae65be9e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000481v1_decoy	LN:1617	M5:e8add50c6a06030a1dca84968a89d4b2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000482v1_decoy	LN:1616	M5:6d496ad94b5cd40c72f5362e446e22c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000483v1_decoy	LN:1615	M5:bcc4bc611bdb483f2f925df072d50a41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000484v1_decoy	LN:1611	M5:19f0a56814e718041b51733abc55a44c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000485v1_decoy	LN:1611	M5:771186a23da9b9c2081773c5a6d73812	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000486v1_decoy	LN:1606	M5:f6dc33d2578fb0ce6a560d5ee7b9b5cb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000487v1_decoy	LN:1605	M5:440c7d94624635647d771ce7f3833416	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000488v1_decoy	LN:1605	M5:7e6682db43f2445cfc3b18ddecb786c0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000489v1_decoy	LN:1600	M5:1b3265b9aa7cae61d843ae0b09e2f3a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000490v1_decoy	LN:1598	M5:8ef2cd8ef0749e5d753b552c1f2fc3d7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000491v1_decoy	LN:1598	M5:9bfcb4215c94e812ae4ead4fc804a63f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000492v1_decoy	LN:1597	M5:8c06a1c635581dd76469e431bda358b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000493v1_decoy	LN:1596	M5:9880ad7b13fdc3af8d8c81e3adf8ba43	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000494v1_decoy	LN:1595	M5:ec1ac1310cc7d4432ced7724829cbdba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000495v1_decoy	LN:1592	M5:f2d436516525e67ce3aa61ec5273dcb5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000496v1_decoy	LN:1589	M5:201a121b6775880be8593d2a9cef12cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000497v1_decoy	LN:1585	M5:491aed38b1a89a77be7b2d1d30bd4fa4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000498v1_decoy	LN:1579	M5:2e63f3a1cf01e023c443b4478459db64	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000499v1_decoy	LN:1578	M5:f9223dc0eaf125b8226c386bbca18647	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000500v1_decoy	LN:1577	M5:3c9bc60202ddedaa3894d11a96f5429b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000501v1_decoy	LN:1577	M5:c367b54edc2b83cb15946ac3c975ccfd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000502v1_decoy	LN:1577	M5:d7d24f1188f1d67db7215729a5c5b8d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000503v1_decoy	LN:1576	M5:229d2aa7ab158e9b4bad158972029e55	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000504v1_decoy	LN:1575	M5:c8f35742cdde94078de3c3d84c130c42	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000505v1_decoy	LN:1574	M5:d0367db77d5a6bff49f54d4acd3d01e1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000506v1_decoy	LN:1572	M5:06b66d904a7902fb764a3e661b9c8bea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000507v1_decoy	LN:1571	M5:e3187302e0771a467d4e7d2b31669e7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000508v1_decoy	LN:1563	M5:78aa7cd4461790084af50b1b80e1838b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000509v1_decoy	LN:1561	M5:abcdf15d561b447b0bdedb366fb77d72	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000510v1_decoy	LN:1561	M5:f9a7e72f7e382fa59a1d2c0c4d6edc53	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000511v1_decoy	LN:1560	M5:bbfe4f1e02f2fdcc9d20e65e8d3da35d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000512v1_decoy	LN:1560	M5:538f38f8d5e6495a85b6bfecf487ecc6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000513v1_decoy	LN:1554	M5:8ae2f8b5f30a6c1762de005819965ec7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000514v1_decoy	LN:1552	M5:392885482ea57d0e3f1311c3be95c89b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000515v1_decoy	LN:1548	M5:1310bfff4743d36d7f8153b6663f2249	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000516v1_decoy	LN:1546	M5:629769b2550c48e2a73115da95946951	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000517v1_decoy	LN:1541	M5:76f0c1d1779803feb107f253ea555df7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000518v1_decoy	LN:1536	M5:686a5b0fc214ac36df8da7605ffae4ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000519v1_decoy	LN:1533	M5:e2bf8fa01d69d0ec7c7e1f6d040912c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000520v1_decoy	LN:1532	M5:0c23895ba0df7ad7ea8f2b58313a0cdf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000521v1_decoy	LN:1532	M5:c9515245780a66ef482674755d38c592	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000522v1_decoy	LN:1530	M5:5caa4ec6f260d2f960770b368909d78c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000523v1_decoy	LN:1527	M5:b05daa30b4f2c9167aac9fde662de4c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000524v1_decoy	LN:1526	M5:cfcd1e358a225fc7c2354b1bad52cccc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000525v1_decoy	LN:1524	M5:08ec33c06085eb399a1e56f43d1d222e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000526v1_decoy	LN:1523	M5:74f16c21c5a2372050d2f61595d52eea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000527v1_decoy	LN:1523	M5:e7cf8c07771c8fa37bf4b6fbca555113	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000528v1_decoy	LN:1522	M5:8f754d63b65c3c7a1e9a1ad5e439d2d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000529v1_decoy	LN:1522	M5:51530101930cfdb66060d0686c4fed16	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000530v1_decoy	LN:1519	M5:dced229b77a1ea722aed13b4eb4e5b79	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000531v1_decoy	LN:1513	M5:dc49162a2d904001541bef4c7f7cd54f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000532v1_decoy	LN:1508	M5:c183c701388b1a11f3cbf31ba2d84f41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000533v1_decoy	LN:1508	M5:0d9b9c8ca5a3b58a13369e0a097f25cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000534v1_decoy	LN:1505	M5:4e806d8438bd8512d22e24a026640d66	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000535v1_decoy	LN:1503	M5:0b9c580f3d47c52b031cb00b9741c1a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000536v1_decoy	LN:1496	M5:ebce7ee144631f93b7001740bff968ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000537v1_decoy	LN:1491	M5:191de45ffda752707ef5b22c780675b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000538v1_decoy	LN:1490	M5:2b8af44ac46088badbdffea0c0c3d368	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000539v1_decoy	LN:1490	M5:378e070f5556e26fd1e89f1f21e2c35a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000540v1_decoy	LN:1487	M5:7c84677ee13bffaac6c5c623f317619f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000541v1_decoy	LN:1486	M5:501226e799037a04ea73a3be5bde460b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000542v1_decoy	LN:1485	M5:8ec76a3f62b296d50ccff9ce4a9aa072	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000543v1_decoy	LN:1484	M5:34e4860b41e4db3fe4ec16fdba4cb85a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000544v1_decoy	LN:1483	M5:ca6b3496195a36f5f1a5a1de26bd9655	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000545v1_decoy	LN:1479	M5:902f04a9f4b960cef80039434d00e63f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000546v1_decoy	LN:1479	M5:16692f78928924e255aeb5b72a97ab21	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000547v1_decoy	LN:1476	M5:e765f1919b45a51913ed7d2f4c9a7491	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000548v1_decoy	LN:1475	M5:fa46ec2fd14b9d99852d4d30568593ff	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000549v1_decoy	LN:1472	M5:d03e8e717a38f0178037af0ca86aafb4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000550v1_decoy	LN:1469	M5:8ee65cdf657a82a381d7cb6caa4f3f5d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000551v1_decoy	LN:1468	M5:bc6f74a7c8ffab037e3eab5ea88037a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000552v1_decoy	LN:1467	M5:7d64a0f8c6675f07e9dec9b70a0afdd0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000553v1_decoy	LN:1465	M5:2e3b43fdc0d1784a2518dfe255384519	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000554v1_decoy	LN:1464	M5:df762923ca57a0113032d663d3c97bea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000555v1_decoy	LN:1463	M5:11aada1e695fe5177d9540b02a2d432b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000556v1_decoy	LN:1463	M5:d3ab1903d41ac470157b0c4d4ed61933	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000557v1_decoy	LN:1459	M5:bbadf4ad4f9a1ee8da95612868cfb018	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000558v1_decoy	LN:1459	M5:bcd6dabc3d1399c379f3adf1cdeae332	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000559v1_decoy	LN:1458	M5:1781d0b5245fdca60eb63e40b293194d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000560v1_decoy	LN:1458	M5:46a7c1c5c2e823abe406cf459179bfde	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000561v1_decoy	LN:1454	M5:a7a571b77c5a922ca842288fc6734696	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000562v1_decoy	LN:1449	M5:cc0f411395c55cc332ad0889e75eca80	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000563v1_decoy	LN:1449	M5:184e7321ea1fcdc47df967c7c5d879f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000564v1_decoy	LN:1448	M5:9cc22c1be7f706f6789fc994e46ddc95	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000565v1_decoy	LN:1446	M5:2be7af38d4e11bbf45397add5e8b29bd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000566v1_decoy	LN:1442	M5:7badb67269751abbac8f46b5704299b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000567v1_decoy	LN:1441	M5:ee8162f4c41a8b15758b34b01d87e2d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000568v1_decoy	LN:1440	M5:d4b0ebe0d4c6d4d270b5a5b7d1a5d7ee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000569v1_decoy	LN:1439	M5:ec8779a6ca200bbe41de6dd3630da10e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000570v1_decoy	LN:1437	M5:3d29e003ab19ba610718173d23d26b37	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000571v1_decoy	LN:1436	M5:a7261a67e8f0dd3de7bb37e12ed74c3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000572v1_decoy	LN:1429	M5:d9b8501a054b0ba4229f7ae1e74bf2c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000573v1_decoy	LN:1429	M5:ddc6caafb94fef7d6209cdff64795226	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000574v1_decoy	LN:1427	M5:9aca197fbaf212c69feea234780489a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000575v1_decoy	LN:1426	M5:1e4c043b8c89e6c193c519db2531e6b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000576v1_decoy	LN:1425	M5:846748418b1797e21e540d92fd794495	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000577v1_decoy	LN:1424	M5:4fd0c37d4a586150a9301f2009c5c1e9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000578v1_decoy	LN:1424	M5:54ac14d019ced5f6bfe22948074afa9e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000579v1_decoy	LN:1423	M5:3fdf802f805e746ac56f30d6d1a68708	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000580v1_decoy	LN:1423	M5:7237c88f6ea636176c0287d0432a9732	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000581v1_decoy	LN:1423	M5:e9eaf98ae51879086e24b98bea88df0b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000582v1_decoy	LN:1414	M5:34272cd5beb57237fb7a193f798cc2d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000583v1_decoy	LN:1414	M5:9060d1ca5fe447374bc2a1e69f4e3224	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000584v1_decoy	LN:1413	M5:3298b158d1b1f933a0e2a292a1529e10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000585v1_decoy	LN:1413	M5:59c1a460224d4414afdea6e15bd8b2e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000586v1_decoy	LN:1410	M5:64228ed4ae27b3994019d9e0038f55a8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000587v1_decoy	LN:1409	M5:4d845a6ec097602753d860feddf23e58	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000588v1_decoy	LN:1409	M5:a000b425fd931ce6015497afb22efd88	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000589v1_decoy	LN:1406	M5:0c059afc9f69018ba9da0b23aa8b9b75	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000590v1_decoy	LN:1405	M5:0c586f3eb4883fc1918171f471f5e5f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000591v1_decoy	LN:1405	M5:cd72088875313abb75d2a891e35b7d4d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000592v1_decoy	LN:1404	M5:abf874737ff5cfa8f718112f32beb985	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000593v1_decoy	LN:1404	M5:eb8f0a5cc692b80655ef58e2547a4cec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000594v1_decoy	LN:1402	M5:6ee2ff095b70b42cd9c9b4e0efabca4c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000595v1_decoy	LN:1402	M5:f4d8da8a43b238c8e0646f5f0b52f89c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000596v1_decoy	LN:1402	M5:8c7872a37fea0f290dc1bc82d975b894	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000597v1_decoy	LN:1402	M5:d0d9fdcbf88b68b1dec6f806c72fed32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000598v1_decoy	LN:1400	M5:6634e5294042b88996256c18dfedb84d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000599v1_decoy	LN:1398	M5:fd8634e8ef145e4987e4520f150aa3f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000600v1_decoy	LN:1396	M5:25350d57a6af0ff5c2c4c9c49b44ce71	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000601v1_decoy	LN:1395	M5:6aedeed255c7942bf7499cf1627f8cbb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000602v1_decoy	LN:1394	M5:535e79d7dc446b1c3d57759eee6e4f79	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000603v1_decoy	LN:1393	M5:300693e040f4152f622506cde18980f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000604v1_decoy	LN:1391	M5:8a946b3527d782026e0dc90559017170	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000605v1_decoy	LN:1389	M5:7a9e96381bae2eb52e9e340616f3d40f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000606v1_decoy	LN:1389	M5:b6ee1b27e065ac10608cc2a75f23b552	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000607v1_decoy	LN:1388	M5:ff5370f5970d37597e705a08fca533b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000608v1_decoy	LN:1387	M5:445d8c03bad3cc26e6adeb0047d18078	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000609v1_decoy	LN:1384	M5:e885e52d68b2de3b4a858205e3e642ba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000610v1_decoy	LN:1381	M5:56708189f55fba9d8406fbd9eee51424	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000611v1_decoy	LN:1381	M5:c7791c86ba8e059389aaa3919f1ed24b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000612v1_decoy	LN:1379	M5:040a6029ad56ae20245dd1757c313f19	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000613v1_decoy	LN:1377	M5:cc1f3e1b6fbcf7cf33ba399c84ff0fd7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000614v1_decoy	LN:1376	M5:73782073ee88b30e5184f8c58b162395	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000615v1_decoy	LN:1376	M5:b49adf2ce996df0a067aa5afccc4d593	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000616v1_decoy	LN:1375	M5:ebef890f7fb5122bf631a5489d6d46a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000617v1_decoy	LN:1374	M5:d165c7fd94b756243531a20cd030e7f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000618v1_decoy	LN:1372	M5:99bb1f26eea260757df2246652e20ce0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000619v1_decoy	LN:1371	M5:fdc45233952efe3a4444e4fc118e9bd7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000620v1_decoy	LN:1370	M5:023468d3dca8b3726de68eb85c7d2301	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000621v1_decoy	LN:1370	M5:fb5072d4c89ac94df7141cacd9701034	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000622v1_decoy	LN:1366	M5:5aee91a1f323fd56c65017a1878fae17	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000623v1_decoy	LN:1363	M5:6b6ecc4a02c37b540c86cd51299d13da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000624v1_decoy	LN:1360	M5:06cd979553eb7045f14feac8e6f2e2bf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000625v1_decoy	LN:1356	M5:d4cf98566c01e8715f3f2d3883ee0960	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000626v1_decoy	LN:1355	M5:1dfb4921c6f707d06505f67e59849603	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000627v1_decoy	LN:1355	M5:0d374e2ae6601c90f80dad8772daeec6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000628v1_decoy	LN:1352	M5:474bb6fe17aa82dbe052602181e2c342	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000629v1_decoy	LN:1345	M5:be38a1cda1a6e1ae5e323c69f41169ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000630v1_decoy	LN:1344	M5:5f167804d39afced5ca6f11bdfc4e79e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000631v1_decoy	LN:1344	M5:a8c1265cc335c37e42363c32f7004283	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000632v1_decoy	LN:1342	M5:7aad5f98492b8fca78e060b6be39462a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000633v1_decoy	LN:1342	M5:f3ffd07c1b2dd961b6182008cc89dca9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000634v1_decoy	LN:1336	M5:64e80f53b6b20fe69e1f570c4bf46bdf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000635v1_decoy	LN:1334	M5:49441fe73d5a6c1424175db5c183d5f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000636v1_decoy	LN:1334	M5:7d75d91acde1b12b627eec4355428b3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000637v1_decoy	LN:1333	M5:e4ece619ebb5ab86de6fab33b38d5481	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000638v1_decoy	LN:1332	M5:7135701f246e43df19f5aba147d6ffe4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000639v1_decoy	LN:1328	M5:fbb7b0f582ebca6f3cef730730d1ba0a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000640v1_decoy	LN:1328	M5:62be463086e26b1df7d57735080ccdad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000641v1_decoy	LN:1328	M5:14eb9b729a7e8e201661d1337b6c986d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000642v1_decoy	LN:1327	M5:7758f1665792870c0c087b3c3dfa6f6f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000643v1_decoy	LN:1325	M5:4e1088e1aa76be60fab929e87bddd522	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000644v1_decoy	LN:1322	M5:af3b1f03c49d83adafa3d8f2d6874c24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000645v1_decoy	LN:1320	M5:446dcf62ddc2538c64ec6aa731ea150b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000646v1_decoy	LN:1319	M5:56748fdfa4712830c7af4c68f4759228	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000647v1_decoy	LN:1318	M5:8eaa0a6e0ed839c74aab55d260c6fc46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000648v1_decoy	LN:1315	M5:56712d4e2ff952bae0ab0ddd610f253d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000649v1_decoy	LN:1314	M5:d3e12fcc460574d688e5bae5d2442b1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000650v1_decoy	LN:1313	M5:b547545a4b0358b765cecfc76a24f5c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000651v1_decoy	LN:1313	M5:6b644257e459efb9331cbf248eb360a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000652v1_decoy	LN:1312	M5:49650bf9d34993f3734ff8be22a21d8c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000653v1_decoy	LN:1310	M5:a4ce42eeaf93dc12fd2c1d548ecb8ec1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000654v1_decoy	LN:1309	M5:b6aa3601c472a96642590f2556fd60f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000655v1_decoy	LN:1309	M5:86d4783a9574d129cdf2d96b81899a69	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000656v1_decoy	LN:1307	M5:f7f361b3f660b392044fad24ffae29fc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000657v1_decoy	LN:1307	M5:754ff5c46ace6aa00b6225c1395948bc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000658v1_decoy	LN:1305	M5:93cb281ea84aef36a85cb9950604dd0b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000659v1_decoy	LN:1304	M5:12d269dc2ce62735236ae94e1f20075b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000660v1_decoy	LN:1303	M5:48fbe06e5f32a0378e9bb9f94280b087	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000661v1_decoy	LN:1302	M5:21449d3d68824fc9c13706be068c9b2d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000662v1_decoy	LN:1302	M5:8b61707178e6e8435c171f9af9103412	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000663v1_decoy	LN:1301	M5:00401a0950f66bdb8079810e7cd7ea17	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000664v1_decoy	LN:1301	M5:da9b6adf8123090f1132c9b33c3aa8e1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000665v1_decoy	LN:1300	M5:a6e3addcf5e77b6d35b918c3d4b07184	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000666v1_decoy	LN:1299	M5:74108c185dba89f41809a3192d33baec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000667v1_decoy	LN:1297	M5:4aa3c2f67ac1c8f495575e8560808f7d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000668v1_decoy	LN:1295	M5:c0e3f662ea9b92faded08da52ec79ba1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000669v1_decoy	LN:1294	M5:acb9567104820929d7f17199b614c243	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000670v1_decoy	LN:1293	M5:d58180a24710ca20cd90857426fba9cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000671v1_decoy	LN:1291	M5:0021de79f69c7e6f7be872209251d8a2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000672v1_decoy	LN:1291	M5:ec57c06e1967b151af9716613687bf06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000673v1_decoy	LN:1289	M5:9e48e5eb17a1e58951e1b652dd9f44d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000674v1_decoy	LN:1288	M5:93d19765c9dd00919c6cfa7d93347c46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000675v1_decoy	LN:1288	M5:71235a1d58334d223edcaa90fefacfdd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000676v1_decoy	LN:1287	M5:a76f2f42317a6ab2cb892a72174adb45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000677v1_decoy	LN:1287	M5:f334340b46a994fa73de757843dce680	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000678v1_decoy	LN:1287	M5:e2d24061f1801ed1293ec0b863363b3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000679v1_decoy	LN:1286	M5:23647de37c2ff39cd67aaef8a5580814	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000680v1_decoy	LN:1283	M5:1dbcdc4ac713f81604583fa6b6106bb4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000681v1_decoy	LN:1281	M5:bb3d85c707984bea66a348264a710aa3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000682v1_decoy	LN:1277	M5:5c2e53fdc0f5cd26c68ab66f14416b3b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000683v1_decoy	LN:1274	M5:f1d20984b2bcf2b2b0e005c54fff514a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000684v1_decoy	LN:1270	M5:0e776546d49756c788dae25d1787fb00	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000685v1_decoy	LN:1267	M5:e52038740e15a18dd9b464342630faed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000686v1_decoy	LN:1266	M5:9b437657983b2138524382ca0130b93b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000687v1_decoy	LN:1260	M5:0a5f065c6de74f1ae3424582269c48da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000688v1_decoy	LN:1259	M5:78788ef8ba3807f9a105d4a9a55a3c65	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000689v1_decoy	LN:1258	M5:4860c125f57848f7afe40d583f7477ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000690v1_decoy	LN:1258	M5:2713e855b2f8f1734239f0523b6200ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000691v1_decoy	LN:1258	M5:619c058b99f936b291f949550793c9f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000692v1_decoy	LN:1256	M5:c21ff94783721fb59f3db81a80c1e0d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000693v1_decoy	LN:1255	M5:8c83cfffa25879e35ab28858fa33d70a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000694v1_decoy	LN:1254	M5:b0caa977dfdfb73b5e1a58b423ff4a8b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000695v1_decoy	LN:1254	M5:e2dd86e353ba1cebb9ee6ed4e35b54f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000696v1_decoy	LN:1253	M5:5036e5442498d2a7fdb0f573f258cd60	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000697v1_decoy	LN:1250	M5:a082ce0af37351135354a3448f4e1e21	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000698v1_decoy	LN:1249	M5:d47b3d78169ea825e882ac16b3117146	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000699v1_decoy	LN:1248	M5:208d107183937e7c221f38693342e39d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000700v1_decoy	LN:1248	M5:0f92b053b9f7b2d596ce45e73486fe32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000701v1_decoy	LN:1247	M5:38be4b2a0f1e5aa9c09b662eee046034	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000702v1_decoy	LN:1242	M5:05cde0965d9330b1048d4d3c3d3d700c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000703v1_decoy	LN:1242	M5:0861806c0301513ad259fe070d39e0dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000704v1_decoy	LN:1241	M5:364bee56428db3836e130cf7a18b713d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000705v1_decoy	LN:1241	M5:854cf124e49f41012ddbad98fa6676d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000706v1_decoy	LN:1241	M5:1f8ca7e72524d4e37948801d7b5a8afe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000707v1_decoy	LN:1239	M5:f24cb34121b984ca68855edd34574629	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000708v1_decoy	LN:1238	M5:d209df786f3b1d1ad941874631548588	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000709v1_decoy	LN:1237	M5:b4a98205bda995826a33cefc257ca695	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000710v1_decoy	LN:1236	M5:e889a8feacb30e59ab4f4b36b7d9c1e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000711v1_decoy	LN:1235	M5:1d00a257b98ad31640bb5ba492b84179	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000712v1_decoy	LN:1234	M5:33721b9972767397365deed771dbf073	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000713v1_decoy	LN:1234	M5:036d24e0ed6b0b50f1cfbd3f587c4cc2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000714v1_decoy	LN:1234	M5:a7ddd63607d708a84ae2b88906989e89	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000715v1_decoy	LN:1233	M5:9eac1d4d910f6c899ce66d778f2f1151	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000716v1_decoy	LN:1232	M5:0b8643f1a24c79b3ecdd1a67db0cc86a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000717v1_decoy	LN:1232	M5:c5a5a989ac7252d8392936662ea77847	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000718v1_decoy	LN:1231	M5:ac3030bfebae64338eb50915e6c8bd90	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000719v1_decoy	LN:1230	M5:57901862b298a5add08f5cca114254dd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000720v1_decoy	LN:1228	M5:425fcf156dc340ca958e76e678b5b1e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000721v1_decoy	LN:1227	M5:8202dba5ecf55e01c2eaa23654a65b28	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000722v1_decoy	LN:1227	M5:84410313c42ed3e74a0db6afd68aea27	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000723v1_decoy	LN:1226	M5:abbfddc0795df55c6e15788256752132	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000724v1_decoy	LN:1224	M5:a62c3a744a6da312ddb499103c0e5dd1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000725v1_decoy	LN:1224	M5:8de8180c87074519ebeedefce23a5bd0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000726v1_decoy	LN:1220	M5:f04fd8bfac48f74f1ba90d5f1730840b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000727v1_decoy	LN:1220	M5:f0dfe089c3f7b049c98dc63e934ff352	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000728v1_decoy	LN:1219	M5:e7c7be67e8022eceeb1748e1bc896244	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000729v1_decoy	LN:1217	M5:d54b84b201adc65a8f6c321c0a9b82b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000730v1_decoy	LN:1216	M5:2a49da07788e874c277958962ecb0df3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000731v1_decoy	LN:1215	M5:c382bd37421a81163d88288a6f7cde1d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000732v1_decoy	LN:1214	M5:2987b50923434c160ee2c370f1a0665f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000733v1_decoy	LN:1214	M5:2cef32c11c190dec442c6760ce3b95d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000734v1_decoy	LN:1214	M5:3320cf99748892c60e02c948326286eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000735v1_decoy	LN:1213	M5:ed1d21ad71609ae43a9b6bcebb49639f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000736v1_decoy	LN:1212	M5:b586f3157d6a08d059ff88c2a8b09110	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000737v1_decoy	LN:1209	M5:7ba7bce4d6531a5524c73a86b5bedbb3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000738v1_decoy	LN:1208	M5:04bd45b790033b8311ed85dea3015e01	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000739v1_decoy	LN:1207	M5:347ce8f1f6a746892189ab8494e8aaa8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000740v1_decoy	LN:1207	M5:707de4a5497ea34c4e4f0bc0c85de3fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000741v1_decoy	LN:1207	M5:be1fcf2149a75c654ccdcd7bdf0f6fbe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000742v1_decoy	LN:1206	M5:4e1effd0109053a328e58366f9f97082	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000743v1_decoy	LN:1206	M5:9f9dfe453260eb10828d18745f7f5dcc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000744v1_decoy	LN:1205	M5:855e900b59e0654686ce1a3d9955d650	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000745v1_decoy	LN:1205	M5:137e80b53681aa0957f4489dc3bebca5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000746v1_decoy	LN:1204	M5:d5ccfc0afa0a8ffeb39566a3edbd5831	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000747v1_decoy	LN:1204	M5:2d8e3051fce1f6364064a61a1015f902	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000748v1_decoy	LN:1204	M5:4ae1aece0937c17d93e0b54aab43444f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000749v1_decoy	LN:1203	M5:108a33f55fef0274c3265bbadc509de9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000750v1_decoy	LN:1201	M5:6ca12ea72ce31843c3a72b1519b0f252	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000751v1_decoy	LN:1201	M5:85e6c0c98d00cefe52487084168379f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000752v1_decoy	LN:1200	M5:6db13990bde5be0862c8524915fea770	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000753v1_decoy	LN:1200	M5:e2708863bd36e41c2e8ea5a6b3ec5110	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000754v1_decoy	LN:1199	M5:beae786e8598f79032fc8c16208aeb00	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000755v1_decoy	LN:1198	M5:0a56caad49417b3587e394dcf70fb6f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000756v1_decoy	LN:1197	M5:7f43dc6c55686b78a0ca14bb83eaf8c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000757v1_decoy	LN:1196	M5:ed9e0446d6bb51755db408158805d507	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000758v1_decoy	LN:1195	M5:cbb14c85e5696a49ce697e346634e422	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000759v1_decoy	LN:1194	M5:af5aad17aff7705f0fd96e58a32a59d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000760v1_decoy	LN:1194	M5:b1a7eab6e2cc0e62933274443fed0a24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000761v1_decoy	LN:1191	M5:23fae8306c0b4a5bf7d0941294736058	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000762v1_decoy	LN:1189	M5:5b7ba9e9888da831b0aa4565b412bcc6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000763v1_decoy	LN:1186	M5:b39edd9fdfea3b1d9644fa805f33a2b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000764v1_decoy	LN:1186	M5:ad284b4b4daf92a4456309e77375468a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000765v1_decoy	LN:1184	M5:98516b9021a46bcc79d7386ac6dc34c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000766v1_decoy	LN:1183	M5:64d3e55e37f2e86e15c96ef1d879bba1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000767v1_decoy	LN:1183	M5:bb4656c8fbc2436252c45a1da9ec9583	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000768v1_decoy	LN:1182	M5:fef2856f46d2c7724e666eafdd402ebc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000769v1_decoy	LN:1181	M5:987931dd2bf6bac95e341d207f146623	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000770v1_decoy	LN:1181	M5:eac4c9bfba221a54e6f9e50cbda276fa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000771v1_decoy	LN:1181	M5:cf5eee43e4ec7820ecca7ad7864f52ac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000772v1_decoy	LN:1181	M5:0b58fd78215049a25bf9904c8d82de05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000773v1_decoy	LN:1179	M5:bbff47313bf9094c388338d41292f0da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000774v1_decoy	LN:1178	M5:0e47d0853364f93c33da6738f79bd494	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000775v1_decoy	LN:1178	M5:f12f849bba7e72b4f1f60d7aad6a21a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000776v1_decoy	LN:1177	M5:1b10327e63ec134bcc76d1d55f9e78d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000777v1_decoy	LN:1177	M5:c87caf65afb409c1775c034ed6b2c791	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000778v1_decoy	LN:1171	M5:d25c5de51ec9619b03cce2f95298e8a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000779v1_decoy	LN:1171	M5:3e4f5e7a0753a3239b3bc0d49eeaf461	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000780v1_decoy	LN:1171	M5:b988438edbb2bbad2f8c1dd32c116f59	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000781v1_decoy	LN:1170	M5:41b5e67b7143e5bf81dbb61b81a230a8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000782v1_decoy	LN:1170	M5:ac3de3666d0730b5fb7f44a84f9c4d1d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000783v1_decoy	LN:1167	M5:7187d1e3ed138db9f1610a9c4dbefeb7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000784v1_decoy	LN:1167	M5:a1f7192900c80cfabbb39df8dc8d3c48	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000785v1_decoy	LN:1167	M5:80ff0c82d9a5bc156c3c0bf340bd68ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000786v1_decoy	LN:1165	M5:688f5bf8eb90c874eda7108fcf283889	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000787v1_decoy	LN:1165	M5:f768117d9e7c2526c123ea228e2cafe9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000788v1_decoy	LN:1162	M5:039765c983a107557b8c3ec0a025e44c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000789v1_decoy	LN:1157	M5:220dbbeab5a5d61415cdfde9f50b5766	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000790v1_decoy	LN:1156	M5:23d66ea0a7a7d160c9413d93f5ad0162	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000791v1_decoy	LN:1156	M5:5cb979a509d0b6052c6e0a55be36cc00	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000792v1_decoy	LN:1154	M5:b0ee554cec6a7fca1a6556932643d8a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000793v1_decoy	LN:1154	M5:0370a3a0105a0683cbd802403418f170	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000794v1_decoy	LN:1151	M5:8e0e1ffe5b02de8878bd4d564bb6323c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000795v1_decoy	LN:1151	M5:7bd0473f38ad03caa52a001a9fbb7354	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000796v1_decoy	LN:1150	M5:5a37e3660ee2c75c170b2b5b40e9fb6b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000797v1_decoy	LN:1150	M5:490b01f6455790bd5df9ffc337520f37	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000798v1_decoy	LN:1147	M5:20582882471f3bed3cd0120b82323ac3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000799v1_decoy	LN:1147	M5:0e5917e383190727d973a070137a2fbc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000800v1_decoy	LN:1146	M5:4bd3ad205dd76c8fb5e52879cad2ae96	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000801v1_decoy	LN:1144	M5:b97e8d5a835434eb2a718b9e61b8108e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000802v1_decoy	LN:1144	M5:2df1004e75f2e124d3578d82432b9495	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000803v1_decoy	LN:1143	M5:f38f2b568b969edfffe4cb768ffbf1f8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000804v1_decoy	LN:1142	M5:9aab8eca5e4d310eded1b7375ddc7cf6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000805v1_decoy	LN:1141	M5:9d60d12e15605e5bdc4e95d5507c5fbe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000806v1_decoy	LN:1141	M5:ed137b8aa6491c9545e9486d7412e617	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000807v1_decoy	LN:1140	M5:153c981d613562052e1fb0b115c4534f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000808v1_decoy	LN:1138	M5:0338a9928d761051eb989aba5a478df1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000809v1_decoy	LN:1134	M5:58756cfdfe491443b22624377976b379	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000810v1_decoy	LN:1134	M5:684bc9fdb4e26e632a8183d8802beedf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000811v1_decoy	LN:1132	M5:cbe47496e2df2406ca4e66332ba1ec10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000812v1_decoy	LN:1131	M5:4408dcacff9d3e25b64da0a9935a7bc3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000813v1_decoy	LN:1131	M5:58cc2832c5530babe80d72360b82afcb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000814v1_decoy	LN:1130	M5:c537aaab4d2fffc792fff332ba26df17	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000815v1_decoy	LN:1127	M5:c10ad449537826ed9790a8e7a91cc9f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000816v1_decoy	LN:1126	M5:43067a55481ed1a3a07a02ad65eaa2df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000817v1_decoy	LN:1124	M5:68a35e6dd8db1522069b2a5cee954207	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000818v1_decoy	LN:1122	M5:488cfcbe81f47dcfda704c5c28ebbe03	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000819v1_decoy	LN:1122	M5:de91661f937117bf675c5f21a54ab668	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000820v1_decoy	LN:1121	M5:5e6a5620500506981d3ab73624f63d9e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000821v1_decoy	LN:1119	M5:fb748af1360cb775a390f0e931dd02b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000822v1_decoy	LN:1119	M5:6b4f3cf5f29db2ef1bddb02c5828ce30	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000823v1_decoy	LN:1119	M5:90f491e70c191edb78a37852f165ac39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000824v1_decoy	LN:1119	M5:53358ae1c3833697bd5f0eb0f8ac79d5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000825v1_decoy	LN:1118	M5:e36d0f228ae617024efb91c918776dbc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000826v1_decoy	LN:1116	M5:28d254c1b706d0bf3b10df07746930cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000827v1_decoy	LN:1116	M5:08d17cf8bbbea61863d1111ebec35b21	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000828v1_decoy	LN:1115	M5:6ab6da5d7d22274a6ed522846b55ebc0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000829v1_decoy	LN:1115	M5:798a4b9e0b964f40d8c23e5cc3336db7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000830v1_decoy	LN:1115	M5:9cbd8613556330a85d27a64185ea84cc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000831v1_decoy	LN:1114	M5:83cc1a5967022f8e841c81fe75d58ffd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000832v1_decoy	LN:1113	M5:01c1108b447f8fc1ac66a83a185cf320	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000833v1_decoy	LN:1113	M5:7f89f5d60ad86ff56b75b22948d678c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000834v1_decoy	LN:1110	M5:5a70b2a58e433469ccb66822189128d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000835v1_decoy	LN:1110	M5:1e38e29d6d62fd249bf64655d6f81862	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000836v1_decoy	LN:1109	M5:96a1d9adc17f059b56e67cfb6937a345	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000837v1_decoy	LN:1108	M5:45ea81c798eb106c5436246caa66b2ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000838v1_decoy	LN:1107	M5:1814f68b7f841bfe03b315aa32382c00	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000839v1_decoy	LN:1107	M5:48441754ca4953c7e3a4a0c8d47ee1e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000840v1_decoy	LN:1107	M5:7f28434a41e01b99a0d611c226b8dae7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000841v1_decoy	LN:1107	M5:d18ae976cb8e092b2164fb5cf8e96c57	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000842v1_decoy	LN:1106	M5:7d6bf428559a5a4c3e493b755ebe5524	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000843v1_decoy	LN:1103	M5:c32717ad22315f9c16c5ec2cc21c930d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000844v1_decoy	LN:1103	M5:a1754553d128a5a63a67e63de2fd3738	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000845v1_decoy	LN:1103	M5:39f91ddc96023a6c28b74bce8ab2612c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000846v1_decoy	LN:1100	M5:82964c295c4313b285a6149d3c1566a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000847v1_decoy	LN:1099	M5:b6ad0bd8376da6c84aad8cf5fe7bc6d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000848v1_decoy	LN:1098	M5:e14ec564d8038b588e7bbcc8b2ec0a9a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000849v1_decoy	LN:1097	M5:7307c9a55c6540dd0e2d41858ae31cbd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000850v1_decoy	LN:1096	M5:a2998a406a8123e41e824e2ede54ed2b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000851v1_decoy	LN:1096	M5:e62b4e85fecea83baffc447a08ca6785	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000852v1_decoy	LN:1094	M5:6e5c8b4b68744e944eab55ecb8fb5844	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000853v1_decoy	LN:1093	M5:24331159404d19f94c9138da50577e51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000854v1_decoy	LN:1090	M5:2929cff1249a75eefb4cfffd96d62464	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000855v1_decoy	LN:1088	M5:fbb037cbafc5f686b9ab73e07f0ffcfe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000856v1_decoy	LN:1087	M5:211034f9737003efb857df7e977d5277	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000857v1_decoy	LN:1086	M5:368e68935f97965228ac78bb2aae203c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000858v1_decoy	LN:1085	M5:ce2ac36f0b0097282b1bff60c135f74e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000859v1_decoy	LN:1084	M5:3418f70e7ae002b97228bff0e077080b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000860v1_decoy	LN:1084	M5:b8e4715e539923de16e145b5eac6191e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000861v1_decoy	LN:1084	M5:fc5500f691a93bcad35796e610743159	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000862v1_decoy	LN:1084	M5:e59c0bee43efc00f925e98deafcb1339	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000863v1_decoy	LN:1083	M5:3f45413c28190577d1c4837a73d4a27a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000864v1_decoy	LN:1083	M5:5e5b283ed71b787f5a90e2a85cae8fcc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000865v1_decoy	LN:1082	M5:50f12f0b974f354351bb88c197b21126	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000866v1_decoy	LN:1082	M5:d678f152fcc7e46daafe921a0a41337d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000867v1_decoy	LN:1081	M5:b861e354b7da07ac9ff8f421b6caf341	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000868v1_decoy	LN:1081	M5:0eb25de463e630b62cb8c32bb42f6ad5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000869v1_decoy	LN:1079	M5:47743f7eabd8f065bf223bf5327dc730	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000870v1_decoy	LN:1076	M5:43ee859a8e75e455f0f1bdbfb155b6c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000871v1_decoy	LN:1074	M5:8de0f0af578c623d46ac53461a51a3cc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000872v1_decoy	LN:1073	M5:788f48af377f20246f7f9a21e90b0e0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000873v1_decoy	LN:1073	M5:45c2f5e2b5413134f6030f49be58ba4f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000874v1_decoy	LN:1071	M5:86a4e6ad2956475caac9b348e6e7f8b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000875v1_decoy	LN:1069	M5:22ee1b95d0dcca48ee2f77ec8135e0d5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000876v1_decoy	LN:1067	M5:3f76ce94efafe5dd1634e6d51aa6d1d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000877v1_decoy	LN:1067	M5:5bc259606f224eb610c64d5e5d55321b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000878v1_decoy	LN:1067	M5:9449555579bbe1f92046e6c9b1d6eb4a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000879v1_decoy	LN:1066	M5:2777151312e10fd89af514515090fcca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000880v1_decoy	LN:1065	M5:ae8283b9a8386e65951be3f19e3b7006	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000881v1_decoy	LN:1065	M5:79e7ca97d9a943a065f8d902b9b01244	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000882v1_decoy	LN:1065	M5:0991862c1ee6015ab6ba1008ec3ff69d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000883v1_decoy	LN:1065	M5:d68bf7942659eebe8f4973154fd1da22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000884v1_decoy	LN:1065	M5:dd08ea8e4c5ee4d1f942b2dce2296cbe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000885v1_decoy	LN:1064	M5:a5179394ece1fe9e2392cac1241bcacf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000886v1_decoy	LN:1064	M5:5ad23055bdc140edb211af99bf7d76e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000887v1_decoy	LN:1064	M5:5fb9770dcbf52d1a7f41c9d235a9ceeb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000888v1_decoy	LN:1063	M5:68844d1f612bcae36302b17758f78e86	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000889v1_decoy	LN:1062	M5:844d181d05473e9b6d06b5defabf50d7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000890v1_decoy	LN:1062	M5:224848a8b0947ecc656065423b7862ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000891v1_decoy	LN:1062	M5:de33c1fe76fea17846a96ea7bc9e91f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000892v1_decoy	LN:1061	M5:919160e2c6fec7a7c92d823d76b66027	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000893v1_decoy	LN:1060	M5:f79c0acfc167625b085df24f5058e8f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000894v1_decoy	LN:1057	M5:6cae16f687b6453bea4343f3a72ea5d7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000895v1_decoy	LN:1057	M5:7b95591d319231c96c2db2ab196e568c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000896v1_decoy	LN:1056	M5:59477a60f18aa435be9cd8e8cb8958fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000897v1_decoy	LN:1055	M5:ef9e2ac86b6dc21510af5a157ffdd9a7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000898v1_decoy	LN:1055	M5:8a426cfbaa95d3a4ff9de0b8cc401ed0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000899v1_decoy	LN:1055	M5:071ea5ccf103c1e5bc64476b69297cae	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000900v1_decoy	LN:1055	M5:a0183c0c525e9830c2487ba397d48984	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000901v1_decoy	LN:1054	M5:fbc0b340afbabfc63b03b8ec4caf77ec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000902v1_decoy	LN:1051	M5:5f5a077b53495abe7fc001c49c8b9306	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000903v1_decoy	LN:1050	M5:69420a1791c126a89681a6620ca82d48	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000904v1_decoy	LN:1050	M5:9c4f6e5286d911f86ede7780174ee24a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000905v1_decoy	LN:1049	M5:0940c85e47df41bd6052ec8f8ca76da3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000906v1_decoy	LN:1048	M5:d1bb56cbbe04f366cb8b9e00e16c0292	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000907v1_decoy	LN:1047	M5:b1bfe8c8a961d7d57914f4d7c4244100	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000908v1_decoy	LN:1046	M5:e48424ce325e8f78e32af41d56e93243	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000909v1_decoy	LN:1046	M5:2b08cbae6f429b208c980cf721fc1a43	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000910v1_decoy	LN:1046	M5:43dfe59c93ea059ca8557bb58d0d3e39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000911v1_decoy	LN:1045	M5:4a62b434c567f91554aba4fe9d29bee5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000912v1_decoy	LN:1045	M5:9dda9f1dca0f324d3ec28a2f95399b6f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000913v1_decoy	LN:1045	M5:f7d06c828a959e093ca5c4fefcaed79d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000914v1_decoy	LN:1044	M5:9565e8a0c6d2b4911f44a2dec3319fec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000915v1_decoy	LN:1042	M5:63910bd693964213823ca9ff1e270883	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000916v1_decoy	LN:1041	M5:9350358a6726a178c8e3c5c038a58b5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000917v1_decoy	LN:1039	M5:1c73f73eb55cd6290be7beede9ad10f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000918v1_decoy	LN:1039	M5:95035075514c5d5ad7852ba2c1b2b649	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000919v1_decoy	LN:1038	M5:f8b064906cddf6b316b6aee040120925	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000920v1_decoy	LN:1036	M5:510d0277b9afc44d0f3a07b3327a111d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000921v1_decoy	LN:1036	M5:d7a9e2e36d916e57d735f657035a9829	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000922v1_decoy	LN:1035	M5:318ac9befd9a2449cae3c371dec8e628	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000923v1_decoy	LN:1035	M5:6af821ff48f6593ccd322ce697bdc253	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000924v1_decoy	LN:1033	M5:bdd1f96a69f748c2a2fc4b21e31c2f06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000925v1_decoy	LN:1032	M5:5b23ae1b5786a5a5eadc92b69bd836c1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000926v1_decoy	LN:1031	M5:b06aa5a4fb487a467429373242a18923	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000927v1_decoy	LN:1031	M5:6fd21c6cec0c8086aa77d26c6d200aeb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000928v1_decoy	LN:1031	M5:196c591c8593f2c090224ae6cec80358	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000929v1_decoy	LN:1027	M5:b7eb33328daf9d0ae316619a61384cec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000930v1_decoy	LN:1027	M5:a1112db1101bde90d172ceb0b455adc0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000931v1_decoy	LN:1026	M5:42be32c5547cde39b2ccc77ac8e41c3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000932v1_decoy	LN:1026	M5:62f5a154eeb5e3613de4f255efe75565	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000933v1_decoy	LN:1024	M5:69e6c66e0db5f669e7762df739c9bba6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000934v1_decoy	LN:1024	M5:f2b5de034be298d37051f37061d1748a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000935v1_decoy	LN:1022	M5:d81ab37920ea303d70fec80162569190	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000936v1_decoy	LN:1022	M5:08f1fd0b0e3cb4204a68c0bd7c5c57a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000937v1_decoy	LN:1021	M5:4c13817a5ba74eee0c03aada914a0243	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000938v1_decoy	LN:1020	M5:e4ef90447f68425ac775770584c2ac6d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000939v1_decoy	LN:1019	M5:d7d108b06883f65ce1ec9f6a55b4842e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000940v1_decoy	LN:1018	M5:3e1e177644a21aa70ff44fba9753313c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000941v1_decoy	LN:1018	M5:6bff6cc8151a99c46a864ea703c2f8b1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000942v1_decoy	LN:1018	M5:e7f0466b453823ed7d075d4a2ede4a7b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000943v1_decoy	LN:1016	M5:3d62e68db3dcf0e169c55174dcbd79c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000944v1_decoy	LN:1010	M5:7b808bb60e41db8c1149f10d7bd5465e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000945v1_decoy	LN:1010	M5:8f606e0943101b0656668a2ae35e055f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000946v1_decoy	LN:1009	M5:5af16ec72873d3cf402dd411e1bbaafa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000947v1_decoy	LN:1008	M5:ccfac7e6bd5f5a5fb98e773922be5b3f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000948v1_decoy	LN:1007	M5:d5e4ec92647dc97d7ca5c479effc5698	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000949v1_decoy	LN:1006	M5:53c640d8a27c49f44643fa6cff64c7bd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000950v1_decoy	LN:1005	M5:4f20464a0e34b4c139f58567dac67a9d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000951v1_decoy	LN:1005	M5:47b4982ddfd84f1b626e9ea7b0859169	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000952v1_decoy	LN:1004	M5:77403eb0765e6a6422307122ee3a0544	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000953v1_decoy	LN:1004	M5:74caf00415bd1b5764ea6082c0945b27	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000954v1_decoy	LN:1003	M5:811dd1c7e02a779772cb0adcd330822d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000955v1_decoy	LN:1003	M5:b217fa3505a5024cd26ddcf42d514a4d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000956v1_decoy	LN:1003	M5:c90b2e71160e8f5cd6d23a740a17841b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000957v1_decoy	LN:1003	M5:3bf126803f3335d9227e753cb43060dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000958v1_decoy	LN:1002	M5:3904df1efaf5438d8e060141cf4dd6a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000959v1_decoy	LN:1002	M5:ab5ef802456142b25705723663909e35	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000960v1_decoy	LN:1000	M5:ff514a3d2ae42b584daf88b9a9a8751d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000961v1_decoy	LN:1000	M5:eb02c1a37ede0d1a737a6c8c984eb06e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000962v1_decoy	LN:8358	M5:567a758298b590bb1f4a159d81b84283	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000963v1_decoy	LN:7932	M5:fd0a26e270577d3a6cc4cb9256e21cc2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000964v1_decoy	LN:6846	M5:4fd9f0f9e88fcd125702c11dfc2c4efc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000965v1_decoy	LN:4591	M5:31483ec110747cfcac4dc1e36e8758ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000966v1_decoy	LN:4041	M5:f4f7ba029902c50fa77ed2b9966eb1a8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000967v1_decoy	LN:3841	M5:00a9379bf89f4556f66988ab0193b4c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000968v1_decoy	LN:3754	M5:bb2217ed56094a266a3fb1b82e6c6a23	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000969v1_decoy	LN:3743	M5:5332a570edd08ee710cafaec398e0156	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000970v1_decoy	LN:3702	M5:2b25e772f95c73582eacc01e9a048d9c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000971v1_decoy	LN:3625	M5:44cc5ae081c41e1c77f2043b88c70e0d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000972v1_decoy	LN:3529	M5:9c1927ed8f09b5ddff51f2f25450a4a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000973v1_decoy	LN:3508	M5:04e36a548c184b404c00b7841ba45394	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000974v1_decoy	LN:3359	M5:43e1fbfc042ef8b79879bd53c3b27521	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000975v1_decoy	LN:3320	M5:4c9cce705cc18e643a96d433b0f0d80d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000976v1_decoy	LN:3231	M5:090a5929ce6079dacc5408a9a7212f91	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000977v1_decoy	LN:3220	M5:b353222bd8f3e04b305911608d5b8b16	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000978v1_decoy	LN:3212	M5:d21eaa3001500aa078c0457aa0ecb160	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000979v1_decoy	LN:3192	M5:87ce752d8b9611f39e6371d84b00dd68	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000980v1_decoy	LN:3092	M5:51fba58b7e482359134618d7115ef0b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000981v1_decoy	LN:3087	M5:86e1c20fe0c0fc2ee5a4627c9dc91dde	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000982v1_decoy	LN:3048	M5:0f4f9a676207d67aa7b835ec767daa3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000983v1_decoy	LN:3005	M5:8cf60855c69aaa947ecffc2d85f7b836	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000984v1_decoy	LN:3004	M5:1fe6d0e0f45dd1c103c83d965f4d065f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000985v1_decoy	LN:2959	M5:5734404ace148ab496a0589c177d68d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000986v1_decoy	LN:2934	M5:6091b4163a2558a3b376861ba46e49b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000987v1_decoy	LN:2933	M5:867d88d0d6a7b4576b5f40df8aee32a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000988v1_decoy	LN:2827	M5:fc01429a43e70e9f45d2e9b183f1cbb5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000989v1_decoy	LN:2794	M5:8c97ce716667af6e7bf7b16598a2d1a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000990v1_decoy	LN:2749	M5:460d8510eb2de1d5521b6303183eca65	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000991v1_decoy	LN:2745	M5:bcb193217c039f3d327b106f7bbb1eb2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000992v1_decoy	LN:2733	M5:38d3109378fc051e0d6d30c9c768c361	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000993v1_decoy	LN:2698	M5:7909dcbf170e075fd5ae77f2de6658bf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000994v1_decoy	LN:2665	M5:90d637dd87631542f98b8a2fb31e45d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000995v1_decoy	LN:2634	M5:a5125437bf818a2f4ece1a2cb7ad4e5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000996v1_decoy	LN:2492	M5:82de7c0346b508963d47eaef107ba2ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000997v1_decoy	LN:2489	M5:904eab4180cdf8accc4e926f65892e16	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000998v1_decoy	LN:2468	M5:5a16ed756cd3e8451225c0c89c299ac3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01000999v1_decoy	LN:2414	M5:a7f82c5206197f2b60bf6e21e8406ff1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001000v1_decoy	LN:2395	M5:fa87a3decbc163bd5c4be47f26ce4c72	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001001v1_decoy	LN:2356	M5:c1764faa777d0cb7e6d10ff41a7f4d46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001002v1_decoy	LN:2339	M5:a71335121d2395b90f88701d0d395b28	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001003v1_decoy	LN:2310	M5:e7727f2a6ea39391478a70b270b9a4c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001004v1_decoy	LN:2288	M5:27c3653c8e9470329db519a7e855887b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001005v1_decoy	LN:2285	M5:07a062d63e1175496ade57cb4924ac86	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001006v1_decoy	LN:2269	M5:da22a2b66c30d77f9c75ac5543b82df4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001007v1_decoy	LN:2253	M5:521007d0a98d89311d4fef1f850e5c3d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001008v1_decoy	LN:2203	M5:efd830cbd9f13d6f2e59621b80df1cc0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001009v1_decoy	LN:2176	M5:35223579474d332cd9c25530d391cb37	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001010v1_decoy	LN:2159	M5:c6451a9867c60bb9414b9f531733227b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001011v1_decoy	LN:2155	M5:c9a15197997fcc229a4ba16daaef7ab9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001012v1_decoy	LN:2149	M5:8fc79f00adb9b9876fc0c760212279a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001013v1_decoy	LN:2129	M5:e0053f5c6a91ee7561e587740719a89a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001014v1_decoy	LN:2116	M5:c4594c9954ddda6bf892d1221deb1f5a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001015v1_decoy	LN:2113	M5:a604e6df460c882c18dd0b761e7da09a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001016v1_decoy	LN:2098	M5:1e7f643633169955a530300b89b41499	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001017v1_decoy	LN:2066	M5:95e88f3c4f847fe97ff528408aee9885	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001018v1_decoy	LN:2066	M5:50eb710c12d63d96710eead27936dbd0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001019v1_decoy	LN:2059	M5:80e50b65d76c95f06a65b213d6e22e3d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001020v1_decoy	LN:2047	M5:1e5494b45601a7dacb84814da24724db	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001021v1_decoy	LN:2040	M5:0fd285ea19d36ac7fbfeb49f98d0e3fc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001022v1_decoy	LN:2030	M5:4d3b39f0ab2f0f051d917cc94faeae9d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001023v1_decoy	LN:2024	M5:a4cef27d7ccd380794cbff4dd6eb41e7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001024v1_decoy	LN:2001	M5:e6821e55e6dbf96dd5ab53b59be17ce5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001025v1_decoy	LN:1992	M5:dda157c4b492e3c1a4e277e1dab4aa7e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001026v1_decoy	LN:1981	M5:4166a173f0411e5579f9d3ed8aacd959	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001027v1_decoy	LN:1979	M5:88e1e86ee00ad030c8e1f25e49ad569a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001028v1_decoy	LN:1957	M5:26727871d8918ce12f1e7fa8f5914c7d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001029v1_decoy	LN:1953	M5:9b38c1ef5a1efb5065c9f3dc102ff199	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001030v1_decoy	LN:1944	M5:85264a3258514a27228a82bcec9ea08d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001031v1_decoy	LN:1936	M5:a7347a7344187fa04690bfdffc33512e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001032v1_decoy	LN:1932	M5:4030d4f8fc378be7ab110a327a3a7f7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001033v1_decoy	LN:1882	M5:ca4279d8b8d3f3b766ec81b34c402aa0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001034v1_decoy	LN:1878	M5:e5d3efe3296f7f5ffb2193bd5be2aead	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001035v1_decoy	LN:1870	M5:1c898a94d86446ff18aeae6c9836d2cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001036v1_decoy	LN:1821	M5:8f2121509d8a9d3e95e78ceeaca8db95	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001037v1_decoy	LN:1813	M5:1111c9f5ecffa495ea2a9408094b8fb6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001038v1_decoy	LN:1809	M5:0ef16d8e23134785f99146b8b3cada3f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001039v1_decoy	LN:1804	M5:11e7f4e8d60fef86d7fbefca0fabf5df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001040v1_decoy	LN:1797	M5:42437cf6fa6210fd9b127e7487d14e4b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001041v1_decoy	LN:1791	M5:1b98bd8020f173b5205948481dd39658	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001042v1_decoy	LN:1781	M5:7460d29d17ba264f4358d5876a383fac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001043v1_decoy	LN:1766	M5:1599e276d124e4a9aa2f66a6300f8a3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001044v1_decoy	LN:1764	M5:fba6f4c5474d22767649a8328d8f3670	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001045v1_decoy	LN:1743	M5:8b83d468225e1a45cb1846dc726f2562	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001046v1_decoy	LN:1741	M5:8adc2f7bd9e61fde6e9824026c0a2430	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001047v1_decoy	LN:1709	M5:7363ff9bc2e506ad5041f70fc083e7fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001048v1_decoy	LN:1706	M5:ef2492257bbf08783a4db0aecad49550	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001049v1_decoy	LN:1701	M5:9c322f81502c32f0c8f405ee752a4f44	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001050v1_decoy	LN:1689	M5:5fe371c4096ae41150f76981d68dacd2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001051v1_decoy	LN:1646	M5:ed85a7af0713ab3b3bcdf61bafeedea5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001052v1_decoy	LN:1641	M5:97b84c347da74fc7614b6363ba4f28e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001053v1_decoy	LN:1639	M5:dc79cb73595caf151cffe0be4286ce1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001054v1_decoy	LN:1636	M5:221da4dd1119306af9f8fa1bc567f6fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001055v1_decoy	LN:1632	M5:6f572e5698e138bf1e7b1edba75588f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001056v1_decoy	LN:1629	M5:fd6f43c6fc2542ce63298bdd465a38a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001057v1_decoy	LN:1623	M5:4a44475e85813d0b54e2afdd3aa8315b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001058v1_decoy	LN:1622	M5:d30e3342b06bd2428d574ef50226a9b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001059v1_decoy	LN:1622	M5:0e6aaefcfab75455e8f59e751c8d44a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001060v1_decoy	LN:1619	M5:e91e56fee1ae99144354eba8e5ec571c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001061v1_decoy	LN:1606	M5:e266b715eded02faa272225186a213dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001062v1_decoy	LN:1593	M5:74d3a9f8a38387de10a759100154372c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001063v1_decoy	LN:1592	M5:efcf64c62b2233135f5794d7b9e2f4cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001064v1_decoy	LN:1558	M5:bbc8fdfa71746e3e396e745a1fc9d63d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001065v1_decoy	LN:1545	M5:fc836522e323b4779fcc5b16f2d28505	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001066v1_decoy	LN:1542	M5:6fe808dc84087dc7d8418eced9744173	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001067v1_decoy	LN:1540	M5:9c582e02bbde278105b2764116a44ef6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001068v1_decoy	LN:1529	M5:9f25be63cbf7cc5da1d1bc6fe23db799	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001069v1_decoy	LN:1518	M5:772df05b40eabe6b084af8cac402aef4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001070v1_decoy	LN:1515	M5:bda033712d93ab6c918ec5b0fa58f343	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001071v1_decoy	LN:1513	M5:faf46f2a8ea7b8d1d0282aaf9e10141b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001072v1_decoy	LN:1507	M5:12e6bce1a4e70c91a764227eafe6d229	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001073v1_decoy	LN:1504	M5:c757ce71d69487d184714bb6bf879036	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001074v1_decoy	LN:1499	M5:d6645febc4c0e7fef261124c74ecff8b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001075v1_decoy	LN:1495	M5:adf3668dcf991b59a38c281c3d7b5647	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001076v1_decoy	LN:1495	M5:2edd8f2a644a90e4ca21826bb31402dd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001077v1_decoy	LN:1492	M5:3dc6cc3ffd2a9b7966ca3e8ea12dc81f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001078v1_decoy	LN:1492	M5:308ce742886a73a84ab8cb90370451ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001079v1_decoy	LN:1489	M5:39d5f26be15da228d1d38b408e0a392c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001080v1_decoy	LN:1485	M5:2a52bf85b6a45c79c92a6c6027abf122	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001081v1_decoy	LN:1483	M5:d22840c21eb279736a5a8262ec8a66b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001082v1_decoy	LN:1473	M5:d6b57113fdeadd16b92fed725a02d12d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001083v1_decoy	LN:1470	M5:5b5ff1a6c8fff55ac6ebd1d9bda4fd80	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001084v1_decoy	LN:1463	M5:80030f88512ee394cc4e9a81b032e17a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001085v1_decoy	LN:1460	M5:2587132a077227d0b8742ec9439f95b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001086v1_decoy	LN:1458	M5:5366ad05ba9fe3bdfbc51dee8759c348	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001087v1_decoy	LN:1456	M5:1d39f2ea075eca983ca23f12efc47f22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001088v1_decoy	LN:1453	M5:020a82dc938b6e53e904f477268c7d5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001089v1_decoy	LN:1443	M5:541cab251db4f8356953dfc20e8cb327	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001090v1_decoy	LN:1441	M5:a563ca647fc20b65ba7baf52e3eb4648	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001091v1_decoy	LN:1426	M5:d096cb367c98d6804b4a1b205054c9ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001092v1_decoy	LN:1425	M5:4c1a5daffb2303c754e4383ec3bff31f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001093v1_decoy	LN:1418	M5:5305c46f4221a62f8001b24ced994801	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001094v1_decoy	LN:1413	M5:8d8667fd137515e7c5d31b0b942a7525	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001095v1_decoy	LN:1413	M5:e38f0eb475fa6f2aee1b51ea785af3f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001096v1_decoy	LN:1412	M5:88ee82e753efc8d4fbd5f1e02ddff9e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001097v1_decoy	LN:1407	M5:732666474ada2d4fe1316edd249b2f5d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001098v1_decoy	LN:1406	M5:f63dbabd25745821024183fe0082257b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001099v1_decoy	LN:1396	M5:0102bc3c8078cc16bddfa125f005370a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001100v1_decoy	LN:1390	M5:181bb8fe5095e667506c66e213f3b51d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001101v1_decoy	LN:1382	M5:545aae1204533fcf75e6c622471d3061	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001102v1_decoy	LN:1376	M5:a69102cf73d82bc4298048ee7eb0aa85	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001103v1_decoy	LN:1375	M5:61f67b4a0c7573bf583ae5a051e7aaf3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001104v1_decoy	LN:1371	M5:4b33e5f1a51a79cdc62fd070cf874f91	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001105v1_decoy	LN:1367	M5:4286f9ebcff872815a9246b3a2596781	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001106v1_decoy	LN:1364	M5:9a3f9b88cf1926d9c75b673647ff46c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001107v1_decoy	LN:1356	M5:b54b34217f1c3efb1ba9d4477a0f2045	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001108v1_decoy	LN:1355	M5:c49fb7670582bf2f81413071056f61ff	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001109v1_decoy	LN:1352	M5:32abeff50bcab272795c72f7b7edd46e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001110v1_decoy	LN:1350	M5:9660451ad55da2148a00b49a126176d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001111v1_decoy	LN:1346	M5:c6722a471b0e8cb1384d59ff72cc732a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001112v1_decoy	LN:1345	M5:6ffb665540f55661d5ccf40795cebd35	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001113v1_decoy	LN:1340	M5:e0ba11f5404075a40b0072d19c2bced2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001114v1_decoy	LN:1330	M5:ccb7f39ff649bf360b5b4186cf18c01f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001115v1_decoy	LN:1329	M5:c52f3a9196ca3b03d2a02680f15419e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001116v1_decoy	LN:1324	M5:f07d0c07c8951023331599b2df20380d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001117v1_decoy	LN:1316	M5:8195f619c45e8d571a25264aa6e7a65c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001118v1_decoy	LN:1307	M5:49f9986c45cac526b89e5520a9baa4dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001119v1_decoy	LN:1304	M5:fdbf4160ba84788b20bd855b64cea30f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001120v1_decoy	LN:1304	M5:edc34fe61ae9a3b15bc5a4ad8d291271	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001121v1_decoy	LN:1303	M5:6aea0ad92108bcebca7f7886b75bf9b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001122v1_decoy	LN:1301	M5:ccf0d28aa2b30e1d8e7ef2eafe01e849	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001123v1_decoy	LN:1300	M5:8bce51ab0470cf3f210d3b25582c2297	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001124v1_decoy	LN:1297	M5:01e9ba63de5b8b6e1a07efb0b1179f20	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001125v1_decoy	LN:1296	M5:dd2148d2b631c1a7e61a18155b56698f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001126v1_decoy	LN:1290	M5:9e7639e4c222198ef6503cc2e1c7577d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001127v1_decoy	LN:1284	M5:1ed6768a3d0449e96d3939d08102f424	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001128v1_decoy	LN:1282	M5:a8d94de0900b31bf20f7c16fa5eb29c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001129v1_decoy	LN:1281	M5:30eded62211ca354db518348aab06f6c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001130v1_decoy	LN:1280	M5:35b60389b57134465f6d190d5955cf46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001131v1_decoy	LN:1279	M5:448c65a5e874d8959bde564141823daa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001132v1_decoy	LN:1272	M5:aeacf07664f294565febc34b1f8f640b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001133v1_decoy	LN:1267	M5:df7730fbbc24afefb2749741f708f001	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001134v1_decoy	LN:1267	M5:eb717a13171c7390c1c2e91a50473c32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001135v1_decoy	LN:1266	M5:76896544c6b4b9c8bc2be23ce31fbe4f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001136v1_decoy	LN:1264	M5:f3195b89752559a8a693e50e17a9d0c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001137v1_decoy	LN:1264	M5:73ff474a35189bec700ddd7f25a140a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001138v1_decoy	LN:1264	M5:b090d99b3c28f2a84a801018d5843220	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001139v1_decoy	LN:1263	M5:a0baed3aa07a676a4fded91fd8edca4a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001140v1_decoy	LN:1249	M5:0e81abee1c989a0f1ceebfa48b5eacee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001141v1_decoy	LN:1240	M5:ddced69f19f82a08186fb39c0354eff3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001142v1_decoy	LN:1239	M5:43ea2140da380099332cf0cb0490293d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001143v1_decoy	LN:1235	M5:fe6e8b59583fb141e7b203df304e688e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001144v1_decoy	LN:1235	M5:7051b4e9e0386119d27af1cbe5a2c633	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001145v1_decoy	LN:1233	M5:703871732eddddd1c5ade422c3a7e105	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001146v1_decoy	LN:1232	M5:a281258df9fd861e7ca6bdb869fd27d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001147v1_decoy	LN:1230	M5:d0939ee2b936624fd9dc5f0bb2a0cff5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001148v1_decoy	LN:1226	M5:21f414046e47b5e9c13d47b9b073c6cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001149v1_decoy	LN:1223	M5:6e73b42728119fe2041f6c920248ed9a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001150v1_decoy	LN:1214	M5:44865e67b99f28cb3bf0d5d89d259a99	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001151v1_decoy	LN:1213	M5:062e3bbeb41213d0e68f944e1911f058	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001152v1_decoy	LN:1211	M5:75ee5d3d8230d6db22a735709fd78e40	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001153v1_decoy	LN:1209	M5:8ea8e29581777bdb7e7e2435b43a9123	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001154v1_decoy	LN:1202	M5:5e4321979f4ad7f0e0630deaf3292360	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001155v1_decoy	LN:1199	M5:de05fbc3c15237ca2c8d5c37f3f66dad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001156v1_decoy	LN:1197	M5:81532092e3b56c94488f88b7b40525f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001157v1_decoy	LN:1193	M5:ebc3be993ac1b9ab8acddc283066d160	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001158v1_decoy	LN:1191	M5:9bb2ea3006a7f808a16cf62efac3d39c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001159v1_decoy	LN:1187	M5:c5586dfb4606cba7d04c9bdb9b970ca3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001160v1_decoy	LN:1186	M5:8ac59cbe50a76ddb4315fa75de02a202	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001161v1_decoy	LN:1184	M5:1acac09b845dc4ff431c33916e819c87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001162v1_decoy	LN:1184	M5:b3d7d809b498912a66c53542f6164aa9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001163v1_decoy	LN:1182	M5:a06ad4e450a32bf31e43fa9794e6c635	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001164v1_decoy	LN:1179	M5:2fa76b3fa2caedda0d3aa46b0071fd03	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001165v1_decoy	LN:1173	M5:ba3aca12cb0c76e77a2ab28a3366cc21	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001166v1_decoy	LN:1169	M5:7eaa353b323f8eadf6cafe90fce641bd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001167v1_decoy	LN:1167	M5:61d674b4fcb995535cf94aa7ee127946	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001168v1_decoy	LN:1166	M5:38aa98ae17ee349012bee80c9828adfe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001169v1_decoy	LN:1165	M5:bbd8f8056d59712fd77f6bbaddca57b1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001170v1_decoy	LN:1164	M5:807bdf141f9ae4103c56e43d949f531e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001171v1_decoy	LN:1163	M5:cd8efaef0aa61647e740aa2b0e22ecd4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001172v1_decoy	LN:1158	M5:3e53721e66305f3f2b4da98d998268d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001173v1_decoy	LN:1158	M5:8ba71ae4bcbf61a48eabeee68296f62e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001174v1_decoy	LN:1157	M5:b99ae11f6934e857cb9399ae6c41824f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001175v1_decoy	LN:1157	M5:bbc9020c1846bb053b237d5b0478531d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001176v1_decoy	LN:1157	M5:52700c360bd82baf97d7bc5fd70a9825	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001177v1_decoy	LN:1155	M5:8e366717b85c08e01d0acc612724c6b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001178v1_decoy	LN:1154	M5:53cfcde178b82cf94450e6ecc610ef24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001179v1_decoy	LN:1149	M5:857f173eae9d86a6ed33b462c9607c5e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001180v1_decoy	LN:1148	M5:ea231418525b44371f390a8a2a11af78	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001181v1_decoy	LN:1148	M5:5a71efd43a930d44ebcb3574bb9cc031	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001182v1_decoy	LN:1146	M5:c8f128dd7893d4ec3036e468d8bd6522	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001183v1_decoy	LN:1144	M5:3cc0de0dd79e700a3369cf024230bc41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001184v1_decoy	LN:1140	M5:fe4503df1d12b851a419140fa4b4173f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001185v1_decoy	LN:1136	M5:224b91af2e2925de5d844cccabcf05ba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001186v1_decoy	LN:1134	M5:cfbd851609b789f2899a3be61d9127c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001187v1_decoy	LN:1133	M5:463b232f53f888f5d3bf049f131ebba1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001188v1_decoy	LN:1129	M5:1e9b1998943db973b5af6f8d3f8cc934	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001189v1_decoy	LN:1127	M5:e780622b257020939988b4785d91218a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001190v1_decoy	LN:1127	M5:7efc9fb11679f19ad35fe9371a9dbb1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001191v1_decoy	LN:1118	M5:911cf50162dfce9f1bec2ae5f5ffcd74	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001192v1_decoy	LN:1110	M5:e8f80a36c02331c337e0b327ff8faf9f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001193v1_decoy	LN:1104	M5:807ca6abca6229d97d8e363a0d01228f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001194v1_decoy	LN:1104	M5:0f010a7025fef93df6efa5c5bf5a0f20	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001195v1_decoy	LN:1101	M5:1c2dc8ff99f4cc1ff11ad3d16b9f272a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001196v1_decoy	LN:1098	M5:cb8ee97689963848f0ab08fab52ac3a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001197v1_decoy	LN:1096	M5:0724eae831018e8ab18798c02eaa4f1a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001198v1_decoy	LN:1094	M5:fefb3d4308c57ce507d9c50c88eaae9f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001199v1_decoy	LN:1091	M5:a86fb31cc351320639079ba611824352	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001200v1_decoy	LN:1089	M5:b75ffa24b8714c207a1d8de82e0812f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001201v1_decoy	LN:1086	M5:0fcd8b558e0ab2ccf0b0d8bc3db23d07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001202v1_decoy	LN:1085	M5:9e3b81bef0ba768284fd5cdc7b7ccf13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001203v1_decoy	LN:1084	M5:35268d23224ae41608aa13bd7fdc7fdd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001204v1_decoy	LN:1083	M5:a74077cc79c0fe324530f49b263b3307	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001205v1_decoy	LN:1083	M5:cc88bb09f7a6ad37d5d5bf95400fc329	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001206v1_decoy	LN:1079	M5:35f5a907b81ef8dbf77ec725790583dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001207v1_decoy	LN:1076	M5:de787959b71e3c620c8ef7e41f6bf5b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001208v1_decoy	LN:1069	M5:062313b0d5e67fee9d60100c7938397d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001209v1_decoy	LN:1068	M5:93480c74c7540c0e7af8c2576e2b9dac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001210v1_decoy	LN:1067	M5:8f8b744585f712f3e0f83707464cf886	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001211v1_decoy	LN:1067	M5:929d9dd00e1ad8454c70511ea362a4e8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001212v1_decoy	LN:1067	M5:24aa3c508b845b2b1048334ce78332c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001213v1_decoy	LN:1063	M5:29f3cd44f918aff7d3164e28bfddb98c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001214v1_decoy	LN:1062	M5:12f432068dd357613e770c93cafe0452	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001215v1_decoy	LN:1059	M5:47cb3f694ffe2d6ce654ed3b6cb5e3f7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001216v1_decoy	LN:1058	M5:f49ebea87cb9479f2d50f484c3217850	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001217v1_decoy	LN:1058	M5:4828d8055dbb4bfe4f703bb55a2ba1f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001218v1_decoy	LN:1055	M5:6feebb18b6b36dd7c31078b901101e23	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001219v1_decoy	LN:1054	M5:bbd43557ef56c3c1b056aa213470e130	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001220v1_decoy	LN:1054	M5:135c9383230d02f4fa50cd9ef42c51d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001221v1_decoy	LN:1053	M5:bf3402855155585fef154c6f26c2f42f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001222v1_decoy	LN:1053	M5:55f5597ffafbca066600c886b78932ab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001223v1_decoy	LN:1052	M5:777b4dde14fe0e0c5aff39ba12f25d7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001224v1_decoy	LN:1051	M5:f46bdaf70049d1b5dcdcf4d9bb8bb616	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001225v1_decoy	LN:1049	M5:a1ecf64987c3a271019ca2bcf6dfb797	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001226v1_decoy	LN:1047	M5:c2548a36b128c6216d1689299d9bc6e8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001227v1_decoy	LN:1044	M5:57aaa99e04236628ee2e2c48688a28e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001228v1_decoy	LN:1043	M5:8ab15ca1a985afa87ec7a9cf048505ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001229v1_decoy	LN:1043	M5:ad851f750b29642813387f1b00a09791	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001230v1_decoy	LN:1042	M5:794f6bbb5ddfaa81ad10c9f97e460d93	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001231v1_decoy	LN:1042	M5:a88fd0ab44445757ce49b2886b3483dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001232v1_decoy	LN:1041	M5:16cfe1e6b786b55e14e1c23b0010abd7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001233v1_decoy	LN:1040	M5:03f3627a2f7242721c8ba740808d67d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001234v1_decoy	LN:1039	M5:2bd140282d454fa86b3d845400c68456	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001235v1_decoy	LN:1038	M5:44928251b94a7ba7b6d78cfdc7b74903	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001236v1_decoy	LN:1037	M5:0021932312a252327115aef207a22260	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001237v1_decoy	LN:1037	M5:7ff32784d45f4a2b9d90d895152d8586	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001238v1_decoy	LN:1035	M5:cafb9e327ae844419f531cc74ad34c2a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001239v1_decoy	LN:1027	M5:87b6d1b7895e0e98849ddb847f85e535	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001240v1_decoy	LN:1021	M5:9f34ec8f23890b5c5ec129f3aa55fb28	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001241v1_decoy	LN:1021	M5:52f88af4a5a6b8a7171df7143c99cec1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001242v1_decoy	LN:1019	M5:093ab05e7ea2f698daf568af4a5f9314	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001243v1_decoy	LN:1019	M5:322f96479243e771eb980526832e662f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001244v1_decoy	LN:1016	M5:cf6212ddc0a137e657fec0764722dcad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001245v1_decoy	LN:1014	M5:21eab5ad8f971f8753d0aee1004c1335	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001246v1_decoy	LN:1013	M5:3c7ad60ac9394211fb081912b61e0f03	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001247v1_decoy	LN:1009	M5:09f86dc178eeb4ecffafd9734a2afd5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001248v1_decoy	LN:1008	M5:43929eb34efd2bbaf9f730d06a1e4799	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001249v1_decoy	LN:1007	M5:494ad809a7d99f4147c2398821be92a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001250v1_decoy	LN:1004	M5:589a72200353f7537edc3a9acccfe913	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001251v1_decoy	LN:1004	M5:183d62e7208aff9604bbbf27702052f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001252v1_decoy	LN:1003	M5:8f62a1d759dfd3a68b63b88c50e5fa85	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001253v1_decoy	LN:1001	M5:0bae6492e6a77abd67b50475fa94a80d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001254v1_decoy	LN:1000	M5:6c3e8a079341eb05dd337a0413754070	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001255v1_decoy	LN:1000	M5:39444bfd408b4e184afe6e0476041965	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001256v1_decoy	LN:1000	M5:44d266b549830722a7a161606171afd9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001257v1_decoy	LN:17929	M5:329d6c2a67aaff331fd020d0c9627310	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001258v1_decoy	LN:9749	M5:446c5fb7d2e7af681df8773fae61fb27	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001259v1_decoy	LN:8053	M5:83998e69640a5925a4a86054bce5f2ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001260v1_decoy	LN:7826	M5:30c34924be761a9b459c27c08f1f85e5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001261v1_decoy	LN:7768	M5:32d54ea636150f497c9484a714b37b8b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001262v1_decoy	LN:5691	M5:ed6cb5bb44a3cfa13f40e14e70bd5fda	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001263v1_decoy	LN:5444	M5:40da5cd1840a6368532eaf7e9e4dbe8b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001264v1_decoy	LN:5077	M5:ea25764cf81ce3030520b86de80c9758	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001265v1_decoy	LN:4990	M5:be003e2c8206a15f2159483f284c898a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001266v1_decoy	LN:4545	M5:f2f37f70dde8161d632cee33ff5ba435	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001267v1_decoy	LN:4544	M5:2b0987b0fb64b16ed454eaff1b74be84	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001268v1_decoy	LN:4202	M5:78643a9f481cc635295ad076fe1e82bc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001269v1_decoy	LN:4195	M5:eb3537b9b9d637c74f1d3b43e5fd06c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001270v1_decoy	LN:3807	M5:dc3d4eca4636d838ee52fe920bbffbfe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001271v1_decoy	LN:3741	M5:dc2e137e3cac9a5093030c34fa68c2ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001272v1_decoy	LN:3699	M5:db44a6f6dcd56edde16009cdfc186ccb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001273v1_decoy	LN:3640	M5:5bda6902f082f2b4a6823836d5d0b48c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001274v1_decoy	LN:3531	M5:2740aeab0828fa2d4f2789d353a40b8c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001275v1_decoy	LN:3455	M5:03cdb0fa6bc0f56dc7266334229fca85	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001276v1_decoy	LN:3411	M5:2127857d57a589d739a30316547e9447	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001277v1_decoy	LN:3387	M5:6b2e8c2f953822e034c233e94c710473	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001278v1_decoy	LN:3358	M5:61be95906f76f332c029bcaaca590c79	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001279v1_decoy	LN:3285	M5:3c9976ca87f24507e195746c96cd0b4f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001280v1_decoy	LN:3273	M5:8e25e50d38f8fb4cbe34cb3c83f14fc5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001281v1_decoy	LN:3262	M5:c1e6634aa95f817084fc1e1eced2abad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001282v1_decoy	LN:3259	M5:eded84ead1eb3b92edb6b77f27f8c4f6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001283v1_decoy	LN:3222	M5:08c79b1d017ddd4136c42b4cb8c16e5c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001284v1_decoy	LN:3127	M5:78f9666a13abcf03877f434199528e58	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001285v1_decoy	LN:3110	M5:19e028e80d77e35d088ea23eb52c9f68	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001286v1_decoy	LN:3104	M5:7f7ac2759ee408d0324f4841b60eb208	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001287v1_decoy	LN:3071	M5:cea9d8679bb3eacfb8b04f6ebbf1d4da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001288v1_decoy	LN:3063	M5:52b2d8ce5acdb6c47cd5cf7924b1bc24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001289v1_decoy	LN:3059	M5:8f356c7dd57f009b249e5147f708ff1a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001290v1_decoy	LN:2990	M5:5ef88696d7bd42f40685d222c13e3750	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001291v1_decoy	LN:2986	M5:5e39db2cc6d246fa9083dae9ffacda96	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001292v1_decoy	LN:2928	M5:09a5226cdb11c4ba418a8bdf844de126	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001293v1_decoy	LN:2922	M5:0b5455a2f20844d83c853abef966cffa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001294v1_decoy	LN:2875	M5:82e9fdbdba365f9449c25c473beabbcd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001295v1_decoy	LN:2859	M5:f0957c602b216d5ed18be6c38733aaf1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001296v1_decoy	LN:2850	M5:183158b1e867bb90712701171e344b1c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001297v1_decoy	LN:2813	M5:cad265dba180a6379fe3ff72f3874c51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001298v1_decoy	LN:2785	M5:b2dea38e300ff000f19f2ed7c17637ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001299v1_decoy	LN:2736	M5:75d2dcbfc2388d15030e0f3414952222	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001300v1_decoy	LN:2688	M5:0a109d9d73d2f16494f280419a294b45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001301v1_decoy	LN:2658	M5:3d83558c586ec81407c8717d1bcf07f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001302v1_decoy	LN:2643	M5:c91faf6dba1b10dadf69cfb999d96386	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001303v1_decoy	LN:2618	M5:10b7e187737a04307d41acec7960dffe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001304v1_decoy	LN:2605	M5:3385ffd5cef2e207dd33adbc369436c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001305v1_decoy	LN:2583	M5:4906d3167051868d21d54e95faccf81d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001306v1_decoy	LN:2534	M5:b315ca81b05ca7fa9b615787a3b18066	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001307v1_decoy	LN:2512	M5:fa1111a29692e4566683516ee2cb9829	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001308v1_decoy	LN:2500	M5:51a81bda9467ea2f1691f1136a69d3a7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001309v1_decoy	LN:2481	M5:66e34aaf92c2486bd4c11db6543995e6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001310v1_decoy	LN:2478	M5:c4ac4ca4a4312da763c265a008380d31	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001311v1_decoy	LN:2473	M5:464b136e01802236f8fcd38d3f548eb8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001312v1_decoy	LN:2467	M5:b4c84cee8bcb72c5b5260d702510937f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001313v1_decoy	LN:2442	M5:9d63b837b16220bf689f455bdc1d96c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001314v1_decoy	LN:2430	M5:56acbbe636fd49946581fc122c6688d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001315v1_decoy	LN:2417	M5:8082a8e6410572af77ebb845f8c1df94	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001316v1_decoy	LN:2408	M5:9a55c9ad04d332fd58a9914422f7d836	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001317v1_decoy	LN:2395	M5:c6c6115fb6941b48dc5a0abc409f5eac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001318v1_decoy	LN:2352	M5:755f704f0ecbfcbbfd31d8f375c83c5b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001319v1_decoy	LN:2337	M5:666a5906da91f80774c953543fb9c2c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001320v1_decoy	LN:2322	M5:0f19d9949679348751b92e237ed27888	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001321v1_decoy	LN:2307	M5:439c6600d966bee934ed52a2139c4687	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001322v1_decoy	LN:2306	M5:27db03ab4ca9e14af33b697876aaa754	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001323v1_decoy	LN:2292	M5:5fe69547ba8f4b03aaa8e71c2608fe14	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001324v1_decoy	LN:2271	M5:69ed4113a87f0c964d9f7515adb0dfeb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001325v1_decoy	LN:2265	M5:78e3664d88395ed413c3de96d0b6aa0d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001326v1_decoy	LN:2260	M5:ccac0591cbfd65e9a8d51f8e05d34f2a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001327v1_decoy	LN:2240	M5:bc9efb2dbf8706ae63a9da56f74a5940	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001328v1_decoy	LN:2238	M5:a0265d5b1e9532d8f124c363fe675206	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001329v1_decoy	LN:2228	M5:422f2cb811b961c3513bb155a4a0fed0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001330v1_decoy	LN:2215	M5:0d7e0facbdb02ac5cbe36bcb3f1683a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001331v1_decoy	LN:2205	M5:8aeb5e1e49ad042e60fd97cbe3bd36b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001332v1_decoy	LN:2191	M5:bc35b989cffe895e99e6a2fc45b7f65e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001333v1_decoy	LN:2191	M5:b1ccfad8f6bde8d9d40c0b7199e30cc5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001334v1_decoy	LN:2190	M5:0ae32cfb78573ddb9929745e2e7a0313	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001335v1_decoy	LN:2184	M5:08a18a9ad801c228f5de34b35b58ce5f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001336v1_decoy	LN:2166	M5:95badad6f81c843868ebb07d1f2d7911	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001337v1_decoy	LN:2165	M5:e10a87e41dccb3ec25e99df332d5a560	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001338v1_decoy	LN:2162	M5:7973da1851b09e72b47bf83450c468dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001339v1_decoy	LN:2146	M5:e8939fd820d746a8792b356c04e54cce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001340v1_decoy	LN:2116	M5:b67c09bdf1ed2f6a0ddd972711b36104	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001341v1_decoy	LN:2112	M5:90340b9fb118df304042bb73e83ec202	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001342v1_decoy	LN:2108	M5:465277293cdb0bf1897d5a17e266d354	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001343v1_decoy	LN:2106	M5:ddc350523aba6f1c4b90f820904cd233	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001344v1_decoy	LN:2106	M5:8c726624d2d1347ec079d4a89d25759e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001345v1_decoy	LN:2106	M5:4b1887bbf69131a205c5cc1a4303c860	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001346v1_decoy	LN:2097	M5:6dc99a12532b35dedef60dc2cfae35b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001347v1_decoy	LN:2081	M5:12316554f4811e33853508ac262465d6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001348v1_decoy	LN:2058	M5:b1935843fbea95bed6588d9d700d9936	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001349v1_decoy	LN:2055	M5:b013f57c784235eb32f6871dd01e5e13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001350v1_decoy	LN:2054	M5:c6835412045762a4c54200ada23f30b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001351v1_decoy	LN:2037	M5:50c1358c2b24fd59d5a286bbaa57818b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001352v1_decoy	LN:2032	M5:45ee3ea9d4de3859645f9b51f0ca2c67	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001353v1_decoy	LN:2032	M5:924e5cc3295232068cf32022f5f7e779	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001354v1_decoy	LN:2020	M5:70660abb35fad19ab75c06b301d4163a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001355v1_decoy	LN:2018	M5:9126be7c6d2612a65885a2fec496e2a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001356v1_decoy	LN:2014	M5:847a7ff01c6682c63ad35fae4dd6f947	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001357v1_decoy	LN:2001	M5:71668bc6a710ff919fd32549ee63f1f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001358v1_decoy	LN:2001	M5:3288f97535eb71395eaf3b088578bc3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001359v1_decoy	LN:1991	M5:b29d731dd150421c4e201d1adc92bd3f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001360v1_decoy	LN:1990	M5:7e91b8bc1cf2c754f8af12a28921575f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001361v1_decoy	LN:1983	M5:71f21061b64aff6e62b116e9384a099a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001362v1_decoy	LN:1981	M5:87dba9523601c5cfc29630be31297114	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001363v1_decoy	LN:1981	M5:2a3b4956ecd118211708b9d7c428818f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001364v1_decoy	LN:1979	M5:eb8501b5022cd696a32a2bff2acbbb3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001365v1_decoy	LN:1963	M5:87a0635cbf78d7359208e0d29a3b9596	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001366v1_decoy	LN:1932	M5:42a66b3579061c6333cfeec8e7bc7b0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001367v1_decoy	LN:1929	M5:95db3317d465876b900ca9167ec31b73	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001368v1_decoy	LN:1881	M5:31fb7324b8669148c367ef667ff3c928	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001369v1_decoy	LN:1874	M5:bb9c6a2d6ec56835ea520c45a854e8eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001370v1_decoy	LN:1849	M5:8f83bc8528784a67dd64f10d89331d81	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001371v1_decoy	LN:1849	M5:aadeed33b6077b0febbd1f61c186805c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001372v1_decoy	LN:1833	M5:155c69774a39a66871981c66bb0f0535	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001373v1_decoy	LN:1832	M5:2677f37d4424e092deaaf6c2371defb9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001374v1_decoy	LN:1826	M5:4dbca21467f25692d20f062b08c3238d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001375v1_decoy	LN:1814	M5:208039e11c53bf03a11d83b417fe5920	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001376v1_decoy	LN:1814	M5:8ef785587310c1f2d2226b740e7e4553	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001377v1_decoy	LN:1791	M5:ab8270aa2cc7626669c77a954b338953	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001378v1_decoy	LN:1789	M5:3ac762e7071f807dda31f5513d9624cd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001379v1_decoy	LN:1786	M5:9149be02831b6a76a57da93d45460920	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001380v1_decoy	LN:1778	M5:a17c5b0d2e1771a62091b6705cfbf5a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001381v1_decoy	LN:1776	M5:2ebb9adddc8d21f56ed91c6fbc97cfe1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001382v1_decoy	LN:1762	M5:686009ce9e6490069ba0845173cf2c16	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001383v1_decoy	LN:1758	M5:34dc7958ca4e0be1690c80cce1f048de	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001384v1_decoy	LN:1757	M5:af98ed1ffd7c4a0166ed1d3bb789d039	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001385v1_decoy	LN:1754	M5:80b9896356b85bbe70c7ed49afb616a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001386v1_decoy	LN:1752	M5:a7c233ed3f050d44d75a9138231b5384	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001387v1_decoy	LN:1751	M5:6e2fe9e7a9951deedb4a39fd837721a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001388v1_decoy	LN:1749	M5:5d5cf3896254f422f70ace465b0f820d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001389v1_decoy	LN:1738	M5:f8265cae7fb03630effc0fede6811b3f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001390v1_decoy	LN:1729	M5:48fe4b417655ad69a29770ec6e412fdb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001391v1_decoy	LN:1726	M5:01bbe99249b489660daa17fa9f958d10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001392v1_decoy	LN:1716	M5:bd9a3ab49b9960e88c2490efe5d8c749	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001393v1_decoy	LN:1712	M5:f05c2bfa07a617b06e6a8ebc4efc5022	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001394v1_decoy	LN:1711	M5:0f06abd7c321228fa763fb3815140af5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001395v1_decoy	LN:1703	M5:09b91ffc2209fd9adc0e0fbac86de4bd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001396v1_decoy	LN:1702	M5:ff652624b7319ee60f8946d8f751cf16	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001397v1_decoy	LN:1699	M5:2a71713d93ad2a6a8edc736ddc02907d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001398v1_decoy	LN:1686	M5:3bfbf7d5273c5ec692b1907c7c3ff2d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001399v1_decoy	LN:1684	M5:6d040733a43c01650e5c098e00d46a62	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001400v1_decoy	LN:1680	M5:c353280f0d833806daec83385e95e393	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001401v1_decoy	LN:1678	M5:c2edb1379f817a8378d4eb089dcdfc0d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001402v1_decoy	LN:1678	M5:740b37d2e6785fc699776f93cc872e86	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001403v1_decoy	LN:1677	M5:6d4b39914847504188d3b9feaf3348fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001404v1_decoy	LN:1676	M5:31845da6d4ed6000f50d5122bdef15cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001405v1_decoy	LN:1672	M5:0630c8622e65da828a153d66ab29b298	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001406v1_decoy	LN:1669	M5:e7d237d72fb65c19aac7bcaca3d86d95	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001407v1_decoy	LN:1668	M5:86c9c0f792de2f54f69278df5e3246cd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001408v1_decoy	LN:1663	M5:481fc7b87114d19302cdde760018a39c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001409v1_decoy	LN:1660	M5:ca249c982b9bc0cae8d02ae5a7e497cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001410v1_decoy	LN:1660	M5:9a4adc64cf2fd32db34af21df269bfe0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001411v1_decoy	LN:1658	M5:9e0ca112ba9edd83dd02ee0a1b977682	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001412v1_decoy	LN:1656	M5:30ba767a8335a19ffbb875f109afcac3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001413v1_decoy	LN:1656	M5:e77633b957a375847ad25f9b01d08580	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001414v1_decoy	LN:1652	M5:33a7cad76ee390036b7d61b167e2b351	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001415v1_decoy	LN:1647	M5:904ad5deeeb540a10728c9fabf9e5909	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001416v1_decoy	LN:1645	M5:378193508f34a25cf912974a4c531bb2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001417v1_decoy	LN:1641	M5:fe667f1d920a30b730d27903d4de3610	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001418v1_decoy	LN:1638	M5:dd1f1f8b342e987caf5e43ffa4b193ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001419v1_decoy	LN:1633	M5:775a347b6935f9e170d809222897833a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001420v1_decoy	LN:1626	M5:44b1b569182bce231346586fe77f0651	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001421v1_decoy	LN:1614	M5:04a70773f36888dde7766a58c3a92de1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001422v1_decoy	LN:1612	M5:0f0f7a8906ae3367b908acc806579e87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001423v1_decoy	LN:1605	M5:345b541ac9d588f32be39d15d00f6305	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001424v1_decoy	LN:1603	M5:dd25e42a5806fade892f5be6c5517133	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001425v1_decoy	LN:1599	M5:42c61caf5957d89e892870d7abb0086a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001426v1_decoy	LN:1589	M5:ff1c151f692dba0e79005392390f2639	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001427v1_decoy	LN:1588	M5:d409b0b1699f38489ac9b78c9e547b12	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001428v1_decoy	LN:1585	M5:549a7c1ad8b79d31a311204a8ce078c5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001429v1_decoy	LN:1584	M5:21ac82f5d3944ac17a667861fe4eb50c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001430v1_decoy	LN:1584	M5:d717e9b20496c0e3cf6f096572904e94	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001431v1_decoy	LN:1580	M5:4cef86e6f0c85a15667ecccf0ec2e509	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001432v1_decoy	LN:1572	M5:83a76ba3b28ab176a0fe0c3932129c1d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001433v1_decoy	LN:1570	M5:eefbc920c0c274a05ccd03672089bd6a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001434v1_decoy	LN:1569	M5:e84f6544b2757c3d68e8333237c05b9c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001435v1_decoy	LN:1568	M5:085a737d9ac2ce5ad615c127373713e9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001436v1_decoy	LN:1567	M5:d0cc61096796d51c565e73784c3df91e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001437v1_decoy	LN:1565	M5:963645d93472e0f55f70cf30e5541dcb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001438v1_decoy	LN:1559	M5:6cd647a043602392b10b564ef25b9bfa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001439v1_decoy	LN:1559	M5:41e3d96f1e4d9a77d4314fb0c550ddc8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001440v1_decoy	LN:1556	M5:f95112abd208efc5ebe4d5529e2537a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001441v1_decoy	LN:1554	M5:ff55b1b730eb936e0ffca09b8fff9a89	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001442v1_decoy	LN:1549	M5:df38873f39fd89b3782d53eb4bd35345	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001443v1_decoy	LN:1542	M5:66b6405dd4c7537d3119eeb1dfa81795	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001444v1_decoy	LN:1541	M5:ce00bd7a73eab91b6d81729240662ea1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001445v1_decoy	LN:1538	M5:96e6001e127eea7213d8378afb6f24d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001446v1_decoy	LN:1537	M5:4a49340b952f5a6e1fbcfbe271cbee49	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001447v1_decoy	LN:1535	M5:9d30511ff7644e5e501c629d82f97441	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001448v1_decoy	LN:1530	M5:ed3d23f4c537a88a36a4a6964bf2d332	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001449v1_decoy	LN:1528	M5:e2f85fa47e8361a098aacb0ddfe058e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001450v1_decoy	LN:1522	M5:525443cf312658767f3ffb263b1ab40a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001451v1_decoy	LN:1514	M5:d378e3b3268d04ee2ed255d9b671404b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001452v1_decoy	LN:1509	M5:434a0e69d1dfb2f439fd8c4c6efee812	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001453v1_decoy	LN:1507	M5:1c60f6588a6a6fdf49ba74bd4d8844ae	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001454v1_decoy	LN:1500	M5:4a8517743aa87c3edd4556e876facf8e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001455v1_decoy	LN:1499	M5:3787c00e3019dc0bd4b019ac8bd677e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001456v1_decoy	LN:1499	M5:93e8bbddc43d5e902eaac3b1569c191d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001457v1_decoy	LN:1497	M5:cedf6613fedd7bcfb6cf4822d6133393	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001458v1_decoy	LN:1496	M5:c6421744963f5f5ef7d06349345f8c11	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001459v1_decoy	LN:1488	M5:c3d6f0be5c1768c3f4ab357b40330c07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001460v1_decoy	LN:1486	M5:cfa272f94abe2b6ea6b8fff9bc2743a0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001461v1_decoy	LN:1485	M5:73b05431178ff099c7143b2c3310a8d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001462v1_decoy	LN:1481	M5:815cd718fd3524c82596f553bc50c030	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001463v1_decoy	LN:1479	M5:3be54176b83f28ddb8402da62d8368c5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001464v1_decoy	LN:1472	M5:a3d5a1d61c0377010cab585d8f86782b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001465v1_decoy	LN:1472	M5:54ed54ed3b16b9482b8bb7a42358e3f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001466v1_decoy	LN:1470	M5:957a8cadb7ce3ea0f910acb49b0d28f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001467v1_decoy	LN:1466	M5:5f1e18ba047f8e50f57be2e0ec9d7ee0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001468v1_decoy	LN:1465	M5:1371b580bc13e98f593106d0c6cc7055	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001469v1_decoy	LN:1461	M5:a1e27c8891fb421149591b6254008534	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001470v1_decoy	LN:1458	M5:0a299df79227b0b8f9d01b64c1091040	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001471v1_decoy	LN:1457	M5:fb81cfbfe3dcf83480d1566dbfb35cdf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001472v1_decoy	LN:1448	M5:5ccf4c226bbe31dec446e5f2cfb754aa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001473v1_decoy	LN:1447	M5:d4e733a5240b77f6521178683ef92f11	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001474v1_decoy	LN:1444	M5:266aac36179cb1faca5c4a0102fc8ace	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001475v1_decoy	LN:1443	M5:6153fa9f83b2dca77912302a435e6783	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001476v1_decoy	LN:1443	M5:eadd62062090a328419de772556bec04	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001477v1_decoy	LN:1438	M5:808b663863cc7b8062a075d60a932ee0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001478v1_decoy	LN:1432	M5:3d320a29f829d8b30da651831563b8fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001479v1_decoy	LN:1430	M5:d406932c6d2e5cda5d40bd5282612ec8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001480v1_decoy	LN:1430	M5:1b514b0604012b9c3bf96dc729d5b570	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001481v1_decoy	LN:1429	M5:bba1c32000bf8515723b23e91e3d73d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001482v1_decoy	LN:1429	M5:469a525eaccd114705d3876e6497d24c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001483v1_decoy	LN:1429	M5:1cab4c8d35aa87cfadcc67327c0cde05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001484v1_decoy	LN:1426	M5:7f0b3e31f88382eb1a9d667b4fa5ae8f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001485v1_decoy	LN:1426	M5:600029364a5faff2a6121c791c26f3b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001486v1_decoy	LN:1420	M5:bd2635b8f37ae8d36555126a2efda82f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001487v1_decoy	LN:1416	M5:1feda0b1dfda8eb29e804bb83d191350	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001488v1_decoy	LN:1416	M5:381713228fbc436ef15eb3fc5ce95526	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001489v1_decoy	LN:1415	M5:c7b5a3592ce2955180a8bf93340ce7a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001490v1_decoy	LN:1415	M5:8a9071712ed09640282279375c1aab9e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001491v1_decoy	LN:1414	M5:ad3849a6c284e0371da519c83c3efd56	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001492v1_decoy	LN:1413	M5:1897ebbd3ccc3ed5dfd33e64df6cee2e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001493v1_decoy	LN:1410	M5:bbae6ade32694ea4d23d50d382e589ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001494v1_decoy	LN:1405	M5:60eac2719276e2c8aed1dd8879086460	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001495v1_decoy	LN:1402	M5:560d0b9e5abc45feb134351a94cda358	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001496v1_decoy	LN:1398	M5:c87eb09186b0ed776438697cefe49c34	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001497v1_decoy	LN:1397	M5:17bdfaf46a6963ba97861fcb9ff9d4ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001498v1_decoy	LN:1395	M5:14942812a5a15869999430aa17472a47	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001499v1_decoy	LN:1392	M5:14d8c0e42dbe62d45491f288a844c263	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001500v1_decoy	LN:1388	M5:3535c9f286c4bc12e2fdab3ebd0e4cbd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001501v1_decoy	LN:1386	M5:3ed31b85ef3e34d8e053031462c9cc64	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001502v1_decoy	LN:1382	M5:370ef584d4cfe29bba430512c01c2d92	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001503v1_decoy	LN:1381	M5:0d6317f9e8c37b0d588aaf5c404621d6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001504v1_decoy	LN:1379	M5:15b371e04aee1e2cd7a2c3ad778615cd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001505v1_decoy	LN:1376	M5:9e5d443eae0beb889e93d9fec1df500f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001506v1_decoy	LN:1374	M5:19e75c42356ec21ffffd6ead1147246d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001507v1_decoy	LN:1374	M5:d047841fe73e626cbad1d1a075cc1179	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001508v1_decoy	LN:1373	M5:9af5c2bfca12c6e109d87d15a001f382	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001509v1_decoy	LN:1373	M5:26c1cdc503f21321bdbbf7184681fd57	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001510v1_decoy	LN:1372	M5:c08f8502b7b9423df1c4988d25d4e1e9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001511v1_decoy	LN:1370	M5:51b5c0febc1d93a3ae056b562f29febe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001512v1_decoy	LN:1367	M5:84cb97f5fa89889026682a6ddb4e17ec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001513v1_decoy	LN:1365	M5:9b35f302f4d7104621ee94c9466fcf05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001514v1_decoy	LN:1364	M5:d26988a458e184ce67dfdf1494cce818	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001515v1_decoy	LN:1361	M5:2be502a9c104f048b5faab19bf6b0c94	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001516v1_decoy	LN:1361	M5:a66a14b66c130258ed0f9a2e60b977a8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001517v1_decoy	LN:1355	M5:f8520c48ea6b728718603ce85ba18832	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001518v1_decoy	LN:1355	M5:d16784b4fc04cab4570de94e9753760e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001519v1_decoy	LN:1354	M5:226153c1ffcb6ca5cb3a64d124c3b9fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001520v1_decoy	LN:1353	M5:36898b58e8fec2ff86a3db37bffcfe2d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001521v1_decoy	LN:1349	M5:919f3dc576e969ebb845489e155befd1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001522v1_decoy	LN:1345	M5:e1f3dc21c137a83319e95d8cd641953b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001523v1_decoy	LN:1344	M5:c7cc4c4587e7e5f69d3afcaca3f62ef6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001524v1_decoy	LN:1343	M5:12b492bc7285ab647a13d8ac1efecc61	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001525v1_decoy	LN:1338	M5:8d831cbc5a7d72f9a5c05360b502005d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001526v1_decoy	LN:1338	M5:89ce2ba0c1414088ff5f502a0908059f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001527v1_decoy	LN:1338	M5:ed5c2d0150ddb784f059ca25eb3b32c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001528v1_decoy	LN:1336	M5:1dbe3107f4bae73b01853e98084f8f47	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001529v1_decoy	LN:1333	M5:1d1e9eb7e4182425f8718dc456a8e9bc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001530v1_decoy	LN:1333	M5:d77e50f1375e757aefd872040ee290b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001531v1_decoy	LN:1332	M5:93546f6ce6b44646b5a2d20190054dcb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001532v1_decoy	LN:1324	M5:bcb215dd97bfb4682fe3d17f99605c5f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001533v1_decoy	LN:1323	M5:0c68586edd47761d55b6a127af21b958	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001534v1_decoy	LN:1323	M5:8290481e03f0efd3da641df90d6a09f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001535v1_decoy	LN:1320	M5:06b5a586c070a38af486a0ae25dac08e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001536v1_decoy	LN:1320	M5:aa7f4ccf5b8955783f201e89c6b8b61b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001537v1_decoy	LN:1317	M5:5f5c4304240e41a75cdf79d590705a7b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001538v1_decoy	LN:1316	M5:2b2e47e474a04b2c5d7538dee74a4520	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001539v1_decoy	LN:1304	M5:70b1f3865cf28cf8c3cb6ca89e299e75	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001540v1_decoy	LN:1304	M5:801a2a35c0eb1ddde4f339fae91bdd02	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001541v1_decoy	LN:1303	M5:0013745a3b7f3937b3f0d58b8fb8b96d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001542v1_decoy	LN:1302	M5:2e708be5a88bc87556f10487d43af5f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001543v1_decoy	LN:1301	M5:9b421120b8e61665a80c2202f9742b11	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001544v1_decoy	LN:1300	M5:7b6b985d4c9b335dde3369fc8ae75a4f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001545v1_decoy	LN:1298	M5:c2c9f5a874990de1d53e53efca362cd0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001546v1_decoy	LN:1297	M5:8849c9f185b5ae8ed6d60d3b99c6591c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001547v1_decoy	LN:1295	M5:134596128a40e4a4c8f40d310152fe2f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001548v1_decoy	LN:1284	M5:c943fc593d7c12a3edad870f24db083c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001549v1_decoy	LN:1283	M5:de6680db4756a0d685d2f2405be073be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001550v1_decoy	LN:1283	M5:a86669f9a78babae5db999b036d712b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001551v1_decoy	LN:1279	M5:48d3b7e152913253a1c7749be4542da0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001552v1_decoy	LN:1278	M5:6f732db21b1679f66b34145d0d179a57	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001553v1_decoy	LN:1271	M5:18a0c55016d63414e1a7c9a868d2167b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001554v1_decoy	LN:1271	M5:fbb66e8da3ee67360e823061c517c47b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001555v1_decoy	LN:1268	M5:668bc50dfcee6830bfd6b8b193cf9aab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001556v1_decoy	LN:1264	M5:512e1b52aa8bc91a79e98a21f48fd69a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001557v1_decoy	LN:1263	M5:a280a5ddd14400e7a21e262dacba0878	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001558v1_decoy	LN:1262	M5:074796c17da27a3ae23b3ab43837eff9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001559v1_decoy	LN:1261	M5:f75ff3300dbd75160e935cd46e4511c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001560v1_decoy	LN:1260	M5:67884b5403ffc61f67795ef0fcc3b616	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001561v1_decoy	LN:1259	M5:778ef716a17f44127ce4648ca3d01437	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001562v1_decoy	LN:1259	M5:79561487702e7f87d4c1babb97cbf910	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001563v1_decoy	LN:1258	M5:05c2d3d1fe5c9569c6f982e7978b0d6d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001564v1_decoy	LN:1256	M5:443af4844c7fe05604fbf14d61807faf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001565v1_decoy	LN:1253	M5:3ab1b0cbc9dfe5e1b97cc5bbee6ba5d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001566v1_decoy	LN:1248	M5:6ca9712ce96adea0a2a178a885e6c403	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001567v1_decoy	LN:1248	M5:a9815826b47ba4c29bb0b6f427c91f9b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001568v1_decoy	LN:1246	M5:847154b1d516e188b5d8b9b6932658a8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001569v1_decoy	LN:1246	M5:cc8ad8f95e7d72b075ce88fc9fd93560	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001570v1_decoy	LN:1244	M5:3df737516c175d1baf5cb57874761a06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001571v1_decoy	LN:1238	M5:350c62d6852c839c79bb94399823a7c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001572v1_decoy	LN:1238	M5:cf4520e99994e5810535b8e92f1f4764	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001573v1_decoy	LN:1236	M5:27e61fe700513169fa02b0a6b9224fb6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001574v1_decoy	LN:1234	M5:6af09c7c1feeb50a156ab599d39314f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001575v1_decoy	LN:1234	M5:1b1c2b7e28c781322697a77df6b717c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001576v1_decoy	LN:1231	M5:24168a14a8a7b0626a75964a5ffa4c06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001577v1_decoy	LN:1231	M5:7b5c30f4c44dc17f05a6022490a1b06b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001578v1_decoy	LN:1230	M5:7dd3d8aa3ad6ae0467cbb5729a65b7fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001579v1_decoy	LN:1230	M5:9838f95ca9d84335f580003e43e0e909	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001580v1_decoy	LN:1228	M5:40d2f9b81666f0aeaadf3b60d6f00326	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001581v1_decoy	LN:1227	M5:b603baea2a6d239b5a0e0482be39ebae	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001582v1_decoy	LN:1222	M5:592ec40093cfd07fe7ae22531e7ff948	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001583v1_decoy	LN:1222	M5:45d2796dafa85ef3ebb8d378ab5c4fe2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001584v1_decoy	LN:1221	M5:7171fedcff845d9bf0eed62d8de65582	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001585v1_decoy	LN:1221	M5:1919b7c47b361c4925ba7f89f672c639	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001586v1_decoy	LN:1220	M5:9b6bee47fab2e16188e112fd219cb63b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001587v1_decoy	LN:1218	M5:403153f244f25427f95b761c7e7643f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001588v1_decoy	LN:1218	M5:4bdec42af039130bb647f35a1587442e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001589v1_decoy	LN:1216	M5:5eb119c85dbdbac20fd9b54ca19e3bb0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001590v1_decoy	LN:1216	M5:30be84f72824c6a73cb46db0880fca34	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001591v1_decoy	LN:1212	M5:a3990c8502d89fd44d2744a7c3b5ec27	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001592v1_decoy	LN:1210	M5:812ecd7a45c18a1ca8e07d380fa9c7fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001593v1_decoy	LN:1209	M5:f3658490a61b9678c62147607e15dd39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001594v1_decoy	LN:1208	M5:6ad7956bf60e17b114d96c186021ba22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001595v1_decoy	LN:1208	M5:07b45f43574a98e35df01f1b02658afa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001596v1_decoy	LN:1206	M5:7ad1a707f9ee83f188f836b84f0ee5de	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001597v1_decoy	LN:1205	M5:c5fe9e310df6cae87f2d597153392ce3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001598v1_decoy	LN:1205	M5:3253a26afa899ec2cde4d0fe80a95557	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001599v1_decoy	LN:1202	M5:7eba2ca9a5450bf7c6febae054f41555	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001600v1_decoy	LN:1200	M5:00f180d0f4f2be5d3a79232ebf1f4150	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001601v1_decoy	LN:1199	M5:06c81b1f3014d187114393c990dbb3d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001602v1_decoy	LN:1198	M5:04ad661ad55cf80b26d65b537fa28426	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001603v1_decoy	LN:1198	M5:10cec3a4b27c1a9e83dba32c764db1a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001604v1_decoy	LN:1198	M5:ca938a555284768f7de4aa5bc45030af	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001605v1_decoy	LN:1195	M5:6352f3ee72fc500fb234cefdc58d230c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001606v1_decoy	LN:1194	M5:7761a04b81c344864c4196c9fa348529	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001607v1_decoy	LN:1191	M5:6f495eb0c24a06b146428c8e15145289	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001608v1_decoy	LN:1189	M5:7cdef7e7fe5039c26f91054002844a08	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001609v1_decoy	LN:1188	M5:8fb25530ab0d6cc405ed3820a00a19b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001610v1_decoy	LN:1180	M5:baa36ab5e7d359dcf38de58e0578aa06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001611v1_decoy	LN:1180	M5:fbf128a1dc1f9852e12d0f7cc819e220	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001612v1_decoy	LN:1179	M5:cb72123adfc2996fb4f8c8023e656377	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001613v1_decoy	LN:1172	M5:9a828a68ee9904074c07ecb9b4a66d85	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001614v1_decoy	LN:1168	M5:47f21c445bb5e0f2901a60313a4b54fe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001615v1_decoy	LN:1166	M5:6640bdaa008c2b633f8732710aea42e5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001616v1_decoy	LN:1157	M5:548cacc169d84926fc794c75c8fe890a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001617v1_decoy	LN:1156	M5:ed240ec48dfc49536a05c15b0cf84b32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001618v1_decoy	LN:1156	M5:4cf17295af5ac519eeb5b60d65d8d630	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001619v1_decoy	LN:1155	M5:7535ed3093386510b39164d7d8c0e75d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001620v1_decoy	LN:1154	M5:942a2c1ebc2dcdc44aca71c7998704e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001621v1_decoy	LN:1154	M5:172266936a16cb96c0fa51a30de2f617	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001622v1_decoy	LN:1149	M5:904c6976a4151582f6e20888f8882b1c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001623v1_decoy	LN:1143	M5:e146ce9a62548893f8042eb31c9eb73a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001624v1_decoy	LN:1143	M5:226937ae596ef9af068232903d42c1f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001625v1_decoy	LN:1140	M5:9f8924f0407c98c271d938a89ce0651a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001626v1_decoy	LN:1137	M5:e6dc97de94f6ebca61e2afaa11081a24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001627v1_decoy	LN:1135	M5:ddc4671e6fc9af479ecc987b65228b89	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001628v1_decoy	LN:1135	M5:156395c17267dbc279afab948e04d7eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001629v1_decoy	LN:1135	M5:b51c39a7e5a4d0f3a185dfe0405d28be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001630v1_decoy	LN:1127	M5:eee6cec0d44e913c8909412bdc06fa14	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001631v1_decoy	LN:1127	M5:e614e251417f03894a86d226643c44b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001632v1_decoy	LN:1126	M5:e3d6bcc05df478652842790b2163c80e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001633v1_decoy	LN:1123	M5:62a0c3d0311f689e83c69aca70ff1d7c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001634v1_decoy	LN:1123	M5:4c25a0253e0d7c0aa032a2af4dc159a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001635v1_decoy	LN:1123	M5:77f17c8bda201de22cb683529469d159	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001636v1_decoy	LN:1122	M5:4716e9809cd6983cc872a801adcfcc46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001637v1_decoy	LN:1122	M5:e854813fe411b829feb5122630115359	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001638v1_decoy	LN:1121	M5:9ee360ada2996f37f05bc35f51af2274	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001639v1_decoy	LN:1121	M5:e9eacf65a91b75a7484d73c0960d1f14	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001640v1_decoy	LN:1119	M5:115a5a8bf67d2676b18db1fa2cf1fb41	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001641v1_decoy	LN:1119	M5:8c12171780de61fb413546e612810679	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001642v1_decoy	LN:1119	M5:d36511233c4008330a6ea48f39a48c8e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001643v1_decoy	LN:1118	M5:49d64211fa0e9269ff0335c106fadf0a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001644v1_decoy	LN:1115	M5:d3b2472895f28b7fa60956f7b18c525d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001645v1_decoy	LN:1106	M5:14d31945977d0566bc15d63216affa59	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001646v1_decoy	LN:1106	M5:954d5725f47430e77ac7a65db6252cb7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001647v1_decoy	LN:1104	M5:afc20c7775696bfe6b465aa9d8d5a2cb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001648v1_decoy	LN:1102	M5:1a699dde289aa62b55f6ac11bb7947e7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001649v1_decoy	LN:1101	M5:97d8bdd4c01947f81c47b798baa7b71e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001650v1_decoy	LN:1098	M5:81be16ab671a23dae662d52a90f53d45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001651v1_decoy	LN:1098	M5:849d2fca45af7dd15c549778da256bd5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001652v1_decoy	LN:1096	M5:85135079f59c18f32cab3330238996f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001653v1_decoy	LN:1096	M5:eeee606c5ce1877c2c17f3c35cee97c0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001654v1_decoy	LN:1095	M5:a67b439018f9500bd22116207fa78bb7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001655v1_decoy	LN:1093	M5:45193d6dc28c575afe0a816a04981a13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001656v1_decoy	LN:1090	M5:9e9a3deb3fbb62096e9267cf17b4538e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001657v1_decoy	LN:1089	M5:2fcd006deec28bc7b3e2ed1c81f6bd69	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001658v1_decoy	LN:1087	M5:b5ff50152c9932bd5f5c8f6d8f085250	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001659v1_decoy	LN:1087	M5:8dc8692a004984e174cae1a798c308ac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001660v1_decoy	LN:1085	M5:a26ef2777b049efc475e9f983166c858	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001661v1_decoy	LN:1085	M5:1d1b538881461819bddec7da548477d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001662v1_decoy	LN:1085	M5:a02c26203237d3ab0fdeec3b2226e415	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001663v1_decoy	LN:1083	M5:97595ecd8251d05c23a9a1f24c4fc331	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001664v1_decoy	LN:1080	M5:bb065f6218181f056b36deb6d5ea3fcf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001665v1_decoy	LN:1080	M5:242177401fdbd05a55373745dd7678ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001666v1_decoy	LN:1079	M5:aee38ae173783e327db2c83e4636269b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001667v1_decoy	LN:1079	M5:eb281bc766d87e3e887aff0c1f473bb7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001668v1_decoy	LN:1079	M5:b15b982e045772eb4fae4cf61eff32f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001669v1_decoy	LN:1075	M5:a0fe4aa8f27e7528a49b7fc241413bcd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001670v1_decoy	LN:1074	M5:5a9ee12d6200281af569684e9eb6c44d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001671v1_decoy	LN:1073	M5:58e3e1c01c24005c1bf6ecc4081328af	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001672v1_decoy	LN:1070	M5:6b4eaaed019b55c1445f856fa75748c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001673v1_decoy	LN:1068	M5:962507e31477075a1ec295c7f3e4f370	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001674v1_decoy	LN:1067	M5:246916ebbed387cdb53894261342b334	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001675v1_decoy	LN:1066	M5:45ef97be51801b68eddaf9d903c6569e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001676v1_decoy	LN:1066	M5:a1e2a77d7c51fc62c3f1261d96788416	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001677v1_decoy	LN:1066	M5:a72df1625ec9a3676769041db2b5db74	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001678v1_decoy	LN:1063	M5:63c3ca073be59c038fca2ce8cf57b58f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001679v1_decoy	LN:1063	M5:3b4176334e519bf0fc0ea90b5c450256	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001680v1_decoy	LN:1063	M5:e0c561be692e2103d216fec5f81a004f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001681v1_decoy	LN:1062	M5:a87bd7c0b225c0db2cc82df0e92fd34d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001682v1_decoy	LN:1058	M5:bd1fa296d60d2c1447479727889fd06d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001683v1_decoy	LN:1056	M5:ec709ad9663274dc4b8d9c95637e6231	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001684v1_decoy	LN:1052	M5:4c92b0e2cf0179f74e829358fdd4fd7d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001685v1_decoy	LN:1051	M5:d301a97b1b34b2cbcd690824430ef873	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001686v1_decoy	LN:1051	M5:bbc47709fbd21b2776773a149cc0338a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001687v1_decoy	LN:1050	M5:a01a1af5e1a2b7e924af29af696e561c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001688v1_decoy	LN:1048	M5:71b188e0ec08d62bcf1e70c1ad5dece1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001689v1_decoy	LN:1046	M5:6a0e08e5268e2e656a415ba75e6fd9bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001690v1_decoy	LN:1046	M5:59e6b5101b057b8b61117d4e775da1a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001691v1_decoy	LN:1045	M5:f09e7737756f026981c00c9f4e4a0fcb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001692v1_decoy	LN:1043	M5:90cc154008842d098dcd3bfcb288fad9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001693v1_decoy	LN:1038	M5:760fd011482ffc7b2972fff26ede08ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001694v1_decoy	LN:1036	M5:403a116827eda12cce96c83a442432ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001695v1_decoy	LN:1035	M5:aa903a22959e0e71bf9b65e184c98664	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001696v1_decoy	LN:1035	M5:c7b013db629c9e53bcc9e5ef6b45ea86	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001697v1_decoy	LN:1035	M5:b124dac1b39002796762805b01e70939	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001698v1_decoy	LN:1033	M5:973b579d06cff1e48883e0c933a40ace	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001699v1_decoy	LN:1032	M5:d91e5694037129aa77037d5c631b2c89	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001700v1_decoy	LN:1031	M5:26f0a1a25d70795beec266b79ee9872a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001701v1_decoy	LN:1026	M5:d895a2e531136b85f91cae9c41bac3eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001702v1_decoy	LN:1026	M5:eeaed2987f143706ea90f593db2ee43c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001703v1_decoy	LN:1026	M5:201ae22e581315eb83bf1b2a90a376ba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001704v1_decoy	LN:1023	M5:676723aca3cbe94f5e6fa6e3e677382e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001705v1_decoy	LN:1022	M5:079f24ae7a37258e2dcd3e45c2a82dc0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001706v1_decoy	LN:1020	M5:0c6c76de07c4a66f7b7c1625990fe97c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001707v1_decoy	LN:1020	M5:23b7cef7e53c021320be37e395337a6b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001708v1_decoy	LN:1020	M5:442bbaf4d63d7243f581f2a4f3c8713e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001709v1_decoy	LN:1019	M5:ead84759fc3d0742886397aa847a8c43	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001710v1_decoy	LN:1018	M5:30842e0e30b9626a2db87c8abee99c69	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001711v1_decoy	LN:1018	M5:85cd9b0b4ac27a135417acad1b49f347	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001712v1_decoy	LN:1017	M5:cf02f8f140f6cabc6edaa85f110e6a45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001713v1_decoy	LN:1015	M5:a1b077bd6e18faf0ce248051997e87b1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001714v1_decoy	LN:1015	M5:c108897419126d2b77335084625f756f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001715v1_decoy	LN:1015	M5:887e1695f416731637dc46a35b2a9548	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001716v1_decoy	LN:1014	M5:f4c888663c13ab55190b9228c5b46bb8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001717v1_decoy	LN:1014	M5:be3c4d0d37c5c1c8c88889dede5ba4b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001718v1_decoy	LN:1013	M5:2d3c3dfc692750b9b4c716debe8451a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001719v1_decoy	LN:1013	M5:c1212f7ba1d00f6f6553fc075e858e42	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001720v1_decoy	LN:1013	M5:6e854869ecc63cf6e45e7f0fc6eeb9c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001721v1_decoy	LN:1012	M5:05b1945756fa1adf0d4547bcd12f01ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001722v1_decoy	LN:1011	M5:0ef4eb4aa59e9725d43ed27a2f67d8d5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001723v1_decoy	LN:1011	M5:b4080ef5ca76b971d7eea5438484ce22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001724v1_decoy	LN:1009	M5:34953db0af28061b89bb32262121af7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001725v1_decoy	LN:1008	M5:b05c20cc6394423a0e1aef1bac72d0b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001726v1_decoy	LN:1008	M5:f2301601e3a88c6be9c38500a9d29685	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001727v1_decoy	LN:1007	M5:2ff7ac77e3568eeb2e7772e932dfa819	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001728v1_decoy	LN:1007	M5:04fd5dc748b4e7815316b0cccea3cba0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001729v1_decoy	LN:1007	M5:957456ba0e3f879860817f3ae6bfca78	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001730v1_decoy	LN:1006	M5:8381668c661d255ffbd7498d663acff2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001731v1_decoy	LN:1005	M5:92a03e55b43fc40c9c010df225cc650c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001732v1_decoy	LN:1003	M5:bc99a37cda9c755b77763c0873a3435d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001733v1_decoy	LN:1001	M5:6a123c9c76f9d1c0a35ba3666f861ddd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001734v1_decoy	LN:1000	M5:31048d43d8cae8a2c51fe5fcfbfa2462	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001735v1_decoy	LN:19311	M5:110c68ef04650368b85e76c55d599fcb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001736v1_decoy	LN:11713	M5:392799b68e6e2c6e288f07bc44a3a6b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001737v1_decoy	LN:11263	M5:091c74a89bf6767adbc92c7cfd9ab6bd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001738v1_decoy	LN:9779	M5:fdbeb36b87e966517a30478e8fd55631	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001739v1_decoy	LN:9568	M5:3562fa1ff9f4f23377f715895ecd504e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001740v1_decoy	LN:9344	M5:7c7fa5c413301e5c71020ee588c0c1cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001741v1_decoy	LN:9188	M5:ec88b5a808b4c20414719ba271b7b641	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001742v1_decoy	LN:9100	M5:bad4d9e7865b7ef45b00609846739bda	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001743v1_decoy	LN:8771	M5:56e67b8b7db6db977411d3485186a095	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001744v1_decoy	LN:8690	M5:f01b9132254ca4074ba5ddc5b74c3d1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001745v1_decoy	LN:8566	M5:d96c00c236c6c63764d62b50443c448a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001746v1_decoy	LN:8058	M5:14979af859f72ff6efa1b0230cb0bbd9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001747v1_decoy	LN:7759	M5:57af8f9f3fb38d3eb268e3d82b21e918	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001748v1_decoy	LN:7585	M5:332f1fac3f4964c85f80b068cd91e49f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001749v1_decoy	LN:7471	M5:a2a4f2f140a6703cfaa11c1a6ca07380	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001750v1_decoy	LN:7461	M5:ec2b8f7282528afa2de49ece1a8d3daa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001751v1_decoy	LN:7342	M5:328d2146da22838f30adcf361c5a9165	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001752v1_decoy	LN:7223	M5:b0e8a99c193409a71f86d373159d576c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001753v1_decoy	LN:7064	M5:3c4648b387bc44aaabddf795d6678ca1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001754v1_decoy	LN:6916	M5:c57ae49f10014609feff4fe84c91b31c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001755v1_decoy	LN:6897	M5:0bd737852eeaf5c723587cbbd74005d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001756v1_decoy	LN:6880	M5:e3d30ef79c4983f0fb99ecf9ac1ca7fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001757v1_decoy	LN:6857	M5:cfd001bcac96f459ceac7a135a59cb04	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001758v1_decoy	LN:6840	M5:6757a710758275b58b95545211e06526	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001759v1_decoy	LN:6728	M5:4d8b4b254f60864202e63aa9dba42086	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001760v1_decoy	LN:6688	M5:9e056067d1281622858dfe9830f147f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001761v1_decoy	LN:6553	M5:9182e4b1d32ec558a3bd3c94a5254ecc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001762v1_decoy	LN:6396	M5:23b91febfc6ba054d109596479f66f8f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001763v1_decoy	LN:6345	M5:f038e6215610b387550c3b50dddd49a5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001764v1_decoy	LN:6295	M5:d0f7f5b63499d6efd4d901a757b1cd7c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001765v1_decoy	LN:6266	M5:95b3fdc4315475b9c0408bc1f1f49202	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001766v1_decoy	LN:6173	M5:4db332a6222e767873f0d9c5051b83f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001767v1_decoy	LN:6171	M5:399db4ef3a58b54f82a07da4f0d264af	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001768v1_decoy	LN:6120	M5:399aa8c3cb106b5c685092b0de9313fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001769v1_decoy	LN:6105	M5:4990624c065870871ce2bfff6bbd26e7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001770v1_decoy	LN:6099	M5:2e817dafcd97d49c6dfa1eef14a5e32e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001771v1_decoy	LN:5893	M5:c8155a905ca8708a397ff91ea578e41f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001772v1_decoy	LN:5829	M5:85146edd3b2fab18762262a7455e00c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001773v1_decoy	LN:5793	M5:b72258377a1fd9ccb2a374de66066126	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001774v1_decoy	LN:5776	M5:51cdb4aa5438f8b50fb21eb9c0959839	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001775v1_decoy	LN:5759	M5:f30e892168c0f735365a13e51c8d0af3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001776v1_decoy	LN:5716	M5:c03eea2b4a0bc45e1e7df084b89340ef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001777v1_decoy	LN:5708	M5:5aba75f216a07e87387db64ea61a7c17	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001778v1_decoy	LN:5590	M5:09a93eafef7f433e1d2b0d7f3e4c2857	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001779v1_decoy	LN:5566	M5:173109c0f5077facb133a124c11fe44f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001780v1_decoy	LN:5558	M5:c7f1155230324ea1ff2ec21957290278	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001781v1_decoy	LN:5418	M5:8de9a43d5de5e0bd3fbdc3a8ba79bb3a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001782v1_decoy	LN:5375	M5:2d96ecf69a27a8876ecd20073def54b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001783v1_decoy	LN:5300	M5:07550b4953f67bec7ce4f4a04c493553	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001784v1_decoy	LN:5255	M5:5c4536fdcf9b0c8f69b6c13e9c535eb3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001785v1_decoy	LN:5157	M5:af427140b151e2e892fc9a95aec694f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001786v1_decoy	LN:5130	M5:254488c203afc62f6965ed57e0644916	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001787v1_decoy	LN:4978	M5:a0d7d65d0e93baf75fd6d6d38c774828	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001788v1_decoy	LN:4957	M5:6acbb899137257944298b46317165e69	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001789v1_decoy	LN:4947	M5:cec51f8ad5909dd8e0d3b01e25acbfd7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001790v1_decoy	LN:4897	M5:a8c98d6ff4dfa416c2dc12f726057ac0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001791v1_decoy	LN:4867	M5:8ad543666fcb2e40d2ce2c0bcb95a150	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001792v1_decoy	LN:4845	M5:a4cb8d08b6f399bd75e5d3edc40320f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001793v1_decoy	LN:4678	M5:02de644cfd20b00dbf3730793f839102	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001794v1_decoy	LN:4641	M5:5326e7bd1418a6bd8475fc0cf9383333	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001795v1_decoy	LN:4592	M5:bd9741fa5a5eaf10cb939a6822ac9473	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001796v1_decoy	LN:4543	M5:465f55fb7df07a219d9cb52c8d369e8a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001797v1_decoy	LN:4532	M5:4956e33b08cf6f8939a8053da18b8b4e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001798v1_decoy	LN:4503	M5:1fe8c217b537b8ff77877f684728af90	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001799v1_decoy	LN:4495	M5:317fc278049d65e36b6b4ac9ea865e2c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001800v1_decoy	LN:4444	M5:1815e62f1fb46ebe5a8f20ca027f5e3b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001801v1_decoy	LN:4414	M5:7911ec2b81df531fe586719cf18f339f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001802v1_decoy	LN:4409	M5:65257f0e3c59604d1b9d1534d2e05cc2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001803v1_decoy	LN:4302	M5:dd3519a759d8fb2773d3ce4e05d2e0c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001804v1_decoy	LN:4300	M5:1baabb53ab93bc883f297c4fd3313726	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001805v1_decoy	LN:4277	M5:a93c3da31dbc626ca07c7a5bb2ae1fce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001806v1_decoy	LN:4173	M5:ad4dbde798fb8814acca378a14f36ef4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001807v1_decoy	LN:4169	M5:5e7896feb74a66cdf343257968e26128	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001808v1_decoy	LN:4136	M5:bb27f7b565373b54a90878f371ecb315	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001809v1_decoy	LN:4101	M5:cc0696dc2c3a1cf86aa2bcf3be4fea1c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001810v1_decoy	LN:4089	M5:84d4249370d2ab227a405c59d78a49e5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001811v1_decoy	LN:4015	M5:13a4dd160518b12fd8900d058ae24627	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001812v1_decoy	LN:4000	M5:0d5607a998bac1719a3842db4b2ac324	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001813v1_decoy	LN:3973	M5:c54b9de7f485ab7729a4b35a122e5676	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001814v1_decoy	LN:3732	M5:0b810e5685d52453ea3c4c3c15f4ab46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001815v1_decoy	LN:3709	M5:41dc92336fe91882541594fefae1b397	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001816v1_decoy	LN:3686	M5:23342688bf37b8caa294e20464135302	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001817v1_decoy	LN:3676	M5:9d214925d90fe222b09cbc3b862d4be5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001818v1_decoy	LN:3673	M5:c4bbe25da86730cc4e55c74636296210	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001819v1_decoy	LN:3672	M5:3365257914847acb537ffb644b32f6fc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001820v1_decoy	LN:3633	M5:9af0a5d44c112d976299f598083354bd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001821v1_decoy	LN:3633	M5:276e5a73fe80f25706975973fca81151	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001822v1_decoy	LN:3613	M5:96044e09be5ba69252a13d71123ac546	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001823v1_decoy	LN:3605	M5:2402d86c44cceab83a438a4af0e24939	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001824v1_decoy	LN:3592	M5:8e4cc1d20a97fbddc8d430158ab2f8a9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001825v1_decoy	LN:3586	M5:b0cc5444bffc7aec1c01a855b52ec3a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001826v1_decoy	LN:3584	M5:9b94b86d924e51adbe1fa241e9eb4980	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001827v1_decoy	LN:3577	M5:2ed768998d7e36315f9b21917eff299e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001828v1_decoy	LN:3537	M5:b9fb044a6692c6bc7dfdca8fcb811f79	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001829v1_decoy	LN:3510	M5:27176699c6daad8aa9991c140bb4dceb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001830v1_decoy	LN:3509	M5:dab9d17bab4efaf2e54273afe4017807	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001831v1_decoy	LN:3488	M5:cc824ab2de05f959425033f7d1b34c54	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001832v1_decoy	LN:3473	M5:05d718c7b92a89c2a4b961ee6c0b008c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001833v1_decoy	LN:3445	M5:c374915181a1f43da7688151fad2c609	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001834v1_decoy	LN:3427	M5:fea3edb105a855523da01bbac633b515	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001835v1_decoy	LN:3395	M5:9323a036098595da4ac07b2de10ef332	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001836v1_decoy	LN:3367	M5:19070dba7b35a5d94fffb7a4c9bc41d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001837v1_decoy	LN:3337	M5:21d6bebf3b38b8e623684b9e0e707909	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001838v1_decoy	LN:3324	M5:445cf21cdd79290b7e69a748db3691c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001839v1_decoy	LN:3315	M5:f1f38a814378ad3f53ab744d03c6faec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001840v1_decoy	LN:3313	M5:943531134a853079b30be3d92c9a37ee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001841v1_decoy	LN:3283	M5:aa33f6f89273b5d970d09f46c4acffc4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001842v1_decoy	LN:3250	M5:6c7e5a0af5d65078902e7369e77c3eca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001843v1_decoy	LN:3247	M5:a40dde4dacd9b3af8d1346af020f3826	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001844v1_decoy	LN:3237	M5:19c321a618697df2f90bf2623e39e09a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001845v1_decoy	LN:3235	M5:858d4ef2c5182eec9a3af185040447c1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001846v1_decoy	LN:3200	M5:5198826fed1230b23329839aa0fe293b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001847v1_decoy	LN:3195	M5:bc41aa22979bdd3975774235ac080c4c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001848v1_decoy	LN:3175	M5:e3cf116e22c63b9ca8f5f83ef00c9227	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001849v1_decoy	LN:3158	M5:2c546de8c11c8b020271c0a602c8e914	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001850v1_decoy	LN:3143	M5:b114278cb76d8a47cd1ea131b6b01c46	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001851v1_decoy	LN:3139	M5:836cf9f277e7abe51f821eea4e72f9da	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001852v1_decoy	LN:3138	M5:99ec6bed7ebdeb700737347dbb987feb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001853v1_decoy	LN:3136	M5:3ce9684d466895b5b1ebc7b730c1a22d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001854v1_decoy	LN:3132	M5:4133dd5a44f06f0676fd2c8f8f2e532a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001855v1_decoy	LN:3132	M5:1d73546845d822a91cbc6d9f4e78688c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001856v1_decoy	LN:3095	M5:318534fba07d7da9181de4e227a5ddf1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001857v1_decoy	LN:3094	M5:bb93d34eb9f7a80b575056a9785171f8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001858v1_decoy	LN:3093	M5:b4c67202f6c2cd5231bdf62ec60bf138	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001859v1_decoy	LN:3059	M5:80bd25131b27cbfb7222fb139cdc03f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001860v1_decoy	LN:2985	M5:3b138424ffa05470fbaf4e81e0b11722	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001861v1_decoy	LN:2975	M5:128ceb0f1b4c41d3107868af22cbd590	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001862v1_decoy	LN:2967	M5:f0bd303b1446335f781e0c2f74d28de3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001863v1_decoy	LN:2961	M5:562fe7159c1f06d7750af9ef9c3d3e6f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001864v1_decoy	LN:2955	M5:8028d9a1447473820a8c0b0e88325ffb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001865v1_decoy	LN:2935	M5:2fb53f3d6f706d8f5738f63429c8de36	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001866v1_decoy	LN:2933	M5:a22cdeb6c078d85e19e089f7f9efb045	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001867v1_decoy	LN:2909	M5:1fd7abd65c5be9c9dc924daa280f43be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001868v1_decoy	LN:2904	M5:5e863959002b0c580d4820a7cebdbf48	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001869v1_decoy	LN:2892	M5:662acc47cf615cef44478309a902b41b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001870v1_decoy	LN:2886	M5:b83662f3f83e28d70a9133675fbe1b1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001871v1_decoy	LN:2885	M5:0734ed3f7e1aed9828f22b347664e98e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001872v1_decoy	LN:2878	M5:2246626d2530d2260b223f28a96a624a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001873v1_decoy	LN:2875	M5:a306eed4bf0048509612220ddfca4dca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001874v1_decoy	LN:2861	M5:45f856116b6642c701e0671967fb8bfe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001875v1_decoy	LN:2856	M5:a35e380dc9bcacbbc7a29692f039feb3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001876v1_decoy	LN:2838	M5:e010e81c2ae154a12105872faac2d033	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001877v1_decoy	LN:2801	M5:c830abeee2c0527ca00ee4004e2f26f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001878v1_decoy	LN:2797	M5:9f0b46d448ffe81f55a61311b72408d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001879v1_decoy	LN:2788	M5:ff37de9e839a483b85b9978f165e2aa4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001880v1_decoy	LN:2773	M5:45df0f07d5235217631f54d4decf8ce9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001881v1_decoy	LN:2755	M5:22fbad6b463ff553fbe7482783018f9b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001882v1_decoy	LN:2754	M5:f5751d68ef59013dd8a924405b61c766	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001883v1_decoy	LN:2743	M5:68564eee42e550492f0bf366f22345f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001884v1_decoy	LN:2725	M5:c4477959c12bb115614ea504cf712579	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001885v1_decoy	LN:2722	M5:d221c4dd4b764a3cf767ae2f408cd855	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001886v1_decoy	LN:2682	M5:6a91b1b63b686c713c6daaa9a5b28c48	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001887v1_decoy	LN:2669	M5:176039ee6f1d1ae8eaf240056ad7e1ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001888v1_decoy	LN:2663	M5:ac2fb1176f2733ad7fcdd03cc15e919d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001889v1_decoy	LN:2652	M5:f14b36f702c6db220606dd6696067369	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001890v1_decoy	LN:2647	M5:82b5cfe2b5ccc5d14445809aefc4acee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001891v1_decoy	LN:2635	M5:fa2959b22afb179b2e6b195f5bba68bc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001892v1_decoy	LN:2633	M5:62d8ae1cef408d715d22ae3ba3dfb9c6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001893v1_decoy	LN:2629	M5:cb667e2bdb9486da5a227dbd50803c45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001894v1_decoy	LN:2612	M5:923dfb32d8271c70d8e8cd9288621481	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001895v1_decoy	LN:2599	M5:691f294fc31908fd910ca9dac0cd4362	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001896v1_decoy	LN:2566	M5:9cce036b1dc05a82d7a2bd677688b7a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001897v1_decoy	LN:2556	M5:975e1058290d80f4ab2cf207313135aa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001898v1_decoy	LN:2551	M5:e52be60ead1084c5dbd6851964b3d575	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001899v1_decoy	LN:2551	M5:71028cef766fc1dc75684dc127ec3f73	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001900v1_decoy	LN:2538	M5:e180467b2632a688c6d3b1e58b17892d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001901v1_decoy	LN:2538	M5:bcaea2754972af50dff62993504801c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001902v1_decoy	LN:2525	M5:647f59f3a4ad408b803a4c971db5651a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001903v1_decoy	LN:2498	M5:80be471faeb22fb67458b7bb8e00ea3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001904v1_decoy	LN:2496	M5:be7e3722d3c1a45b98f79cf89cfc235f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001905v1_decoy	LN:2483	M5:609856bcc6aeb799c0a57773bccc7598	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001906v1_decoy	LN:2475	M5:e64a6fb38d225decae7e079ea7b9732b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001907v1_decoy	LN:2469	M5:e2b450a085ac14eec02539b8c1bd6bed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001908v1_decoy	LN:2455	M5:0b0b3b8bce8db6dc091b3429802919bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001909v1_decoy	LN:2444	M5:6a091545fa77d96dc253bedeaccb6692	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001910v1_decoy	LN:2437	M5:ad77fbca3fa49f1c970e8c64b58391d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001911v1_decoy	LN:2435	M5:233e3f635c3bd0fae9ed04c155c799a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001912v1_decoy	LN:2427	M5:e22283fea810c2cc4c92cc5ac5ead914	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001913v1_decoy	LN:2419	M5:ea7d2ed4522c0ecea6389a3b9fb7bcfd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001914v1_decoy	LN:2413	M5:953de10ba34733832f5bbcb37e12c5fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001915v1_decoy	LN:2412	M5:ea8ef9ae0476686a6cbd488a0202b2bd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001916v1_decoy	LN:2400	M5:0198ad2dfad702357fb849a43500deaa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001917v1_decoy	LN:2399	M5:d566d3ebbd937aa7ba415298188a1c93	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001918v1_decoy	LN:2396	M5:536fac7c509791bd524e9da425d7fd93	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001919v1_decoy	LN:2393	M5:522e11044a40018a2f755d9d4fd8103b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001920v1_decoy	LN:2386	M5:aa9e69c6d5f6d04b4030be6b3226964c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001921v1_decoy	LN:2384	M5:b4d05aabf35963906d1861ef966a4709	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001922v1_decoy	LN:2382	M5:97749df462ddf825702a260f9aa2f021	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001923v1_decoy	LN:2382	M5:3c0d3376e16a20d57497a815d2475873	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001924v1_decoy	LN:2367	M5:e76216aa8c58c6949a9c04cfa9b95995	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001925v1_decoy	LN:2366	M5:4b4ae46d37a4f45b63c4b8c3cb63294c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001926v1_decoy	LN:2362	M5:589965b553dd53d631ae9970b0c65403	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001927v1_decoy	LN:2361	M5:aaac326f62cef7cc31b28e60534d0a3a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001928v1_decoy	LN:2353	M5:2c60f763bb39af3328df40c97b8e4f0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001929v1_decoy	LN:2349	M5:5e3aee054d3451ec9e4e18ee277b5efb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001930v1_decoy	LN:2348	M5:c885bcc19373dca31580a65ec6fc7e48	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001931v1_decoy	LN:2340	M5:b36f2e5330d409cd8ba0973000358c52	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001932v1_decoy	LN:2339	M5:63104b56d2278c3cb82c3d6f23d8977c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001933v1_decoy	LN:2336	M5:2c7518f9e4ed0d994be4698762511cf3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001934v1_decoy	LN:2333	M5:308cac07c79336f8162a8c2e855f7762	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001935v1_decoy	LN:2330	M5:bb4702fc9e6227387e8ce3498109d998	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001936v1_decoy	LN:2327	M5:ddad50424c1114dd98bc0202ac1cd9fa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001937v1_decoy	LN:2318	M5:28804e3d50bf7764ac6b1897b1128790	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001938v1_decoy	LN:2293	M5:2aa344c0d737b4d9042325fb5a858bee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001939v1_decoy	LN:2292	M5:22b000d9737a411cb3844951ebc17b87	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001940v1_decoy	LN:2287	M5:44ec350c3d506da4df5a5c6c60683796	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001941v1_decoy	LN:2274	M5:c2d8c7fed619477a490f674da302b98c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001942v1_decoy	LN:2274	M5:bae016f221de9bcae9788e26dee71d3a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001943v1_decoy	LN:2267	M5:88696dc559363af860e8828eed45eb07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001944v1_decoy	LN:2260	M5:be18f9c08c02b23d6bc3e38f71843b69	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001945v1_decoy	LN:2257	M5:bc65d96f85bac2cf76e5db2847c7c723	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001946v1_decoy	LN:2240	M5:98c67c23fdf01dd3a05e1213470d56d5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001947v1_decoy	LN:2239	M5:0ec5d58555d46a257ce56425c730f4d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001948v1_decoy	LN:2232	M5:b8901c5291103859cc240e5d6c96c4ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001949v1_decoy	LN:2230	M5:976e267cf6d42bc3c67a345bb56e707f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001950v1_decoy	LN:2230	M5:f179f9db12db687102c9a63bacaf36ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001951v1_decoy	LN:2222	M5:f5a5058d6f869ae64c9a4b69439d4114	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001952v1_decoy	LN:2216	M5:63f1d3d20deaabfeeb68d11879debd0d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001953v1_decoy	LN:2214	M5:b09d559a9d44f7eb887d75fd192524ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001954v1_decoy	LN:2210	M5:7d0a884bf7fd09ebc9175286c058635f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001955v1_decoy	LN:2203	M5:6005c464e19405b659d2d2e09778b06b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001956v1_decoy	LN:2197	M5:a15768dc613354cb73ec09a4c5c814ee	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001957v1_decoy	LN:2196	M5:cd06502f93b8e17fd05511c84cf6c523	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001958v1_decoy	LN:2196	M5:c315413cc7a46460c67bde0cd8e78b71	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001959v1_decoy	LN:2179	M5:708d5a6db13c3ac37d5e90e0cc2a8c32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001960v1_decoy	LN:2178	M5:e217486e375bc7a5925ec6cc7fa9e003	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001961v1_decoy	LN:2178	M5:dd793d59199c7f60817d549e0c149b15	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001962v1_decoy	LN:2172	M5:aff6ab00ffade197cf1c12f043e2cbe5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001963v1_decoy	LN:2170	M5:2cf0f6c81889758a8dadc195f7928b09	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001964v1_decoy	LN:2167	M5:c20e5ca2be0e106f7d0694f9e67a3ea2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001965v1_decoy	LN:2167	M5:df1f17762d17818e216feee97299c37b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001966v1_decoy	LN:2157	M5:071891675e2ba4476534e0035ef13cef	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001967v1_decoy	LN:2153	M5:59ad2443710d81ac651620a8f216e7c0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001968v1_decoy	LN:2151	M5:2c5f2ad4a6812000584bf131c918c3f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001969v1_decoy	LN:2147	M5:e6458e552c51be648c8cc8ca7c01ac98	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001970v1_decoy	LN:2145	M5:408a6d5ea59519609696b4228f0cbf97	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001971v1_decoy	LN:2142	M5:90b747485a6b12433a92fb55202869fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001972v1_decoy	LN:2142	M5:7de080d8181d8066e63905fc22a7ee14	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001973v1_decoy	LN:2136	M5:b611d1ca78ef211201bfc0b6a68e74df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001974v1_decoy	LN:2130	M5:5f1f983972aaf38be9f2fd9fbcef8a9a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001975v1_decoy	LN:2128	M5:0323f4f5194c96dc1bcb919f06960a20	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001976v1_decoy	LN:2126	M5:c142de1e2c1924e545f116a373abafc1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001977v1_decoy	LN:2126	M5:6ec3293375949e50d082d3f5639ba434	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001978v1_decoy	LN:2119	M5:e1eeff28afd215be837a02bfe59d8294	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001979v1_decoy	LN:2107	M5:eee07feaf8a44d69317e6b46e8eee089	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001980v1_decoy	LN:2091	M5:ea5e9165f2f579567e1addc7de1a7a6c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001981v1_decoy	LN:2087	M5:635626092c6f01e77135d2798172beb8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001982v1_decoy	LN:2086	M5:269d34f32d02129323bbc21d6336cc6f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001983v1_decoy	LN:2083	M5:5aadd7636d45bda287185de4cefac8d9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001984v1_decoy	LN:2075	M5:ae2d128f1ba2ba34942dffebf4b7905f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001985v1_decoy	LN:2075	M5:0f195e7dde4153887f4f0615cbd730e8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001986v1_decoy	LN:2072	M5:b236a0d4a67c91d699b3cdf5adc47a71	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001987v1_decoy	LN:2068	M5:2e34944b2779f309285d9db7a20b69ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001988v1_decoy	LN:2067	M5:233b964d4a2e5bab26b7b996dc46d4b8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001989v1_decoy	LN:2055	M5:795ffd63a0e2d97ac00ca57cdab045eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001990v1_decoy	LN:2051	M5:5e69880a7e6f7bf744cf4b305624a7e7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001991v1_decoy	LN:2050	M5:abba4241716dcac69b95e887f8358859	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001992v1_decoy	LN:2033	M5:096ca0754d9f8f4cf7a582f57c5fc083	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001993v1_decoy	LN:2024	M5:288495a36e0f4b1fc8e90cff6d4734eb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001994v1_decoy	LN:2016	M5:96d95a271cf5d103433921842ead9915	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001995v1_decoy	LN:2011	M5:cb8560d292475a0fd481b0e794ed0186	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001996v1_decoy	LN:2009	M5:a6503ea36c1b69162d3eda87c4f33922	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001997v1_decoy	LN:2003	M5:d3a1bed41244634725882235662d11a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:chrUn_JTFH01001998v1_decoy	LN:2001	M5:35916d4135a2a9db7bc0749955d7161a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:01:01:01	LN:3503	M5:01cd0df602495b044b2c214d69a60aa2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:01:01:02N	LN:3291	M5:743d9f66c77fc21b964a681e0c6de2ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:01:38L	LN:3374	M5:dd27b7fe617e92bb77eea00fede6fd15	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:02	LN:3374	M5:3ba47a11a8a5b47ccb855308e26a2f4a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:03	LN:3503	M5:554d43de8f2a97cae068169fe3d8462e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:04N	LN:3136	M5:072ea3e53c79f3d00e1f1a7b492b0a8f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:09	LN:3105	M5:68176666a98582ea361a9181d69679af	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:11N	LN:3374	M5:b9ad3338cc73e2a99888a36e04c29f75	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:14	LN:3095	M5:0385be87eb49df4c59d7487495e3b1b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:16N	LN:2985	M5:10150ad21301a29f92e1521530fdd3f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*01:20	LN:3105	M5:05dc0384da2f751afe549a9bfdbc3037	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:01:01:01	LN:3517	M5:174a8ac24d2e6625c1e7589219d6fb84	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:01:01:02L	LN:3287	M5:96a6b1f55c41a7da24857ab8844a7a22	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:01:01:03	LN:3023	M5:0ac19a55ed1a22389a2d667c42ba1218	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:01:01:04	LN:3516	M5:f6a0bed71d059f8387d9d22e2b0c46b2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:02:01	LN:2917	M5:a99f213073198aa5a532f950135f6d1d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:03:01	LN:3517	M5:8a795bfd81ee3440e8d0fa3e5d09cd35	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:03:03	LN:3148	M5:6ec792b8a5944a6edb0c1acc18ee1418	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:05:01	LN:3517	M5:dbb2cf4bd26ccd1d7c17327d2cbc119f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:06:01	LN:3517	M5:00a663d257ac9d4d6eabae95f6fb6d8d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:07:01	LN:3517	M5:2833baebca84548dd4e37d79642db779	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:10	LN:3517	M5:61bf8d00643229eaec4eb8def24f1a98	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:251	LN:3517	M5:d39aa010841e51a5fc857e82a3378d96	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:259	LN:2978	M5:fcedee868a44319f80c453cf7b833abc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:264	LN:3002	M5:6cc807b0948af0b655ad0265629b7906	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:265	LN:3148	M5:5e00ac7ffc401cd5f866e17cd6b7d76b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:266	LN:3084	M5:fe25829d3992130e1ca423e98507b843	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:269	LN:3101	M5:724d76a112c0b557ae52e35dcc2973dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:279	LN:3103	M5:0aef01822ccf2bada1e9a2ce8c771711	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:32N	LN:3517	M5:02ae1b32f6268509dbfab828c8339a36	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:376	LN:3104	M5:79dba7660c7fa948d23f2703e80eab7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:43N	LN:3218	M5:68aa8847e8ec55dce252be3812b03bac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:455	LN:3118	M5:6903220f41d0f8754d6cc3ff6fb3fbba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:48	LN:3517	M5:2947ea9bc4c28b64abba44002460a38f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:51	LN:3109	M5:84c0d488e0a5f95cb3587efd6c84b00c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:533	LN:3217	M5:34bc003a99760f4ec928572b3a747094	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:53N	LN:3305	M5:108696b83e605fa59b435cfb8406edf4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:57	LN:3054	M5:bc22083129551a34dbbdfd07e36f763b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:60:01	LN:3112	M5:b58aed6de00585e7f185bf3eb573cb45	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:65	LN:3387	M5:03702f960713a7c42469b033b7ef05ec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:68	LN:3109	M5:74777150832f351162301c7d04a64d48	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:77	LN:3371	M5:9e5ec638d0de688fc20aaf00b74b5a9c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:81	LN:3309	M5:2cbf6e9f368ea4387632204bbdcba76f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:89	LN:3371	M5:782c923ac311a590d29e9e85b6a6b5e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*02:95	LN:3388	M5:36b421cc1baeb1cc37291f98566cc5f9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*03:01:01:01	LN:3502	M5:bc204fec41a0219e8044aae1c5a3a6ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*03:01:01:02N	LN:3373	M5:c9d431f34db1cf123c6dec89ae7075f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*03:01:01:03	LN:3094	M5:4744e9f0617b3715ed23779866c2e1ba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*03:02:01	LN:3502	M5:d54cdfb5d7a25804bc3b5a3711d1e42c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*03:11N	LN:3404	M5:fb87c0184303005cf961e7e6bc65a3f5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*03:21N	LN:3095	M5:665152840dba04b1bdbfefaf3d4913ac	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*03:36N	LN:3142	M5:c5889d985a6d5ac0f86ee9a5f1449762	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:01:01	LN:3503	M5:1b32d51d3415a99c68971d21b686744a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:01:18	LN:3503	M5:3283d7a24c7ad61f9024a8f7d76d5bd6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:02:01	LN:3503	M5:fd13f748ca0c574e318250f8dc0f147e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:05	LN:3373	M5:78f70065b11cbfb3f502af9802ae3b7d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:110	LN:2903	M5:ca7ce57dc961032a37af87fc26cb626e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:25	LN:3073	M5:e1ba0819b77d173c0a9c6697f76f3e50	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:50Q	LN:3362	M5:ec1d5f53ad6427e623c41a11393bc518	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:60	LN:3241	M5:6815ddd990a7231bc8dc40a414cba309	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:69N	LN:3500	M5:dd8ce51ba7bb514b56ffcb5d7566dcae	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:74	LN:3227	M5:057f5c85ad1f09e82b0f04bbc54f9283	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:75	LN:3184	M5:9975bcb416ee87f54025f71692bbc1ce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*11:77	LN:3233	M5:615353e3ceac5a04cb381339a800ad9a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*23:01:01	LN:3502	M5:edf8a55a69faad1aab25516e1126b0c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*23:09	LN:3104	M5:fbcac94109d55d95b94b869fd6e42705	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*23:38N	LN:3020	M5:83381147ae6889a0af532bcb7af83e6a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:02:01:01	LN:3502	M5:95495e041aa53313d12032c49baa1b1e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:02:01:02L	LN:3502	M5:d91ba7d36f6472faec4c54d1f476c9f8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:02:01:03	LN:3075	M5:a89ed5d11db1d882965e052a6a049217	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:02:03Q	LN:3247	M5:d55685eded22f07791df08b502ad3872	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:02:10	LN:3356	M5:739b4ee3c4a555c2b699fa358ad07744	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:03:01	LN:3502	M5:d866111fbc6e2ea2cf086915b28442b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:07:01	LN:3502	M5:872c7be9ec525309cd91d949580a87e8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:08	LN:3502	M5:f0bbd52535d5ef86e21c4486e1761207	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:09N	LN:3502	M5:9d122834f5117a876ff9ef768a61672e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:10:01	LN:3502	M5:035534e6b4f7a7b2b20506a41290b8de	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:11N	LN:3503	M5:bb7085dbbd00c565896a17505dbd06c5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:152	LN:3176	M5:6d81297ebe64b08f9ec9e8adedcde902	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:20	LN:3502	M5:eb4b55e730512095c889a1c36a7fb51d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:215	LN:3116	M5:f6c6ec83d1c70ef4bdc483abf45a141c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:61	LN:3043	M5:8ae770b761bfdf718a8cf382b54fc71a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*24:86N	LN:3415	M5:0e1108b26db8b22f177b460c8a34c017	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*25:01:01	LN:2917	M5:2e22cd0725822e29d3f0df6844339714	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*26:01:01	LN:3517	M5:51cabb4c3149d169568609c1906d969a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*26:11N	LN:3091	M5:112419eeaa846213785eadd7380308a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*26:15	LN:3217	M5:2a2c8f5ba64eb0110f2de0d8b74a5d98	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*26:50	LN:3141	M5:9a1a6cdedaef2a3c66ca98f77622fe50	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*29:01:01:01	LN:3518	M5:6a6e4c826d8743d5f327d8906a311270	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*29:01:01:02N	LN:3303	M5:497a11cff2fde28a5c500d529581c57b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*29:02:01:01	LN:3518	M5:77d1ca0d5ea97ccf052d85d9515117ed	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*29:02:01:02	LN:3518	M5:53bad80334b21427430686d44dbda04d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*29:46	LN:3310	M5:b4635ec707263c634b27769afb46323a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*30:01:01	LN:3503	M5:c6b537ed485b72a6b78cf527493d8ca4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*30:02:01:01	LN:2903	M5:65d618ee20ba439ef5ae408a182e25df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*30:02:01:02	LN:3374	M5:4031b0ca00a39d4d076dcdc2808f590d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*30:04:01	LN:3503	M5:21f4d62eb6e85f6257661e4c94b68aa4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*30:89	LN:2903	M5:694bc9c1c804f437646697ba9d968bc5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*31:01:02	LN:3518	M5:6e24e36ceae5a9c0dfa1cbe4520b4425	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*31:01:23	LN:2918	M5:61060b6e397e85fd905668b5876d8c50	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*31:04	LN:2918	M5:2d4a59604c2d3d795f3647a186685ad9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*31:14N	LN:3090	M5:afc943d7553ef55e21a855f5e266c8a8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*31:46	LN:3075	M5:ae87be36c211dbf040022ade7713d2c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*32:01:01	LN:3518	M5:d3a7f1fb642659538a431ee2c1d8113e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*32:06	LN:3389	M5:06c6aff700dd7ddd935fd83f2def16e9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*33:01:01	LN:3518	M5:f1f4a4e1fd2e774e4003c4f94c67b36a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*33:03:01	LN:3518	M5:4e7abd41072e8f3c62c49c683497d39c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*33:07	LN:3389	M5:4ed7b17c57b32199660f285b9e53bdd8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*34:01:01	LN:3517	M5:c79f20a6bd41e2e41b6e067222b4af42	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*34:02:01	LN:3096	M5:a3a26d9b6292599851c207c193d92b23	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*36:01	LN:2903	M5:a923a3fb762fa22c7956888b6634dbcf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*43:01	LN:3388	M5:a5e6a04ac5537f379e03956d57cefe3d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*66:01:01	LN:3517	M5:787d6cacbda41669a942dc4b54c4f7e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*66:17	LN:3075	M5:5f0734606934302fccb508a2f5d3b915	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:01:01:01	LN:2930	M5:93bb5b64ccd0bab2bc0478d6bd0e8854	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:01:01:02	LN:3517	M5:957d09385dbaaadcf87f85227a2a43d2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:01:02:01	LN:3517	M5:0e43acd52311b6485d4542edf7c6d286	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:01:02:02	LN:3388	M5:fbfbf3067287661249f797a0701cbb58	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:02:01:01	LN:3517	M5:21b71bd572d6dda388a4d60211edba0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:02:01:02	LN:3506	M5:00fd36e8b22143b0adfbe025e2d5d2b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:02:01:03	LN:2909	M5:df913a8914cc697da83538a7b8e1898e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:02:02	LN:2916	M5:a34e21e7b4de5c05f67281bf68bdeb66	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:03:01	LN:2917	M5:9eaaf636f6b7bcb8557a2b843eda3b60	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:08:01	LN:3120	M5:c2e72d05d212b232f180c5020ad652ba	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:113	LN:3070	M5:474b432629b8d4cc0486021e71e3dabd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:17	LN:3134	M5:f44b78e8df335a94b8ba2ee62214ed82	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:18N	LN:3237	M5:250389f8d56a86c0037d9e10ce88aad4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:22	LN:3119	M5:5a8b2633f1fb32860f4d5df30e8677ca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*68:71	LN:3198	M5:dd6320e01a52a1aaa9224cd4c39807e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*69:01	LN:2917	M5:02bd84b3d7b9d16ec8546efc41b4d0c5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*74:01	LN:2918	M5:948aa5c51d96d4ecbe3fc862f0214a3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*74:02:01:01	LN:2918	M5:4b972360085a8e764c52f0a30ff47673	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*74:02:01:02	LN:3518	M5:97a7f1d63575aaadaff78b53c7bdd231	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*80:01:01:01	LN:3263	M5:5405ef04524037ea84ce1fc83dc9ac20	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-A*80:01:01:02	LN:3055	M5:5cc77fd13bd6123b7300d6da19ae5c13	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:02:01	LN:3323	M5:5eba87e3d51a0b86a498f97022e5714a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:05:01	LN:2676	M5:d41a7c05ac284e89b86b658d33564b3d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:06	LN:2676	M5:a5d7749f86004926ffe9fc104b1e99c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:156	LN:2967	M5:8cc8227691836b87823ff2228f9b25a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:33:01	LN:3239	M5:6ab184ee1fa9167f8857a4d6a7b33da6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:41	LN:3266	M5:9b52773dd0c042b641ea254944e932d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:44	LN:3270	M5:03ee83997251cdeeec6269f547238122	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*07:50	LN:3323	M5:e369192a36b773e819b37507a823343d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:01:01	LN:3322	M5:4ed3fc74f9934e922cc8345b00459784	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:08N	LN:3035	M5:3d8eb010a8cb9c3da8d4eb759dee63f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:132	LN:2675	M5:a863b21bd08f28404b8b991486beec56	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:134	LN:2959	M5:cd3c81892d9127631465bd4454169e3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:19N	LN:3322	M5:c64401d837f2f4eb51a6f89375d02401	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:20	LN:3322	M5:87e42f5c7d6c6b2f1990fb2477271f14	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:33	LN:3322	M5:704bdddcfc1c52e4181d4c12a4e25e54	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*08:79	LN:2676	M5:f08c9b4724eaaedae63d87b79af851de	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*13:01:01	LN:3324	M5:6a8fa9ecf6d7b7a57c77b21c908740b0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*13:02:01	LN:3324	M5:120d59fa894b11fe23dce75e3f4869f2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*13:02:03	LN:3323	M5:d52345523e7897e545fffd4718dcccf4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*13:02:09	LN:2919	M5:ef118f2b15e542e80c1b9c162ad69345	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*13:08	LN:3324	M5:11f30cc59a8a4b6d4b43144c294440c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*13:15	LN:3323	M5:0684fd43ee5428bc529561b33db2f2d0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*13:25	LN:2689	M5:dbbc5af54a1289ade5eb273e2f7aee7e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*14:01:01	LN:3312	M5:3764a48b755f8e31055b0e861e4c74e3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*14:02:01	LN:3312	M5:26b567e4c01ece594ca1d0f0b18ae0c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*14:07N	LN:3255	M5:74dd725f56e8dad2652028bd0b496125	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:01:01:01	LN:3336	M5:b00240fd0143d1f67ee96b53a30adcfa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:01:01:02N	LN:1208	M5:1c5acd964349055939ac8654093dde0b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:01:01:03	LN:3026	M5:dcd416dc1f3d5d91d7374096d09a68ec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:02:01	LN:3335	M5:25973b11c58535f98da0dae1d36e1ce7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:03:01	LN:2689	M5:bc488eabb3f7519b04b6a795acdf81c8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:04:01	LN:3052	M5:6ccb4f7a3eeb9e8ed44236b5092c2bd9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:07:01	LN:3336	M5:7630abd7e06b6d17b3542a0efdb6c780	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:108	LN:3283	M5:80b9c94caa804a2bd7f2447b9d24cf82	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:10:01	LN:2689	M5:c0699fd2bce33c66fbad3066177f17db	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:11:01	LN:3336	M5:c3971913c6e6b41e2f1bbb56026c60b0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:13:01	LN:2688	M5:a5d9251e2d32c20001b7845134141a39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:16:01	LN:2688	M5:fc7d48526274847fbb255137159d9d47	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:17:01:01	LN:3051	M5:fbfa24d81ff319e1c9a77eb23a5c5af6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:17:01:02	LN:3051	M5:547e0689ef02b1b497deaa785f374c32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:18:01	LN:3336	M5:79c954404a5e1b10f46264fbb3c6b32a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:220	LN:2878	M5:a87213c0fe840a0cac742fc92c4a203c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:25:01	LN:3335	M5:316c1666b4ee7ffb47f4922157d121c1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:27:01	LN:2689	M5:e01a2e586f79a078cc425bfca6367182	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:32:01	LN:3336	M5:4411f20a66f0e08032144115799b7530	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:42	LN:3333	M5:e6b197d6c9397d8de0ea8de14a814b05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:58	LN:3336	M5:1c0d71c98a79449eabd99e163692bd6c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:66	LN:2902	M5:a5186448b35a7b3923ccdae5bdf4bd8c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:77	LN:3336	M5:a4984835f8285fd5518e523394749864	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*15:83	LN:3337	M5:322d07dc63950f70a35cd4a6cb9ba2ab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*18:01:01:01	LN:3323	M5:b0017c6a0823ba043caa28c260a41b12	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*18:01:01:02	LN:3323	M5:a51373cbff28c2af5ebec8fac8e33cca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*18:02	LN:2686	M5:ba01be9495db45e331f731023378e599	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*18:03	LN:3323	M5:207b298dc49c700b8a16865a72eb7c7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*18:17N	LN:2979	M5:01b001b48d8d89f7671231f8cd45ca05	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*18:26	LN:3323	M5:655b4f8cf9b575997c39e45df3664c8e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*18:94N	LN:2970	M5:67c613fbd0339031dc79fc91e294348a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:04:01	LN:3325	M5:4380eeb25545f28b8d6a8bf602e7c2f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:05:02	LN:3325	M5:f60437ab7a86bf431ed0854fd2641cdf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:05:18	LN:3321	M5:ff2e5f34be64b46f1e15d1091ea54645	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:06	LN:3325	M5:4c3f65501973406722a9c66c6f129061	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:07:01	LN:2677	M5:61c1b2092f60d8b21a413b8e6846c58d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:131	LN:3325	M5:08dcdc60c6c29f52d100af9900b30e39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:24	LN:2677	M5:c0e3b858ba702a5959d35e51b8b75406	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:25	LN:2677	M5:f1a1a745dc082e0c0a91813d3f12e52d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*27:32	LN:3325	M5:ef9b650861b7081940788ef1618a074c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:01:01:01	LN:3327	M5:72eabdc1286e5f8faec021e4c3fbd212	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:01:01:02	LN:3327	M5:8d6dd73094fd1458c95866fab0bccfb3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:01:22	LN:2806	M5:198a61b3d4b83cfed1fa018f0b5313e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:02:01	LN:3327	M5:69e50f2988b92d745c93ebc9877eace7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:03:01	LN:2689	M5:866f05a4324734d3cca067f98354488e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:05:01	LN:2690	M5:c6cc89ecf3130ee79cefb981dd362f0c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:08:01	LN:2689	M5:6baeeca7110354530934af4af0cccd8f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:14:02	LN:3327	M5:99db27c20c358808c9e75b090eb54d06	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:241	LN:3042	M5:9fd1849b96ef49c7b705acfdfb430e8f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*35:41	LN:3327	M5:8526562f5800fb5180e418bdf4b6e56b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*37:01:01	LN:3324	M5:8e4396d6b7c04761713fc800437312bf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*37:01:05	LN:2687	M5:c4312bfb5ca6f84d1c4b2c444107b844	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*38:01:01	LN:3312	M5:205bcc2884f405305b551c58c25d7232	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*38:02:01	LN:3312	M5:501fd25edfcd87eeda45de0caa78e1de	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*38:14	LN:2738	M5:7639a6e735e55ac574403a7970e113b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:01:01:01	LN:3155	M5:eee292da1356cc9c3bf1b333e89661d6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:01:01:02L	LN:3153	M5:cd343572a20faec9ea375660b4b08feb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:01:01:03	LN:3312	M5:e3fff974f234f099f66e0fe53a93ef2c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:01:03	LN:3155	M5:2e520e3148dcdf7d8fc7763872d61957	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:01:16	LN:3155	M5:cb333cf3f06cf66b86f11654c941690f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:01:21	LN:3312	M5:6e1fb83beab576ba8c39ff0237d40277	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:05:01	LN:2675	M5:bf2d7c62a16bf00c2559565daeb0538d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:06:02	LN:2674	M5:77758f231bef5ff95e5a4be58d38dde1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:10:01	LN:3027	M5:fb13d6eeb084ecb4d241e45485ef36e8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:13:02	LN:3255	M5:5836ea0fc7935bd208b6caa597934b98	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:14	LN:2765	M5:76c31f2b103685de65a25008bf484f11	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:34	LN:3254	M5:840ee3b914f83a21f98cde71f89d77d6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*39:38Q	LN:2675	M5:55571273ba2d1a50d1f87b47ae59d9aa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:01:01	LN:2676	M5:afc20b1efd5b1b479db2e62fb8b88337	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:01:02	LN:3323	M5:e80885c2e036b557e2bd1ca6c2b6667f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:02:01	LN:3258	M5:e6e0e85a0fab0b1e17686742e0ace0e4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:03	LN:2677	M5:a4f89215e2d83f162c338ac822bfb46e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:06:01:01	LN:3325	M5:9a238e4bba71b906acf8c46254a9bc31	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:06:01:02	LN:3299	M5:ee4804e6a27f57a5c37e372dc6daa312	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:10:01	LN:3304	M5:5d4db1b120369dcee6c52764f69bfb3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:150	LN:2800	M5:f889007857633aee1ffcdf1fc924ca96	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:40	LN:2677	M5:549008522cb77878ea5c2cf5bd048064	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:72:01	LN:3283	M5:7d61179ccd5e3f1fe4b4976456960d02	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*40:79	LN:3257	M5:521e3a50ed37f445b431b465b0d4ed77	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*41:01:01	LN:3322	M5:17390ad33a3efae3617d3a175671902c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*41:02:01	LN:3322	M5:c886279897cd7e75a357ac3218a1be5f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*42:01:01	LN:3322	M5:154e1df41ca09b47ebd7e365545f6e6d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*42:02	LN:2675	M5:59d27bea1d07ea5695101e714f65812c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*42:08	LN:3165	M5:d860761be3a99c6724146e606a28aac9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:02:01:01	LN:3323	M5:477ac3a92e88828aa579f38ac0fc39d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:02:01:02S	LN:3152	M5:05fc8de1a02c971099db853c790d3fca	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:02:01:03	LN:3152	M5:2202501e60f1d3e547cfe4e814c7f877	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:02:17	LN:3323	M5:3af3bf43df87b594bc20bc5f791785b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:02:27	LN:2872	M5:6ca96787a367bd1ce0838f941140cb81	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:03:01	LN:3323	M5:83f22de8d085ea321aad42dbf25a571a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:03:02	LN:2676	M5:9fcac4fbbe8fd92d125550cd06db12c1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:04	LN:3239	M5:9b24c6a9a01dea4a6bcdb76824470e3e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:09	LN:3317	M5:5ed7833ec37da80387b4a86c6b2a2040	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:138Q	LN:3043	M5:1088ef8207c18405bc0b180f0226dab0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:150	LN:2676	M5:0290d7c3b24a19eefc6a89bc41146c39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:23N	LN:3323	M5:f1ec2e8fa319def50d20ce89e0b80d5a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:26	LN:2804	M5:174005655892f2cff1ad41bb64927506	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:46	LN:3323	M5:4b352ce812b6c8a65a2e45741d805d7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:49	LN:3039	M5:cb75887e3f845944c90cdf5315369b16	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*44:56N	LN:2676	M5:4da8a161653ca5951070a765b2070b3f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*45:01:01	LN:3338	M5:86f5f0263cbccdf31fc646079fce98d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*45:04	LN:3339	M5:bba751b5e3727ad2af0a8cb343a94d57	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*46:01:01	LN:3336	M5:7ab2f1273efeb3a770ca80b5d0d078b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*46:01:05	LN:2891	M5:314e19fc403d8ea017669e53723aead0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*47:01:01:01	LN:3041	M5:3107f208d002db7e36cf098ebbb8516c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*47:01:01:02	LN:3041	M5:9f6a5f1290f5f00afcc6b1e732a37b14	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*48:01:01	LN:3323	M5:105f81689cb818d76fe1effd3d150157	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*48:03:01	LN:2676	M5:874fcca35339a027ede1021bb682c5b9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*48:04	LN:2676	M5:77accce2b51d36c34cfae7d7f77a0644	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*48:08	LN:3323	M5:f6f1a40b586aa5025bb2ed56a890ac8c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*49:01:01	LN:3340	M5:7da4db3c2933e38871dde7de2cdf0131	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*49:32	LN:3340	M5:1a762b6501a216624feb498212c99a07	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*50:01:01	LN:3340	M5:9d8a8957807527e6413e745a8fd4e068	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*51:01:01	LN:3327	M5:263006da7f87d352df017a5efcc6a2ad	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*51:01:02	LN:3043	M5:d0a5d20ecc047c9db286860c217ffe57	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*51:02:01	LN:3327	M5:0f09e1d79fda822bb499e29d59e7dfb0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*51:07:01	LN:3327	M5:63b4b6ba9c4049e98e44399a1b1ad03c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*51:42	LN:2962	M5:8253b5b1e485378dfeedfa598e677579	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*52:01:01:01	LN:3327	M5:bb94101c60541202c4b844e21b640a92	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*52:01:01:02	LN:3327	M5:ff0ebc333c63692ac07e7b95c6febbd0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*52:01:01:03	LN:3327	M5:9e6abe5b1d3205aed3a8b62d580f5c6c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*52:01:02	LN:3327	M5:d7fde559163710e8a22f5497902dee7b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*53:01:01	LN:3327	M5:0e08f9e5e5ee052f077c388fe43ed672	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*53:11	LN:3274	M5:9d84a07be4be471551bc6c8cd89ddfa0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*54:01:01	LN:3332	M5:7621d4b27eef76b4b57df91eee3bd38c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*54:18	LN:2813	M5:ecf8408d4379ee7e2467c784e51ea2bb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*55:01:01	LN:3332	M5:b19860ce7d3e3feec3da15d850ffaf83	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*55:01:03	LN:3332	M5:17fe5fcacdc35ec18448d04e206578e2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*55:02:01	LN:3333	M5:fe9cf4bfff80e738fa573a1e4336621c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*55:12	LN:3332	M5:570fdcabb0ff55d30de3a319b09b2da2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*55:24	LN:3332	M5:0194f66b5128ba6d3eb9fec43ee985c7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*55:48	LN:2980	M5:b8cd7ebdabaea8025fe0b0308b1c500f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*56:01:01	LN:2688	M5:8ea679a7f814ff4b104970fc3363591c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*56:03	LN:2688	M5:13a5b854a9c6cf607e0758dd8977a136	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*56:04	LN:2688	M5:52674e8d83e65bf23b0b36f2cee3b279	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*57:01:01	LN:3337	M5:435c90dcaa816e70a0a07c23d2f363b7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*57:03:01	LN:2689	M5:b412ccacf520ef015be9010e88d13fd6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*57:06	LN:3284	M5:14711544ed455ec1aa9a55bae251514e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*57:11	LN:3306	M5:66b4e723563c1e4a79cc9233cbc2d5fb	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*57:29	LN:3337	M5:ae6a6681ba3a2ed0efeceafc6ac41fb7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*58:01:01	LN:3336	M5:89112836a876c731a21d3e2357e297d6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*58:31N	LN:3004	M5:8507d0acf3a65b125d7ff5bd6c4d1e8b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*59:01:01:01	LN:3333	M5:23fda5090f014267db805d001c7c3add	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*59:01:01:02	LN:3332	M5:c4602c638fb61927261e08d529f2898f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*67:01:01	LN:3312	M5:87814da89393ae312125f9b36af8bb77	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*67:01:02	LN:2675	M5:390a5500664173ba6708dbeed0e360dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*67:02	LN:3307	M5:ca5872a8e8c8fe4b920ba96e1542cf58	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*73:01	LN:3323	M5:0136d8cfbbe9fd393a1e699753f7f7a3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*78:01:01	LN:3327	M5:81fbcef3edbbc1e8df879a12d817a9b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*81:01	LN:2676	M5:06b880357cb8d04e7715100462e6e58d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-B*82:02:01	LN:3050	M5:7f0f011b72e32064bdeab6fc9d15df0f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:02:01	LN:3349	M5:0071e65ee429afd318ef699ad315c4b4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:02:11	LN:3057	M5:b9f8c9b73140b44e888ca0d3cb97a51a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:02:29	LN:3349	M5:daaad7b0fa23883b6f6a74c29b218154	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:02:30	LN:3333	M5:f72ada7c617959035065509827004c55	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:03	LN:3349	M5:1dfba36de6a84343e0f1bc21f4290dd1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:06	LN:2895	M5:707a109a70808774faabaa9f20fc9c2d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:08	LN:3349	M5:d84d29f8412f7bc25c6faa02ce1e8027	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:14	LN:2895	M5:6184a7ce778825a8d3dbbdca08425352	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:21	LN:2895	M5:7c3c33a8a09cf7ab14dfb252dbb028be	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:30	LN:3349	M5:e7dc7b0b79ca3fba89e46935c2f6f53a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*01:40	LN:2968	M5:1f1ff8df1d52ca176768c131fa0dfd1b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:02:02:01	LN:3347	M5:7d432e207af5901819172d943367ab85	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:02:02:02	LN:3347	M5:3b927e5396f09d7b73cebc3cf7894022	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:10	LN:2893	M5:bc3caf3cb6c08beee025921ea8ab2c2b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:11	LN:3320	M5:86a83cd46a667da7f75c104e6964997a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:16:02	LN:3029	M5:117c55e59cdf735f8e4600c677295e86	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:69	LN:2933	M5:8fb20dc7ab2383635eb05c7b6aa75585	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:85	LN:3347	M5:19bc16298211d1df9285935c0e74349e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:86	LN:3347	M5:1a839f0d783dd916f4c4d85314fb33d3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*02:87	LN:3064	M5:efb30bed21ab99dd6db7b5aec573702f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:02:01	LN:2894	M5:df3f967e88fe534c02bfad024b8c887a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:02:02:01	LN:3348	M5:7ca03d45f7f1fd27eac518520148daa3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:02:02:02	LN:2896	M5:6d6e1775bedec2a59fa4d0bd7c94f4c5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:02:02:03	LN:3348	M5:22fe2d580ec4460d1b085eba87d9aac0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:03:01	LN:3348	M5:4e9e631972020eda52a012a3bcce4cd5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:04:01:01	LN:3348	M5:df0eaa78940580a0f21395f9387cc32d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:04:01:02	LN:3348	M5:d13c9657f578e20631d54771581b5204	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:04:02	LN:2877	M5:be42038dd5348757a9c683918b1db4f0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:04:04	LN:2966	M5:deeefe05be47eaf45bb483add4913ffc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:05	LN:2894	M5:bb0c05e7fd6c15d9d6593a4f3bbe783f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:06	LN:2894	M5:21c18b0c0ff10700610d7f1a50b1c899	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:100	LN:3034	M5:99e13ee46eceaa60fe5084f320894a2d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:13:01	LN:3065	M5:3981907aafcbb510b01423d7f323477c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:20N	LN:3321	M5:b3a7cb20db02d1256c2106d420e765fa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:219	LN:3070	M5:2f9e694079fd1378d796e05baa51889c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:261	LN:3348	M5:3248cc886e5d3793ba099f0ab1a05d66	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:40:01	LN:2894	M5:93c62f86d2dfc6633dbd2c975908da1a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:41:02	LN:3328	M5:f5752e34d19b00f37d306621c38909a2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:46	LN:2997	M5:0ea8327e0b67ad6f90e5a44c1629c7d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*03:61	LN:2894	M5:6d712f749acb251535e2ae8c3c617413	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:01:01:01	LN:3349	M5:3efce3936c70251730ad6b287f7d110e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:01:01:02	LN:3349	M5:5d4e1f36ad16f12cbf6447e60f24081c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:01:01:03	LN:3349	M5:9e9f6956c08e23d56266b6fa217efd7c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:01:01:04	LN:3012	M5:2579591d3a321b72379ecd8a51d7edd7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:01:01:05	LN:2931	M5:64ad58c15cabe00bc7528c32341c0878	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:01:62	LN:3329	M5:43792d77155a7b8f48cd4c57e217997e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:03:01	LN:3349	M5:0ccb8d21235af6c2aff22aa6afbc6732	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:06	LN:3349	M5:63b57fd97300edc439359a50449974db	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:09N	LN:2991	M5:0fbbbf7cb8fddeb130cf9e967404f973	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:128	LN:3086	M5:e6d5cc6672b9d7e2050ce659e5ed35b6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:161	LN:3237	M5:5bf40c2edbc86b4e13300af3d685dc1b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:177	LN:3349	M5:8547dcf17572b7586eec8ec28cbb8792	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:70	LN:3058	M5:5f1c7d679cd5c3f3110db5fe628cd613	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*04:71	LN:3086	M5:02b46fcce463bf80c626c51f5d36bab3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*05:01:01:01	LN:3349	M5:c6d922fe90d58a4380b338ce33a098db	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*05:01:01:02	LN:3349	M5:a7b54d490750d2723ab72f5eab4de589	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*05:08	LN:3059	M5:1560938f348bbf8027a77fe08ce4b46f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*05:09:01	LN:3322	M5:bb8835a101a1bd226ba1cf04e30c8298	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*05:93	LN:2946	M5:8163cb61a36ebacb034b44d4537e3ccd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*06:02:01:01	LN:3349	M5:e2d2d51306ffa6a15072abc9e218afa3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*06:02:01:02	LN:3349	M5:289ade2a84e2a669f4950d905de18ef3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*06:02:01:03	LN:3349	M5:541d1cf5b93596d04882fdcea98fdb24	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*06:23	LN:3349	M5:f90da72a0371a17e345090ee35ced67e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*06:24	LN:3349	M5:8416842ec1691954a14211e9b178951b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*06:46N	LN:2987	M5:1276d9ecb257086ba85fb1dff231b2d1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:01:01:01	LN:3354	M5:718bc83515052da25d2aa2cf1017aa8d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:01:01:02	LN:3093	M5:e45eed48ec341cc12ae10b917381d885	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:01:02	LN:3352	M5:d7dd73d1eb5b9a25c83e84ef950dd44b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:01:19	LN:3354	M5:db13dc42d8ac6f58daa4d04dd21e0296	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:01:27	LN:3195	M5:53fc59605c057f246aa7cb06caa3523c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:01:45	LN:3354	M5:7b104b85dc1b908764ff4904a903c90a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:01:01	LN:3354	M5:00b5a7cce8e5acc98b508e4d39091f15	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:01:02	LN:3074	M5:152f1c93813d70470aa3a116478c5a69	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:01:03	LN:3354	M5:b854cfa857b40775c2ad6e6ded4b848a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:01:04	LN:3353	M5:7de039797ea7911c70f4fa82c658366e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:01:05	LN:3354	M5:00709b8f2f15aa3aa482a992d1d87b60	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:05	LN:2903	M5:c7cbc76d1fb0114a55ee635afdb0cd15	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:06	LN:3354	M5:1d0e73f11030eece15f033cab7216c51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:02:64	LN:3354	M5:7f780958705ae801a5814f2471cb59f4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:04:01	LN:3354	M5:7aa1a4c1a413aca4e232a2e7dce8ee4d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:04:02	LN:3343	M5:b44a66a5ff9ba711c465dc629d4336e9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:06	LN:3354	M5:3ac9135bdf1975f31d5f501cb5b62c98	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:149	LN:3098	M5:df315cb1e89fca70587836e750b11737	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:18	LN:3353	M5:fa6f988acdf9509ba3790814e29ef79c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:19	LN:3222	M5:2597c84fe3afb1831211a4c9ad6427ec	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:26	LN:3069	M5:705cb7c1e6112114a894aab34b391fdf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:30	LN:2903	M5:e5947b700176aabf378cf29e78c17084	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:32N	LN:3334	M5:fe7d565923067a8248624f41f45c79df	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:384	LN:3349	M5:90a8a5267a890ccd78717e88de59232d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:385	LN:3354	M5:20b5d8a093d1e81d1e6b9e56b6d4ad17	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:386	LN:3183	M5:b5524ee2cc10b5a45e99af42e190f5f3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:391	LN:3354	M5:de98c716203e1ca551130af6affe2199	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:392	LN:3354	M5:1a509719976de84a60b59343364e4b51	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:49	LN:2935	M5:45a4d818fffa2d2428658489af9e98b1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:56:02	LN:3354	M5:e4c99b9226de6adbf587934d835048d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:66	LN:3354	M5:a822c754dee47e720af532f5f5bb1ef4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*07:67	LN:3354	M5:2ba41a6538775c77f84b648069196d70	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:01:01	LN:3349	M5:96d5d92a1f9a605bb014f058b767ecfd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:01:03	LN:2998	M5:585c1deb75a38ddadc48575546be3772	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:02:01:01	LN:3349	M5:734e931f1481380f2d0bf98c7925ee2f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:02:01:02	LN:3349	M5:8f2c108d077649a22ae5df5fb42fe265	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:03:01	LN:3349	M5:633f446c1fba5006f49dd2bbddb3ce5e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:04:01	LN:2895	M5:0d4f700e3c6bb58e12ab10c1c85f1bcc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:112	LN:3178	M5:ad581d3ae2ddf7d3895c8bda459221c3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:20	LN:3349	M5:de321b1690b9ce4e07c6f6f1c838ba7c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:21	LN:3349	M5:574d8b3a969397fe0d6168a851acac10	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:22	LN:3349	M5:c4fc4ff7544492d91fc221e274b790a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:24	LN:2895	M5:9cc0d743f4c6cea3a61dd94cf81e8782	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:27	LN:3349	M5:3ab94e3b0cb8b613e8cc644c6dc715d4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:36N	LN:3097	M5:5e4997d79367c75ea3301d1222f70938	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:40	LN:2978	M5:e8013eaab611499b1827191279b34223	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:41	LN:3019	M5:bf7ecc6786f26c3740e9291e7fdd990e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*08:62	LN:3086	M5:a3f951c6e67ba7b5d43b4678504ceb8f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:02:02	LN:3349	M5:6f12358794b5c624b6948b27722c0d4d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:03:01:01	LN:3349	M5:a5f9f1324e2a617a08c5bcbc275608b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:03:01:02	LN:3348	M5:ff3c56a68534ef6adbf0622ea691498c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:08	LN:3066	M5:5800471074ab27c8bea70d68c5e225d7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:13	LN:3058	M5:807b94f9d89314085415b5578b24a778	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:19	LN:3349	M5:3f11cc62c9ed887231ac88ad834d72c9	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:22	LN:2895	M5:9ba9eb10b465c567357944d23d28cb83	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*12:99	LN:3349	M5:6bc65113a76be4e417061df97ec9323e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*14:02:01	LN:3349	M5:8707b7806173ec4a4c61b1d405f1aae3	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*14:03	LN:3349	M5:833afc09e1ba23f97925580cbd67b077	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*14:21N	LN:3099	M5:360ab26c5e5b147d6195bcdff0c92871	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*14:23	LN:2976	M5:e5e65cbe62521c667b3ed587aaa762e0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*15:02:01	LN:3349	M5:95c60c535112b121a9e6ee900399d619	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*15:05:01	LN:3349	M5:d59cc60db3e774256fafc8cb4e13702e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*15:05:02	LN:3349	M5:e4ecf0c60d3ee668e494d70c54964c29	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*15:13	LN:2895	M5:a7312985b9c4182c9232eb0ffdc57ed0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*15:16	LN:3066	M5:35043b5832829f2204f9418cc925e19b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*15:17	LN:3349	M5:82cd4aaf3336e9d3414b28f0d7286e9b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*15:96Q	LN:3349	M5:42133cdaef4b18738bc26fa5695f8f65	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*16:01:01	LN:3349	M5:0c9b3216f1f00e1a3201ea90fb49bd61	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*16:02:01	LN:2895	M5:cf1da0837be9b9302b0fb7158fc5396d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*16:04:01	LN:3349	M5:aefc6289675459afe38397002b7451c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*17:01:01:01	LN:3368	M5:aafe636c5bfce4449d6eed73eefa3a9f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*17:01:01:02	LN:3368	M5:d3cbf8067c1957eaeb80c6a399477245	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*17:01:01:03	LN:3368	M5:f2cc1e59a91a4f102f9ab5fdf4d3c1ff	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*17:03	LN:3197	M5:a94688722b11045bbf7ef13dfc7d34a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-C*18:01	LN:3346	M5:d53dd9ee731f0437bbbffc584867b0b5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:01:02	LN:6489	M5:d0d728fb8e62a0b0366517669b0e4164	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:02:01:01	LN:6484	M5:823632b556203973124fe9c35cb13a3b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:02:01:02	LN:6485	M5:6d2b0b5b4de67207756f9a9ca9132232	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:02:01:03	LN:6485	M5:df8eab835a0677224be043db0196865c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:02:01:04	LN:6492	M5:1e79553d8e925c6243368db955220c7d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:03:01:01	LN:6485	M5:705ec2d75d9d349a7e4d1b2df73073d7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:03:01:02	LN:6492	M5:dc4b199889931d13d1522358a9a01f3c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:04:01:01	LN:6484	M5:f9a28fc80725b04a807c1a7fa37786bf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:04:01:02	LN:6485	M5:da201e2fb04103e9cfa1eaecab78b098	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:05:01	LN:6485	M5:a13023aaec38d48c163c5fe5996596d8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:07	LN:5959	M5:1af58658f072dc6319086af52c3d5f6f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:10	LN:5790	M5:52685ee8463a30a3909841a38e4b9d8b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*01:11	LN:5926	M5:18894dd38987f5ffd32b9896a4a7f732	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*02:01	LN:6403	M5:14bb0fb46e443150199a75018f001115	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*03:01:01	LN:6437	M5:75b42b5c4fb93885ab4fdb6a312d690f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*03:02	LN:6437	M5:caaf9e4318294ebd0c262db0018d88fa	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*03:03:01	LN:6437	M5:c0908bb87356f6cad982be1acb618dcc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*04:01:02:01	LN:5853	M5:dc7c3223c9df7e828a1c8f22c4cc89c4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*04:01:02:02	LN:5666	M5:6548c257283705fae841fe89148efc1f	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*04:02	LN:6210	M5:6d9b8e4e332e7e398b831c81a6179e76	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*05:01:01:01	LN:5806	M5:72dbcba71cbed79962e1fcb9efa94824	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*05:01:01:02	LN:6529	M5:b129bfcbf4b80c10ffab12eb652ba5a1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*05:03	LN:6121	M5:38e52c5a505ee662100c0789cfe884a7	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*05:05:01:01	LN:6593	M5:f4020b6d26ac50eed22026f28371f610	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*05:05:01:02	LN:6597	M5:456ddd5aaccb336023a80f2ae5abbbdd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*05:05:01:03	LN:6393	M5:39e340eb675634315a0f9aa27e8fdb32	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*05:11	LN:6589	M5:a47aa87bace1ec4da327ee121bceac36	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQA1*06:01:01	LN:5878	M5:cd02d6c8bd4c86f9abb999bab52820cf	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*02:01:01	LN:7480	M5:0b0031da03392e56acd208fc67ae6e39	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*02:02:01	LN:7471	M5:69337da3c9bd0a6048d1a1144aabbdb0	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:01:01:01	LN:7231	M5:78802163e98cdc6f909438b62e0cfab4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:01:01:02	LN:7230	M5:e8f01ef987d6dd2a878f94e6d97be1f1	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:01:01:03	LN:7231	M5:2423aebb09fea4369cab41a1ea47afc8	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:02:01	LN:7126	M5:2218c10eeaa7f39f94ed3f0309605510	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:03:02:01	LN:7126	M5:ffa1cdc44c405e284e6f51859e1c2b36	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:03:02:02	LN:7126	M5:739f0c7c0c72cf31a975aebe2109f11c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:03:02:03	LN:6800	M5:2dd9cf67abbc473a663d6d559694616b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*03:05:01	LN:6934	M5:0de7b3ac9974b084f8db58e416c25eb5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*05:01:01:01	LN:7090	M5:38570713e3fcfe831cc045e479f65e9b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*05:01:01:02	LN:7090	M5:0f304adf7acf3bd4b7c54c1394c85a4b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*05:03:01:01	LN:7089	M5:618b80618d0a6750a82d9caf5b2b01ea	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*05:03:01:02	LN:7089	M5:198d06518fff03b2dafc0bb113efc008	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*06:01:01	LN:7111	M5:231c9c7d1321a266933777181a2761a4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*06:02:01	LN:7102	M5:739d56a7e8c44823d1a11bd4ff13f465	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*06:03:01	LN:7103	M5:1bfde4e12c5bac5e9e5e7e6b84582b0b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DQB1*06:09:01	LN:7102	M5:805267e877e03b8ec95319888e38c5dc	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*01:01:01	LN:10741	M5:91618decb1b3933c623070b2ccbe52a6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*01:02:01	LN:11229	M5:9efa1a8356e55f6be83b4ddb84833e4b	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*03:01:01:01	LN:13908	M5:411919f8128149a1f5099cdd22d276ab	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*03:01:01:02	LN:13426	M5:869ae29cc3f279d7fc43e27249a53e8a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*04:03:01	LN:15246	M5:ce0de8afd561fb1fb0d3acce94386a27	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*07:01:01:01	LN:16110	M5:4063054a8189fbc81248b0f37b8273fd	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*07:01:01:02	LN:16120	M5:a4b1a49cfe8fb2c98c178c02b6c64ed4	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*08:03:02	LN:13562	M5:dc6eb484555ba796b15b9b91aa1a9ec6	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*09:21	LN:16039	M5:cad793cbc22699d1cca3101b5a55437d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*10:01:01	LN:13501	M5:91dcd8c149b00a3edb1afa43a1cc6346	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*11:01:01	LN:13921	M5:07cefc23572c21731a2804c5d44fcf55	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*11:01:02	LN:13931	M5:f47cd478ee5be3ff048069adbbb5c101	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*11:04:01	LN:13919	M5:fc86714e3d7b9503d74e40d92f08cd7a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*12:01:01	LN:13404	M5:31f08980f62b68be96334f3cafc3e7c2	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*12:17	LN:11260	M5:b0b7bea536479c8e61164e1475203038	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*13:01:01	LN:13935	M5:937994edc4b4760eb13cbf451c3f3bbe	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*13:02:01	LN:13941	M5:6a124566ab0a103d525d2fcf1292ce15	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*14:05:01	LN:13933	M5:10890137f738be0861b6ba128cfb953d	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*14:54:01	LN:13936	M5:2b67be4ed005b3f3040e3c72bfc65c0c	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*15:01:01:01	LN:11080	M5:d22cd7f323b0e51abb025a4dec827aa5	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*15:01:01:02	LN:11571	M5:5e3280587aa6f38dd9a282e9bf21287e	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*15:01:01:03	LN:11056	M5:d548f5e5798e09c869571ea8c660c983	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*15:01:01:04	LN:11056	M5:3bb2753595aaf099a490a7ce1e042fce	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*15:02:01	LN:10313	M5:2deab6035ce8cc2e09db20698cf1f117	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*15:03:01:01	LN:11567	M5:e6a26b767a62b282e0db211bbc9a7363	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*15:03:01:02	LN:11569	M5:4e0d459b9bd15bff8645de84334e3d25	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+@SQ	SN:HLA-DRB1*16:02:01	LN:11005	M5:4a972df76bd3ee2857b87bd5be5ea00a	AS:38	UR:/seq/references/Homo_sapiens_assembly38/v0/Homo_sapiens_assembly38.fasta	SP:Homo sapiens
+chr1	103620656	103621698	+	NUMT_1_104163778_104163820_chr1_103621156_103621198_500bp
+chr1	106802141	106803742	+	NUMT_1_107345263_107345410_chr1_106802641_106802788_500bp|NUMT_1_107345592_107345864_chr1_106802970_106803242_500bp
+chr1	106804326	106806384	+	NUMT_1_107347448_107347964_chr1_106804826_106805342_500bp|NUMT_1_107348016_107348228_chr1_106805394_106805606_500bp|NUMT_1_107348354_107348506_chr1_106805732_106805884_500bp
+chr1	113576282	113577373	+	NUMT_1_114119404_114119495_chr1_113576782_113576873_500bp
+chrUn_KI270742v1	8919	12595	+	NUMT_1_142790441_142790498_chrUn_KI270742v1_9419_9476_500bp|NUMT_1_142790559_142791157_chrUn_KI270742v1_9537_10135_500bp|NUMT_1_142791272_142791468_chrUn_KI270742v1_10250_10446_500bp|NUMT_1_142791639_142791858_chrUn_KI270742v1_10617_10836_500bp|NUMT_1_142791956_142792081_chrUn_KI270742v1_10934_11059_500bp|NUMT_1_142792628_142793117_chrUn_KI270742v1_11606_12095_500bp
+chr1_KI270706v1_random	124963	128529	+	NUMT_1_143243224_143243691_chr1_KI270706v1_random_125463_125930_500bp|NUMT_1_143244266_143244391_chr1_KI270706v1_random_126505_126630_500bp|NUMT_1_143244489_143244708_chr1_KI270706v1_random_126728_126947_500bp|NUMT_1_143244898_143245130_chr1_KI270706v1_random_127137_127369_500bp|NUMT_1_143245190_143245790_chr1_KI270706v1_random_127429_128029_500bp
+chr14_GL000009v2_random	1	2874	+	NUMT_1_143342891_143343229_chr14_GL000009v2_random_75_413_500bp|NUMT_1_143343289_143343540_chr14_GL000009v2_random_473_724_500bp|NUMT_1_143344028_143344153_chr14_GL000009v2_random_1212_1337_500bp|NUMT_1_143344706_143345044_chr14_GL000009v2_random_1890_2228_500bp|NUMT_1_143345104_143345190_chr14_GL000009v2_random_2288_2374_500bp
+chr1	147860172	147861283	+	NUMT_1_147332804_147332915_chr1_147860672_147860783_500bp
+chr1	169473563	169474658	+	NUMT_1_169443301_169443396_chr1_169474063_169474158_500bp
+chr1	181422285	181423478	+	NUMT_1_181391921_181392114_chr1_181422785_181422978_500bp
+chr1	191961360	191962402	+	NUMT_1_191930990_191931032_chr1_191961860_191961902_500bp
+chr1	205474916	205476004	+	NUMT_1_205444544_205444632_chr1_205475416_205475504_500bp
+chr1	212504499	212505572	+	NUMT_1_212678341_212678414_chr1_212504999_212505072_500bp
+chr1	215499296	215500334	+	NUMT_1_215673139_215673177_chr1_215499796_215499834_500bp
+chr1	220454658	220455755	+	NUMT_1_220628500_220628597_chr1_220455158_220455255_500bp
+chr1	226957671	226958750	+	NUMT_1_227145872_227145951_chr1_226958171_226958250_500bp
+chr1	235538091	235542865	+	NUMT_1_235701891_235701995_chr1_235538591_235538695_500bp|NUMT_1_235702039_235702268_chr1_235538739_235538968_500bp|NUMT_1_235702354_235702504_chr1_235539054_235539204_500bp|NUMT_1_235702640_235702974_chr1_235539340_235539674_500bp|NUMT_1_235703146_235703260_chr1_235539846_235539960_500bp|NUMT_1_235703712_235704114_chr1_235540412_235540814_500bp|NUMT_1_235704233_235704388_chr1_235540933_235541088_500bp|NUMT_1_235704669_235704817_chr1_235541369_235541517_500bp|NUMT_1_235705442_235705665_chr1_235542142_235542365_500bp
+chr1	237940276	237949433	+	NUMT_1_238104076_238104183_chr1_237940776_237940883_500bp|NUMT_1_238104374_238104757_chr1_237941074_237941457_500bp|NUMT_1_238105374_238105553_chr1_237942074_237942253_500bp|NUMT_1_238105788_238106144_chr1_237942488_237942844_500bp|NUMT_1_238106270_238106653_chr1_237942970_237943353_500bp|NUMT_1_238106772_238107369_chr1_237943472_237944069_500bp|NUMT_1_238107504_238107831_chr1_237944204_237944531_500bp|NUMT_1_238108043_238108168_chr1_237944743_237944868_500bp|NUMT_1_238108190_238108412_chr1_237944890_237945112_500bp|NUMT_1_238108766_238109283_chr1_237945466_237945983_500bp|NUMT_1_238109412_238109627_chr1_237946112_237946327_500bp|NUMT_1_238110626_238110788_chr1_237947326_237947488_500bp|NUMT_1_238111572_238111671_chr1_237948272_237948371_500bp|NUMT_1_238111864_238112233_chr1_237948564_237948933_500bp
+chr1	237949794	237952159	+	NUMT_1_238113594_238113878_chr1_237950294_237950578_500bp|NUMT_1_238114079_238114151_chr1_237950779_237950851_500bp|NUMT_1_238114436_238114620_chr1_237951136_237951320_500bp|NUMT_1_238114842_238114959_chr1_237951542_237951659_500bp
+chr1	50016697	50017872	+	NUMT_1_50482869_50483044_chr1_50017197_50017372_500bp
+chr1	628584	635424	+	NUMT_1_564464_570304_chr1_629084_634924_500bp
+chr1	5849758	5850968	+	NUMT_1_5910318_5910528_chr1_5850258_5850468_500bp
+chr1	76970749	76971915	+	NUMT_1_77436934_77437100_chr1_76971249_76971415_500bp
+chr1	81080311	81081378	+	NUMT_1_81546496_81546563_chr1_81080811_81080878_500bp
+chr1	8909243	8910405	+	NUMT_1_8969802_8969964_chr1_8909743_8909905_500bp
+chr1	93936003	93937503	+	NUMT_1_94402059_94402156_chr1_93936503_93936600_500bp|NUMT_1_94402401_94402559_chr1_93936845_93937003_500bp
+chr1	9574178	9575317	+	NUMT_1_9634736_9634875_chr1_9574678_9574817_500bp
+chr10	100056887	100058401	+	NUMT_10_101817144_101817658_chr10_100057387_100057901_500bp
+chr10	112894078	112895135	+	NUMT_10_114654337_114654394_chr10_112894578_112894635_500bp
+chr10	119837530	119838632	+	NUMT_10_121597542_121597644_chr10_119838030_119838132_500bp
+chr10	130130642	130131704	+	NUMT_10_131929406_131929468_chr10_130131142_130131204_500bp
+chr10	19746246	19748679	+	NUMT_10_20035675_20036008_chr10_19746746_19747079_500bp|NUMT_10_20036195_20036297_chr10_19747266_19747368_500bp|NUMT_10_20036366_20036445_chr10_19747437_19747516_500bp|NUMT_10_20036516_20036569_chr10_19747587_19747640_500bp|NUMT_10_20036622_20036759_chr10_19747693_19747830_500bp|NUMT_10_20037055_20037108_chr10_19748126_19748179_500bp
+chr10	2235195	2236305	+	NUMT_10_2277889_2277999_chr10_2235695_2235805_500bp
+chr10	25638017	25639091	+	NUMT_10_25927446_25927520_chr10_25638517_25638591_500bp
+chr10	26872761	26873905	+	NUMT_10_27162190_27162334_chr10_26873261_26873405_500bp
+chr10	27876248	27877309	+	NUMT_10_28165677_28165738_chr10_27876748_27876809_500bp
+chr10	30564772	30565821	+	NUMT_10_30854201_30854250_chr10_30565272_30565321_500bp
+chr10	36432747	36435650	+	NUMT_10_36722175_36722535_chr10_36433247_36433607_500bp|NUMT_10_36722621_36722772_chr10_36433693_36433844_500bp|NUMT_10_36722896_36723183_chr10_36433968_36434255_500bp|NUMT_10_36723402_36723531_chr10_36434474_36434603_500bp|NUMT_10_36723867_36724078_chr10_36434939_36435150_500bp
+chr10	37600693	37603327	+	NUMT_10_37890121_37890389_chr10_37601193_37601461_500bp|NUMT_10_37890460_37890706_chr10_37601532_37601778_500bp|NUMT_10_37890849_37891186_chr10_37601921_37602258_500bp|NUMT_10_37891276_37891309_chr10_37602348_37602381_500bp|NUMT_10_37891401_37891520_chr10_37602473_37602592_500bp|NUMT_10_37891549_37891755_chr10_37602621_37602827_500bp
+chr10	46705670	46706931	+	NUMT_10_46843186_46843447_chr10_46706170_46706431_500bp
+chr10	47633471	47634732	+	NUMT_10_47323991_47324252_chr10_47633971_47634232_500bp
+chr10	55597377	55601174	+	NUMT_10_57357637_57357825_chr10_55597877_55598065_500bp|NUMT_10_57357872_57357949_chr10_55598112_55598189_500bp|NUMT_10_57357988_57358092_chr10_55598228_55598332_500bp|NUMT_10_57358100_57358272_chr10_55598340_55598512_500bp|NUMT_10_57358347_57358397_chr10_55598587_55598637_500bp|NUMT_10_57358575_57358653_chr10_55598815_55598893_500bp|NUMT_10_57358886_57359085_chr10_55599126_55599325_500bp|NUMT_10_57359173_57359245_chr10_55599413_55599485_500bp|NUMT_10_57359452_57359841_chr10_55599692_55600081_500bp|NUMT_10_57360249_57360434_chr10_55600489_55600674_500bp
+chr10	69590650	69593821	+	NUMT_10_71350906_71351224_chr10_69591150_69591468_500bp|NUMT_10_71351274_71351334_chr10_69591518_69591578_500bp|NUMT_10_71351412_71351582_chr10_69591656_69591826_500bp|NUMT_10_71351669_71352237_chr10_69591913_69592481_500bp|NUMT_10_71352697_71352885_chr10_69592941_69593129_500bp|NUMT_10_71353006_71353077_chr10_69593250_69593321_500bp
+chr10	69594769	69596425	+	NUMT_10_71355025_71355257_chr10_69595269_69595501_500bp|NUMT_10_71355618_71355681_chr10_69595862_69595925_500bp
+chr10	79410729	79411793	+	NUMT_10_81170985_81171049_chr10_79411229_79411293_500bp
+chr10	89786179	89787232	+	NUMT_10_91546436_91546489_chr10_89786679_89786732_500bp
+chr11	103401629	103403122	+	NUMT_11_103272857_103273350_chr11_103402129_103402622_500bp
+chr11	103403655	103411495	+	NUMT_11_103274883_103275102_chr11_103404155_103404374_500bp|NUMT_11_103275372_103276049_chr11_103404644_103405321_500bp|NUMT_11_103276576_103276694_chr11_103405848_103405966_500bp|NUMT_11_103276718_103276943_chr11_103405990_103406215_500bp|NUMT_11_103277402_103277483_chr11_103406674_103406755_500bp|NUMT_11_103277548_103277680_chr11_103406820_103406952_500bp|NUMT_11_103277962_103278170_chr11_103407234_103407442_500bp|NUMT_11_103278536_103278708_chr11_103407808_103407980_500bp|NUMT_11_103278904_103279035_chr11_103408176_103408307_500bp|NUMT_11_103279243_103279484_chr11_103408515_103408756_500bp|NUMT_11_103279627_103279669_chr11_103408899_103408941_500bp|NUMT_11_103279687_103279921_chr11_103408959_103409193_500bp|NUMT_11_103280147_103280283_chr11_103409419_103409555_500bp|NUMT_11_103280391_103280692_chr11_103409663_103409964_500bp|NUMT_11_103280797_103280887_chr11_103410069_103410159_500bp|NUMT_11_103280939_103281017_chr11_103410211_103410289_500bp|NUMT_11_103281062_103281418_chr11_103410334_103410690_500bp|NUMT_11_103281596_103281723_chr11_103410868_103410995_500bp
+chr11	10507387	10510836	+	NUMT_11_10529434_10531883_chr11_10507887_10510336_500bp
+chr11	110876492	110877628	+	NUMT_11_110747716_110747852_chr11_110876992_110877128_500bp
+chr11	11239560	11240674	+	NUMT_11_11261607_11261721_chr11_11240060_11240174_500bp
+chr11	123003106	123004177	+	NUMT_11_122874314_122874385_chr11_123003606_123003677_500bp
+chr11	123139566	123140743	+	NUMT_11_123010774_123010951_chr11_123140066_123140243_500bp
+chr11	31554609	31555693	+	NUMT_11_31576656_31576740_chr11_31555109_31555193_500bp
+chr11	39765939	39767574	+	NUMT_11_39787989_39788212_chr11_39766439_39766662_500bp|NUMT_11_39788433_39788624_chr11_39766883_39767074_500bp
+chr11	47323484	47324681	+	NUMT_11_47345535_47345732_chr11_47323984_47324181_500bp
+chr11	48972784	48973861	+	NUMT_11_48994836_48994913_chr11_48973284_48973361_500bp
+chr11	49812121	49813198	+	NUMT_11_49834173_49834250_chr11_49812621_49812698_500bp
+chr11	55273084	55274161	+	NUMT_11_55041060_55041137_chr11_55273584_55273661_500bp
+chr11	64186835	64187971	+	NUMT_11_63954807_63954848_chr11_64187335_64187376_500bp|NUMT_11_63954873_63954943_chr11_64187401_64187471_500bp
+chr11	6501409	6502471	+	NUMT_11_6523139_6523201_chr11_6501909_6501971_500bp
+chr11	73510161	73511323	+	NUMT_11_73221706_73221868_chr11_73510661_73510823_500bp
+chr11	81551074	81557493	+	NUMT_11_81262616_81262832_chr11_81551574_81551790_500bp|NUMT_11_81263225_81263383_chr11_81552183_81552341_500bp|NUMT_11_81263477_81263586_chr11_81552435_81552544_500bp|NUMT_11_81263896_81263943_chr11_81552854_81552901_500bp|NUMT_11_81264199_81264399_chr11_81553157_81553357_500bp|NUMT_11_81265030_81265149_chr11_81553988_81554107_500bp|NUMT_11_81265372_81265505_chr11_81554330_81554463_500bp|NUMT_11_81265545_81265675_chr11_81554503_81554633_500bp|NUMT_11_81265795_81265908_chr11_81554753_81554866_500bp|NUMT_11_81266035_81266220_chr11_81554993_81555178_500bp|NUMT_11_81267216_81267770_chr11_81556174_81556728_500bp|NUMT_11_81267886_81268035_chr11_81556844_81556993_500bp
+chr11	87813102	87814567	+	NUMT_11_87524494_87524959_chr11_87813602_87814067_500bp
+chr11	87815159	87816712	+	NUMT_11_87526551_87527104_chr11_87815659_87816212_500bp
+chr12	126582809	126584892	+	NUMT_12_127067855_127067915_chr12_126583309_126583369_500bp|NUMT_12_127067916_127067962_chr12_126583370_126583416_500bp|NUMT_12_127068057_127068103_chr12_126583511_126583557_500bp|NUMT_12_127068104_127068150_chr12_126583558_126583604_500bp|NUMT_12_127068856_127068938_chr12_126584310_126584392_500bp
+chr12	130315106	130316301	+	NUMT_12_130800151_130800346_chr12_130315606_130315801_500bp
+chr12	22005336	22006436	+	NUMT_12_22158770_22158870_chr12_22005836_22005936_500bp
+chr12	31247163	31249367	+	NUMT_12_31400597_31400696_chr12_31247663_31247762_500bp|NUMT_12_31401631_31401801_chr12_31248697_31248867_500bp
+chr12	40285792	40287155	+	NUMT_12_40680094_40680457_chr12_40286292_40286655_500bp
+chr12	41363135	41364223	+	NUMT_12_41757437_41757525_chr12_41363635_41363723_500bp
+chr12	41698702	41699908	+	NUMT_12_42093004_42093210_chr12_41699202_41699408_500bp
+chr12	49816858	49818002	+	NUMT_12_50211141_50211285_chr12_49817358_49817502_500bp
+chr12	62773510	62774577	+	NUMT_12_63167790_63167857_chr12_62774010_62774077_500bp
+chr13	107058331	107059372	+	NUMT_13_107711179_107711220_chr13_107058831_107058872_500bp
+chr13	109423625	109424880	+	NUMT_13_110076472_110076727_chr13_109424125_109424380_500bp
+chr13	22112713	22113815	+	NUMT_13_22687352_22687454_chr13_22113213_22113315_500bp
+chr13	23765488	23766585	+	NUMT_13_24340127_24340224_chr13_23765988_23766085_500bp
+chr13	36064991	36066196	+	NUMT_13_36639628_36639833_chr13_36065491_36065696_500bp
+chr13	40767852	40768922	+	NUMT_13_41342488_41342558_chr13_40768352_40768422_500bp
+chr13	47570506	47571549	+	NUMT_13_48145141_48145184_chr13_47571006_47571049_500bp
+chr13	53891096	53892207	+	NUMT_13_54465731_54465842_chr13_53891596_53891707_500bp
+chr13	55971134	55972256	+	NUMT_13_56545768_56545890_chr13_55971634_55971756_500bp
+chr13	56687976	56689149	+	NUMT_13_57262610_57262783_chr13_56688476_56688649_500bp
+chr13	75591739	75592896	+	NUMT_13_76166375_76166532_chr13_75592239_75592396_500bp
+chr13	84519884	84523682	+	NUMT_13_85094519_85094632_chr13_84520384_84520497_500bp|NUMT_13_85095020_85095168_chr13_84520885_84521033_500bp|NUMT_13_85095747_85095864_chr13_84521612_84521729_500bp|NUMT_13_85096094_85096280_chr13_84521959_84522145_500bp|NUMT_13_85096891_85097005_chr13_84522756_84522870_500bp|NUMT_13_85097058_85097317_chr13_84522923_84523182_500bp
+chr13	95692041	95695566	+	NUMT_13_96344795_96345079_chr13_95692541_95692825_500bp|NUMT_13_96345376_96345471_chr13_95693122_95693217_500bp|NUMT_13_96346272_96346402_chr13_95694018_95694148_500bp|NUMT_13_96346883_96347320_chr13_95694629_95695066_500bp
+chr13	96697189	96698330	+	NUMT_13_97349943_97350084_chr13_96697689_96697830_500bp
+chr14	23425987	23427031	+	NUMT_14_23895696_23895740_chr14_23426487_23426531_500bp
+chr14	32483598	32485618	+	NUMT_14_32953304_32954324_chr14_32484098_32485118_500bp
+chr14	51586921	51588268	+	NUMT_14_52054139_52054486_chr14_51587421_51587768_500bp
+chr14	83587006	83589613	+	NUMT_14_84053850_84054322_chr14_83587506_83587978_500bp|NUMT_14_84054666_84054706_chr14_83588322_83588362_500bp|NUMT_14_84054754_84055457_chr14_83588410_83589113_500bp
+chr14	84170852	84177496	+	NUMT_14_84637696_84638079_chr14_84171352_84171735_500bp|NUMT_14_84638350_84638625_chr14_84172006_84172281_500bp|NUMT_14_84638769_84639028_chr14_84172425_84172684_500bp|NUMT_14_84639090_84639184_chr14_84172746_84172840_500bp|NUMT_14_84639187_84639382_chr14_84172843_84173038_500bp|NUMT_14_84640033_84640133_chr14_84173689_84173789_500bp|NUMT_14_84640228_84640336_chr14_84173884_84173992_500bp|NUMT_14_84640726_84640850_chr14_84174382_84174506_500bp|NUMT_14_84640935_84641307_chr14_84174591_84174963_500bp|NUMT_14_84641838_84641946_chr14_84175494_84175602_500bp|NUMT_14_84642685_84643050_chr14_84176341_84176706_500bp|NUMT_14_84643090_84643340_chr14_84176746_84176996_500bp
+chr15	34394221	34395371	+	NUMT_15_34686922_34687072_chr15_34394721_34394871_500bp
+chr15	34540442	34541592	+	NUMT_15_34833143_34833293_chr15_34540942_34541092_500bp
+chr15	35395772	35396848	+	NUMT_15_35688473_35688549_chr15_35396272_35396348_500bp
+chr15	40133270	40135692	+	NUMT_15_40425971_40426116_chr15_40133770_40133915_500bp|NUMT_15_40426316_40426466_chr15_40134115_40134265_500bp|NUMT_15_40426754_40426880_chr15_40134553_40134679_500bp|NUMT_15_40427203_40427393_chr15_40135002_40135192_500bp
+chr15	41156700	41157797	+	NUMT_15_41449398_41449495_chr15_41157200_41157297_500bp
+chr15	46340903	46342041	+	NUMT_15_46633601_46633739_chr15_46341403_46341541_500bp
+chr15	58149862	58154338	+	NUMT_15_58442561_58442835_chr15_58150362_58150636_500bp|NUMT_15_58443140_58443335_chr15_58150941_58151136_500bp|NUMT_15_58443432_58443550_chr15_58151233_58151351_500bp|NUMT_15_58443947_58444337_chr15_58151748_58152138_500bp|NUMT_15_58444375_58444454_chr15_58152176_58152255_500bp|NUMT_15_58445030_58445172_chr15_58152831_58152973_500bp|NUMT_15_58445446_58445559_chr15_58153247_58153360_500bp|NUMT_15_58445672_58445745_chr15_58153473_58153546_500bp|NUMT_15_58445839_58446037_chr15_58153640_58153838_500bp
+chr15	58154398	58156032	+	NUMT_15_58447097_58447451_chr15_58154898_58155252_500bp|NUMT_15_58447597_58447731_chr15_58155398_58155532_500bp
+chr15	67040411	67041453	+	NUMT_15_67333249_67333291_chr15_67040911_67040953_500bp
+chr16	10718397	10725636	+	NUMT_16_10812754_10812898_chr16_10718897_10719041_500bp|NUMT_16_10813042_10813668_chr16_10719185_10719811_500bp|NUMT_16_10814117_10814707_chr16_10720260_10720850_500bp|NUMT_16_10814928_10815126_chr16_10721071_10721269_500bp|NUMT_16_10815343_10815551_chr16_10721486_10721694_500bp|NUMT_16_10815792_10815894_chr16_10721935_10722037_500bp|NUMT_16_10816127_10816326_chr16_10722270_10722469_500bp|NUMT_16_10816448_10816610_chr16_10722591_10722753_500bp|NUMT_16_10816867_10817020_chr16_10723010_10723163_500bp|NUMT_16_10817674_10817891_chr16_10723817_10724034_500bp|NUMT_16_10818302_10818482_chr16_10724445_10724625_500bp|NUMT_16_10818730_10818993_chr16_10724873_10725136_500bp
+chr16	20720548	20722901	+	NUMT_16_20732370_20732466_chr16_20721048_20721144_500bp|NUMT_16_20732524_20732746_chr16_20721202_20721424_500bp|NUMT_16_20732817_20732924_chr16_20721495_20721602_500bp|NUMT_16_20733250_20733378_chr16_20721928_20722056_500bp|NUMT_16_20733596_20733723_chr16_20722274_20722401_500bp
+chr16	3366986	3372607	+	NUMT_16_3417486_3417647_chr16_3367486_3367647_500bp|NUMT_16_3417808_3417946_chr16_3367808_3367946_500bp|NUMT_16_3418052_3418837_chr16_3368052_3368837_500bp|NUMT_16_3419742_3420110_chr16_3369742_3370110_500bp|NUMT_16_3420223_3420607_chr16_3370223_3370607_500bp|NUMT_16_3420907_3420981_chr16_3370907_3370981_500bp|NUMT_16_3421053_3421315_chr16_3371053_3371315_500bp|NUMT_16_3421781_3422107_chr16_3371781_3372107_500bp
+chr16	69358195	69359310	+	NUMT_16_69392598_69392713_chr16_69358695_69358810_500bp
+chr16	82120365	82122586	+	NUMT_16_82154470_82154623_chr16_82120865_82121018_500bp|NUMT_16_82154795_82155691_chr16_82121190_82122086_500bp
+chr17	19597175	19606020	+	NUMT_17_19500988_19501118_chr17_19597675_19597805_500bp|NUMT_17_19501872_19502665_chr17_19598559_19599352_500bp|NUMT_17_19502710_19502796_chr17_19599397_19599483_500bp|NUMT_17_19502840_19502921_chr17_19599527_19599608_500bp|NUMT_17_19503153_19503357_chr17_19599840_19600044_500bp|NUMT_17_19503702_19503832_chr17_19600389_19600519_500bp|NUMT_17_19504037_19504273_chr17_19600724_19600960_500bp|NUMT_17_19504577_19504668_chr17_19601264_19601355_500bp|NUMT_17_19504718_19504770_chr17_19601405_19601457_500bp|NUMT_17_19504821_19505077_chr17_19601508_19601764_500bp|NUMT_17_19505136_19505197_chr17_19601823_19601884_500bp|NUMT_17_19505868_19506222_chr17_19602555_19602909_500bp|NUMT_17_19506352_19506456_chr17_19603039_19603143_500bp|NUMT_17_19506498_19506735_chr17_19603185_19603422_500bp|NUMT_17_19507331_19507432_chr17_19604018_19604119_500bp|NUMT_17_19507848_19507897_chr17_19604535_19604584_500bp|NUMT_17_19508097_19508286_chr17_19604784_19604973_500bp|NUMT_17_19508361_19508833_chr17_19605048_19605520_500bp
+chr17	22518695	22533266	+	NUMT_17_22018521_22020228_chr17_22519195_22520902_500bp|NUMT_17_22020533_22020726_chr17_22521207_22521400_500bp|NUMT_17_22020727_22020961_chr17_22521401_22521635_500bp|NUMT_17_22021121_22021170_chr17_22521795_22521844_500bp|NUMT_17_22021385_22022346_chr17_22522059_22523020_500bp|NUMT_17_22022360_22024802_chr17_22523034_22525476_500bp|NUMT_17_22024848_22026588_chr17_22525522_22527262_500bp|NUMT_17_22026593_22028979_chr17_22527267_22529653_500bp|NUMT_17_22029026_22029211_chr17_22529700_22529885_500bp|NUMT_17_22029254_22031051_chr17_22529928_22531725_500bp|NUMT_17_22031160_22031645_chr17_22531834_22532319_500bp|NUMT_17_22031760_22031841_chr17_22532434_22532515_500bp|NUMT_17_22031838_22032092_chr17_22532512_22532766_500bp
+chr17	28973848	28974926	+	NUMT_17_27301366_27301444_chr17_28974348_28974426_500bp
+chr17	35654371	35655546	+	NUMT_17_33981890_33982065_chr17_35654871_35655046_500bp
+chr17	43997216	43998283	+	NUMT_17_42075084_42075151_chr17_43997716_43997783_500bp
+chr17	53105233	53106885	+	NUMT_17_51183094_51183746_chr17_53105733_53106385_500bp
+chr17	63392911	63394085	+	NUMT_17_61470772_61470946_chr17_63393411_63393585_500bp
+chr17	80617082	80618122	+	NUMT_17_78591382_78591422_chr17_80617582_80617622_500bp
+chr18	14136295	14137357	+	NUMT_18_14136794_14136856_chr18_14136795_14136857_500bp
+chr18	2841700	2842854	+	NUMT_18_2842198_2842352_chr18_2842200_2842354_500bp
+chr18	47852746	47853937	+	NUMT_18_45379617_45379808_chr18_47853246_47853437_500bp
+chr18	61874071	61875385	+	NUMT_18_59541804_59542118_chr18_61874571_61874885_500bp
+chr19	12095601	12096794	+	NUMT_19_12206916_12207109_chr19_12096101_12096294_500bp
+chr19	12507471	12508596	+	NUMT_19_12618785_12618910_chr19_12507971_12508096_500bp
+chr19	27741309	27742375	+	NUMT_19_28232717_28232783_chr19_27741809_27741875_500bp
+chr19	37572146	37573264	+	NUMT_19_38063548_38063666_chr19_37572646_37572764_500bp
+chr19	44145928	44147009	+	NUMT_19_44650581_44650662_chr19_44146428_44146509_500bp
+chr19	56921727	56922921	+	NUMT_19_57433595_57433789_chr19_56922227_56922421_500bp
+chr2	116751685	116752805	+	NUMT_2_117509761_117509881_chr2_116752185_116752305_500bp
+chr2	117019742	117027001	+	NUMT_2_117777818_117777948_chr2_117020242_117020372_500bp|NUMT_2_117778789_117779426_chr2_117021213_117021850_500bp|NUMT_2_117779450_117779554_chr2_117021874_117021978_500bp|NUMT_2_117779740_117779813_chr2_117022164_117022237_500bp|NUMT_2_117780024_117780404_chr2_117022448_117022828_500bp|NUMT_2_117780474_117780517_chr2_117022898_117022941_500bp|NUMT_2_117780634_117780942_chr2_117023058_117023366_500bp|NUMT_2_117781098_117781291_chr2_117023522_117023715_500bp|NUMT_2_117781403_117781669_chr2_117023827_117024093_500bp|NUMT_2_117782317_117782390_chr2_117024741_117024814_500bp|NUMT_2_117782420_117782668_chr2_117024844_117025092_500bp|NUMT_2_117782962_117783078_chr2_117025386_117025502_500bp|NUMT_2_117783692_117784077_chr2_117026116_117026501_500bp
+chr2	120211216	120217382	+	NUMT_2_120969292_120969788_chr2_120211716_120212212_500bp|NUMT_2_120970237_120970477_chr2_120212661_120212901_500bp|NUMT_2_120970828_120971035_chr2_120213252_120213459_500bp|NUMT_2_120971146_120971236_chr2_120213570_120213660_500bp|NUMT_2_120971508_120971602_chr2_120213932_120214026_500bp|NUMT_2_120971795_120972183_chr2_120214219_120214607_500bp|NUMT_2_120972248_120972414_chr2_120214672_120214838_500bp|NUMT_2_120972655_120972766_chr2_120215079_120215190_500bp|NUMT_2_120973740_120973821_chr2_120216164_120216245_500bp|NUMT_2_120974184_120974458_chr2_120216608_120216882_500bp
+chr2	124680424	124681502	+	NUMT_2_125438501_125438579_chr2_124680924_124681002_500bp
+chr2	125811694	125812907	+	NUMT_2_126569771_126569984_chr2_125812194_125812407_500bp
+chr2	130271310	130283786	+	NUMT_2_131029383_131029623_chr2_130271810_130272050_500bp|NUMT_2_131029645_131030056_chr2_130272072_130272483_500bp|NUMT_2_131030337_131030472_chr2_130272764_130272899_500bp|NUMT_2_131031158_131031464_chr2_130273585_130273891_500bp|NUMT_2_131031578_131031740_chr2_130274005_130274167_500bp|NUMT_2_131031988_131032688_chr2_130274415_130275115_500bp|NUMT_2_131032847_131033003_chr2_130275274_130275430_500bp|NUMT_2_131033026_131033196_chr2_130275453_130275623_500bp|NUMT_2_131033634_131033767_chr2_130276061_130276194_500bp|NUMT_2_131034058_131034126_chr2_130276485_130276553_500bp|NUMT_2_131034308_131034637_chr2_130276735_130277064_500bp|NUMT_2_131034746_131035586_chr2_130277173_130278013_500bp|NUMT_2_131035926_131036132_chr2_130278353_130278559_500bp|NUMT_2_131036203_131036355_chr2_130278630_130278782_500bp|NUMT_2_131036623_131036749_chr2_130279050_130279176_500bp|NUMT_2_131036909_131037169_chr2_130279336_130279596_500bp|NUMT_2_131037253_131037419_chr2_130279680_130279846_500bp|NUMT_2_131037728_131037871_chr2_130280155_130280298_500bp|NUMT_2_131038092_131038220_chr2_130280519_130280647_500bp|NUMT_2_131038497_131038621_chr2_130280924_130281048_500bp|NUMT_2_131038669_131038917_chr2_130281096_130281344_500bp|NUMT_2_131039003_131039119_chr2_130281430_130281546_500bp|NUMT_2_131039696_131039865_chr2_130282123_130282292_500bp|NUMT_2_131040163_131040395_chr2_130282590_130282822_500bp|NUMT_2_131040514_131040859_chr2_130282941_130283286_500bp
+chr2	131368561	131374256	+	NUMT_2_132126634_132127023_chr2_131369061_131369450_500bp|NUMT_2_132127142_132127595_chr2_131369569_131370022_500bp|NUMT_2_132127676_132127829_chr2_131370103_131370256_500bp|NUMT_2_132128427_132129028_chr2_131370854_131371455_500bp|NUMT_2_132129670_132129806_chr2_131372097_131372233_500bp|NUMT_2_132130189_132130294_chr2_131372616_131372721_500bp|NUMT_2_132130373_132130633_chr2_131372800_131373060_500bp|NUMT_2_132130745_132130910_chr2_131373172_131373337_500bp|NUMT_2_132131218_132131329_chr2_131373645_131373756_500bp
+chr2	131379126	131386662	+	NUMT_2_132137199_132137339_chr2_131379626_131379766_500bp|NUMT_2_132137679_132137989_chr2_131380106_131380416_500bp|NUMT_2_132138164_132138497_chr2_131380591_131380924_500bp|NUMT_2_132138606_132138935_chr2_131381033_131381362_500bp|NUMT_2_132139117_132139185_chr2_131381544_131381612_500bp|NUMT_2_132139470_132139603_chr2_131381897_131382030_500bp|NUMT_2_132140015_132140209_chr2_131382442_131382636_500bp|NUMT_2_132140232_132140487_chr2_131382659_131382914_500bp|NUMT_2_132140548_132141253_chr2_131382975_131383680_500bp|NUMT_2_132141375_132141537_chr2_131383802_131383964_500bp|NUMT_2_132141651_132141957_chr2_131384078_131384384_500bp|NUMT_2_132142643_132142778_chr2_131385070_131385205_500bp|NUMT_2_132143059_132143446_chr2_131385486_131385873_500bp|NUMT_2_132143492_132143735_chr2_131385919_131386162_500bp
+chr2	132424600	132425657	+	NUMT_2_133182673_133182730_chr2_132425100_132425157_500bp
+chr2	140216752	140218138	+	NUMT_2_140974821_140975207_chr2_140217252_140217638_500bp
+chr2	140219513	140224724	+	NUMT_2_140977582_140977635_chr2_140220013_140220066_500bp|NUMT_2_140977933_140978082_chr2_140220364_140220513_500bp|NUMT_2_140978184_140978272_chr2_140220615_140220703_500bp|NUMT_2_140978426_140978679_chr2_140220857_140221110_500bp|NUMT_2_140978948_140979142_chr2_140221379_140221573_500bp|NUMT_2_140979190_140979450_chr2_140221621_140221881_500bp|NUMT_2_140979593_140979904_chr2_140222024_140222335_500bp|NUMT_2_140980131_140980351_chr2_140222562_140222782_500bp|NUMT_2_140980384_140980621_chr2_140222815_140223052_500bp|NUMT_2_140980710_140980808_chr2_140223141_140223239_500bp|NUMT_2_140980880_140981390_chr2_140223311_140223821_500bp|NUMT_2_140981397_140981555_chr2_140223828_140223986_500bp|NUMT_2_140981662_140981793_chr2_140224093_140224224_500bp
+chr2	143088325	143089362	+	NUMT_2_143846394_143846431_chr2_143088825_143088862_500bp
+chr2	143089533	143092966	+	NUMT_2_143847602_143848000_chr2_143090033_143090431_500bp|NUMT_2_143848384_143849129_chr2_143090815_143091560_500bp|NUMT_2_143849916_143850035_chr2_143092347_143092466_500bp
+chr2	143093148	143094686	+	NUMT_2_143851217_143851755_chr2_143093648_143094186_500bp
+chr2	143094824	143100474	+	NUMT_2_143852893_143853251_chr2_143095324_143095682_500bp|NUMT_2_143853364_143853482_chr2_143095795_143095913_500bp|NUMT_2_143853759_143853907_chr2_143096190_143096338_500bp|NUMT_2_143854119_143854327_chr2_143096550_143096758_500bp|NUMT_2_143854706_143855094_chr2_143097137_143097525_500bp|NUMT_2_143855214_143855400_chr2_143097645_143097831_500bp|NUMT_2_143855842_143856076_chr2_143098273_143098507_500bp|NUMT_2_143856396_143856616_chr2_143098827_143099047_500bp|NUMT_2_143857384_143857543_chr2_143099815_143099974_500bp
+chr2	147264693	147265772	+	NUMT_2_148022761_148022840_chr2_147265193_147265272_500bp
+chr2	148881226	148882357	+	NUMT_2_149639295_149639426_chr2_148881726_148881857_500bp
+chr2	155262965	155265302	+	NUMT_2_156119977_156120236_chr2_155263465_155263724_500bp|NUMT_2_156120290_156120669_chr2_155263778_155264157_500bp|NUMT_2_156120740_156120849_chr2_155264228_155264337_500bp|NUMT_2_156120914_156121314_chr2_155264402_155264802_500bp
+chr2	155310586	155314853	+	NUMT_2_156167598_156167694_chr2_155311086_155311182_500bp|NUMT_2_156167940_156168133_chr2_155311428_155311621_500bp|NUMT_2_156168305_156168495_chr2_155311793_155311983_500bp|NUMT_2_156168557_156168654_chr2_155312045_155312142_500bp|NUMT_2_156168771_156168887_chr2_155312259_155312375_500bp|NUMT_2_156169006_156169205_chr2_155312494_155312693_500bp|NUMT_2_156169874_156170022_chr2_155313362_155313510_500bp|NUMT_2_156170219_156170319_chr2_155313707_155313807_500bp|NUMT_2_156170468_156170549_chr2_155313956_155314037_500bp|NUMT_2_156170798_156170865_chr2_155314286_155314353_500bp
+chr2	166413995	166415213	+	NUMT_2_167271005_167271084_chr2_166414495_166414574_500bp|NUMT_2_167271087_167271223_chr2_166414577_166414713_500bp
+chr2	174780538	174781596	+	NUMT_2_175645766_175645824_chr2_174781038_174781096_500bp
+chr2	179738847	179740240	+	NUMT_2_180604074_180604289_chr2_179739347_179739562_500bp|NUMT_2_180604379_180604467_chr2_179739652_179739740_500bp
+chr2	201211796	201215481	+	NUMT_2_202077019_202077161_chr2_201212296_201212438_500bp|NUMT_2_202077290_202077581_chr2_201212567_201212858_500bp|NUMT_2_202077802_202077950_chr2_201213079_201213227_500bp|NUMT_2_202078250_202078483_chr2_201213527_201213760_500bp|NUMT_2_202078526_202078775_chr2_201213803_201214052_500bp|NUMT_2_202078902_202079088_chr2_201214179_201214365_500bp|NUMT_2_202079286_202079436_chr2_201214563_201214713_500bp|NUMT_2_202079558_202079704_chr2_201214835_201214981_500bp
+chr2	201557316	201558437	+	NUMT_2_202422539_202422660_chr2_201557816_201557937_500bp
+chr2	202613732	202620534	+	NUMT_2_203478955_203479319_chr2_202614232_202614596_500bp|NUMT_2_203479529_203479673_chr2_202614806_202614950_500bp|NUMT_2_203480260_203480300_chr2_202615537_202615577_500bp|NUMT_2_203480675_203480947_chr2_202615952_202616224_500bp|NUMT_2_203481115_203481338_chr2_202616392_202616615_500bp|NUMT_2_203481671_203481984_chr2_202616948_202617261_500bp|NUMT_2_203482375_203482533_chr2_202617652_202617810_500bp|NUMT_2_203482605_203482714_chr2_202617882_202617991_500bp|NUMT_2_203483339_203483497_chr2_202618616_202618774_500bp|NUMT_2_203483969_203484201_chr2_202619246_202619478_500bp|NUMT_2_203484634_203484757_chr2_202619911_202620034_500bp
+chr2	211773295	211780177	+	NUMT_2_212638520_212638717_chr2_211773795_211773992_500bp|NUMT_2_212639158_212639496_chr2_211774433_211774771_500bp|NUMT_2_212639697_212640072_chr2_211774972_211775347_500bp|NUMT_2_212640291_212640371_chr2_211775566_211775646_500bp|NUMT_2_212640412_212640502_chr2_211775687_211775777_500bp|NUMT_2_212640547_212640600_chr2_211775822_211775875_500bp|NUMT_2_212640675_212640934_chr2_211775950_211776209_500bp|NUMT_2_212641062_212641333_chr2_211776337_211776608_500bp|NUMT_2_212641934_212641971_chr2_211777209_211777246_500bp|NUMT_2_212642042_212642123_chr2_211777317_211777398_500bp|NUMT_2_212642585_212642967_chr2_211777860_211778242_500bp|NUMT_2_212643406_212643639_chr2_211778681_211778914_500bp|NUMT_2_212643707_212643923_chr2_211778982_211779198_500bp|NUMT_2_212644053_212644402_chr2_211779328_211779677_500bp
+chr2	220048356	220049488	+	NUMT_2_220913577_220913709_chr2_220048856_220048988_500bp
+chr2	22316559	22317718	+	NUMT_2_22539931_22540090_chr2_22317059_22317218_500bp
+chr2	226721769	226722926	+	NUMT_2_227586985_227587142_chr2_226722269_226722426_500bp
+chr2	235455516	235456668	+	NUMT_2_236364660_236364812_chr2_235456016_235456168_500bp
+chr2	237520737	237524072	+	NUMT_2_238429880_238429981_chr2_237521237_237521338_500bp|NUMT_2_238430092_238430252_chr2_237521449_237521609_500bp|NUMT_2_238430338_238430420_chr2_237521695_237521777_500bp|NUMT_2_238430426_238430481_chr2_237521783_237521838_500bp|NUMT_2_238430487_238430531_chr2_237521844_237521888_500bp|NUMT_2_238430548_238430603_chr2_237521905_237521960_500bp|NUMT_2_238430609_238430664_chr2_237521966_237522021_500bp|NUMT_2_238430670_238430725_chr2_237522027_237522082_500bp|NUMT_2_238430731_238430786_chr2_237522088_237522143_500bp|NUMT_2_238430792_238430847_chr2_237522149_237522204_500bp|NUMT_2_238430853_238430908_chr2_237522210_237522265_500bp|NUMT_2_238430914_238430969_chr2_237522271_237522326_500bp|NUMT_2_238430975_238431019_chr2_237522332_237522376_500bp|NUMT_2_238431036_238431091_chr2_237522393_237522448_500bp|NUMT_2_238431097_238431152_chr2_237522454_237522509_500bp|NUMT_2_238431158_238431202_chr2_237522515_237522559_500bp|NUMT_2_238431219_238431274_chr2_237522576_237522631_500bp|NUMT_2_238431280_238431394_chr2_237522637_237522751_500bp|NUMT_2_238431686_238431801_chr2_237523043_237523158_500bp|NUMT_2_238432026_238432215_chr2_237523383_237523572_500bp
+chr2	33766971	33768023	+	NUMT_2_33992538_33992590_chr2_33767471_33767523_500bp
+chr2	40784457	40785617	+	NUMT_2_41012097_41012257_chr2_40784957_40785117_500bp
+chr2	49229128	49230399	+	NUMT_2_49456767_49457038_chr2_49229628_49229899_500bp
+chr2	50588192	50589890	+	NUMT_2_50815830_50816528_chr2_50588692_50589390_500bp
+chr2	68260240	68261404	+	NUMT_2_68487872_68488036_chr2_68260740_68260904_500bp
+chr2	75063248	75064353	+	NUMT_2_75290875_75290980_chr2_75063748_75063853_500bp
+chr2	81665984	81667225	+	NUMT_2_81893608_81893849_chr2_81666484_81666725_500bp
+chr2	82815106	82817265	+	NUMT_2_83042730_83042851_chr2_82815606_82815727_500bp|NUMT_2_83043150_83043293_chr2_82816026_82816169_500bp|NUMT_2_83043498_83043613_chr2_82816374_82816489_500bp|NUMT_2_83043725_83043889_chr2_82816601_82816765_500bp
+chr2	82817592	82819127	+	NUMT_2_83045216_83045538_chr2_82818092_82818414_500bp|NUMT_2_83045584_83045751_chr2_82818460_82818627_500bp
+chr2	82819330	82820371	+	NUMT_2_83046954_83046995_chr2_82819830_82819871_500bp
+chr2	82820393	82821505	+	NUMT_2_83048017_83048129_chr2_82820893_82821005_500bp
+chr2	85068329	85069530	+	NUMT_2_85295952_85296153_chr2_85068829_85069030_500bp
+chr2	87824390	87825865	+	NUMT_2_88124409_88124884_chr2_87824890_87825365_500bp
+chr2	94898509	94902128	+	NUMT_2_95564754_95565221_chr2_94899009_94899476_500bp|NUMT_2_95565445_95565716_chr2_94899700_94899971_500bp|NUMT_2_95565794_95565948_chr2_94900049_94900203_500bp|NUMT_2_95566509_95566715_chr2_94900764_94900970_500bp|NUMT_2_95566763_95567105_chr2_94901018_94901360_500bp|NUMT_2_95567146_95567373_chr2_94901401_94901628_500bp
+chr20	13166812	13167854	+	NUMT_20_13147959_13148001_chr20_13167312_13167354_500bp
+chr20	57063554	57064623	+	NUMT_20_55639110_55639179_chr20_57064054_57064123_500bp
+chr20	57357148	57361558	+	NUMT_20_55932704_55932933_chr20_57357648_57357877_500bp|NUMT_20_55932991_55933131_chr20_57357935_57358075_500bp|NUMT_20_55933304_55933519_chr20_57358248_57358463_500bp|NUMT_20_55933574_55933835_chr20_57358518_57358779_500bp|NUMT_20_55933883_55934311_chr20_57358827_57359255_500bp|NUMT_20_55934688_55934864_chr20_57359632_57359808_500bp|NUMT_20_55935092_55935172_chr20_57360036_57360116_500bp|NUMT_20_55935219_55935732_chr20_57360163_57360676_500bp|NUMT_20_55935747_55936114_chr20_57360691_57361058_500bp
+chr20	9168424	9169465	+	NUMT_20_9149571_9149612_chr20_9168924_9168965_500bp
+chr21	10014355	10015514	+	NUMT_21_10492883_10493042_chr21_10014855_10015014_500bp
+chr21	14021080	14022142	+	NUMT_21_15393901_15393963_chr21_14021580_14021642_500bp
+chr21	44474594	44475672	+	NUMT_21_45894977_45895055_chr21_44475094_44475172_500bp
+chr21	45375706	45376884	+	NUMT_21_46796121_46796299_chr21_45376206_45376384_500bp
+chr21	8844031	8847702	+	NUMT_21_9733364_9733421_chr21_8844531_8844588_500bp|NUMT_21_9733482_9734080_chr21_8844649_8845247_500bp|NUMT_21_9734195_9734391_chr21_8845362_8845558_500bp|NUMT_21_9734874_9734999_chr21_8846041_8846166_500bp|NUMT_21_9735551_9735889_chr21_8846718_8847056_500bp|NUMT_21_9735949_9736035_chr21_8847116_8847202_500bp
+chr22	16875734	16876813	+	NUMT_22_17357124_17357203_chr22_16876234_16876313_500bp
+chr22_KI270879v1_alt	241661	243067	+	NUMT_22_24347986_24348128_chr22_KI270879v1_alt_242161_242303_500bp|NUMT_22_24348211_24348392_chr22_KI270879v1_alt_242386_242567_500bp
+chr22_KI270879v1_alt	243145	244393	+	NUMT_22_24349470_24349631_chr22_KI270879v1_alt_243645_243806_500bp|NUMT_22_24349643_24349718_chr22_KI270879v1_alt_243818_243893_500bp
+chr22	32894462	32895665	+	NUMT_22_33290948_33291151_chr22_32894962_32895165_500bp
+chr22	35885172	35886218	+	NUMT_22_36281719_36281765_chr22_35885672_35885718_500bp
+chr22	36178893	36179932	+	NUMT_22_36575441_36575480_chr22_36179393_36179432_500bp
+chr22	46469784	46470833	+	NUMT_22_46866181_46866230_chr22_46470284_46470333_500bp
+chr22	50085668	50086849	+	NUMT_22_50524597_50524778_chr22_50086168_50086349_500bp
+chr3	106893639	106896317	+	NUMT_3_106612986_106613108_chr3_106894139_106894261_500bp|NUMT_3_106613701_106613958_chr3_106894854_106895111_500bp|NUMT_3_106614209_106614248_chr3_106895362_106895401_500bp|NUMT_3_106614531_106614664_chr3_106895684_106895817_500bp
+chr3	106896399	106898033	+	NUMT_3_106615746_106615937_chr3_106896899_106897090_500bp|NUMT_3_106616282_106616380_chr3_106897435_106897533_500bp
+chr3	106898160	106904023	+	NUMT_3_106617507_106617587_chr3_106898660_106898740_500bp|NUMT_3_106617843_106618139_chr3_106898996_106899292_500bp|NUMT_3_106618270_106618370_chr3_106899423_106899523_500bp|NUMT_3_106618747_106618824_chr3_106899900_106899977_500bp|NUMT_3_106619741_106619822_chr3_106900894_106900975_500bp|NUMT_3_106620801_106620998_chr3_106901954_106902151_500bp|NUMT_3_106621370_106621516_chr3_106902523_106902669_500bp|NUMT_3_106621780_106621872_chr3_106902933_106903025_500bp|NUMT_3_106622048_106622370_chr3_106903201_106903523_500bp
+chr3	120721533	120723127	+	NUMT_3_120440880_120441474_chr3_120722033_120722627_500bp
+chr3	122688238	122689295	+	NUMT_3_122407585_122407642_chr3_122688738_122688795_500bp
+chr3	127004976	127006065	+	NUMT_3_126724319_126724408_chr3_127005476_127005565_500bp
+chr3	152919208	152920334	+	NUMT_3_152637497_152637623_chr3_152919708_152919834_500bp
+chr3	153658385	153659487	+	NUMT_3_153376674_153376776_chr3_153658885_153658987_500bp
+chr3	160947154	160948447	+	NUMT_3_160665442_160665735_chr3_160947654_160947947_500bp
+chr3	166159905	166162507	+	NUMT_3_165878193_165878302_chr3_166160405_166160514_500bp|NUMT_3_165878377_165878535_chr3_166160589_166160747_500bp|NUMT_3_165878926_165879184_chr3_166161138_166161396_500bp|NUMT_3_165879586_165879795_chr3_166161798_166162007_500bp
+chr3	166231982	166233301	+	NUMT_3_165950270_165950589_chr3_166232482_166232801_500bp
+chr3	169936297	169937368	+	NUMT_3_169654585_169654656_chr3_169936797_169936868_500bp
+chr3	171533941	171535148	+	NUMT_3_171252230_171252437_chr3_171534441_171534648_500bp
+chr3	176965826	176966925	+	NUMT_3_176684114_176684213_chr3_176966326_176966425_500bp
+chr3	177010220	177011528	+	NUMT_3_176728508_176728631_chr3_177010720_177010843_500bp|NUMT_3_176728745_176728816_chr3_177010957_177011028_500bp
+chr3	187465708	187466751	+	NUMT_3_187183996_187184039_chr3_187466208_187466251_500bp
+chr3	25467004	25468042	+	NUMT_3_25508995_25509033_chr3_25467504_25467542_500bp
+chr3	29797197	29798367	+	NUMT_3_29839188_29839358_chr3_29797697_29797867_500bp
+chr3	40251647	40254267	+	NUMT_3_40293638_40293722_chr3_40252147_40252231_500bp|NUMT_3_40293767_40293872_chr3_40252276_40252381_500bp|NUMT_3_40293958_40294436_chr3_40252467_40252945_500bp|NUMT_3_40294638_40294975_chr3_40253147_40253484_500bp|NUMT_3_40295112_40295258_chr3_40253621_40253767_500bp
+chr3	43228914	43230231	+	NUMT_3_43270906_43271223_chr3_43229414_43229731_500bp
+chr3	63846533	63847594	+	NUMT_3_63832709_63832770_chr3_63847033_63847094_500bp
+chr3	68658556	68659787	+	NUMT_3_68708207_68708282_chr3_68659056_68659131_500bp|NUMT_3_68708305_68708438_chr3_68659154_68659287_500bp
+chr3	72582800	72584029	+	NUMT_3_72632451_72632680_chr3_72583300_72583529_500bp
+chr3	89586353	89587959	+	NUMT_3_89636003_89636120_chr3_89586853_89586970_500bp|NUMT_3_89636332_89636609_chr3_89587182_89587459_500bp
+chr3	89588014	89590026	+	NUMT_3_89637664_89637854_chr3_89588514_89588704_500bp|NUMT_3_89637975_89638048_chr3_89588825_89588898_500bp|NUMT_3_89638175_89638676_chr3_89589025_89589526_500bp
+chr3	96616688	96619010	+	NUMT_3_96336032_96337354_chr3_96617188_96618510_500bp
+chr3	96764640	96765784	+	NUMT_3_96483984_96484128_chr3_96765140_96765284_500bp
+chr4	116297241	116300750	+	NUMT_4_117218897_117219189_chr4_116297741_116298033_500bp|NUMT_4_117219309_117219702_chr4_116298153_116298546_500bp|NUMT_4_117219747_117219833_chr4_116298591_116298677_500bp|NUMT_4_117219881_117219983_chr4_116298725_116298827_500bp|NUMT_4_117220177_117220536_chr4_116299021_116299380_500bp|NUMT_4_117220742_117221079_chr4_116299586_116299923_500bp|NUMT_4_117221270_117221406_chr4_116300114_116300250_500bp
+chr4	12639794	12641135	+	NUMT_4_12641918_12642259_chr4_12640294_12640635_500bp
+chr4	128080905	128082276	+	NUMT_4_129002560_129002931_chr4_128081405_128081776_500bp
+chr4	14505406	14506949	+	NUMT_4_14507530_14507742_chr4_14505906_14506118_500bp|NUMT_4_14507834_14508073_chr4_14506210_14506449_500bp
+chr4	155451374	155458869	+	NUMT_4_156373026_156373274_chr4_155451874_155452122_500bp|NUMT_4_156373862_156373927_chr4_155452710_155452775_500bp|NUMT_4_156374769_156375127_chr4_155453617_155453975_500bp|NUMT_4_156375213_156375363_chr4_155454061_155454211_500bp|NUMT_4_156375643_156375767_chr4_155454491_155454615_500bp|NUMT_4_156375995_156376114_chr4_155454843_155454962_500bp|NUMT_4_156376347_156376528_chr4_155455195_155455376_500bp|NUMT_4_156376688_156376959_chr4_155455536_155455807_500bp|NUMT_4_156377093_156377252_chr4_155455941_155456100_500bp|NUMT_4_156377555_156377663_chr4_155456403_155456511_500bp|NUMT_4_156377746_156377920_chr4_155456594_155456768_500bp|NUMT_4_156378282_156378541_chr4_155457130_155457389_500bp|NUMT_4_156378655_156379210_chr4_155457503_155458058_500bp|NUMT_4_156379333_156379521_chr4_155458181_155458369_500bp
+chr4	155459026	155466959	+	NUMT_4_156380678_156380779_chr4_155459526_155459627_500bp|NUMT_4_156380961_156381891_chr4_155459809_155460739_500bp|NUMT_4_156382331_156382606_chr4_155461179_155461454_500bp|NUMT_4_156382640_156382787_chr4_155461488_155461635_500bp|NUMT_4_156383468_156383756_chr4_155462316_155462604_500bp|NUMT_4_156383810_156384225_chr4_155462658_155463073_500bp|NUMT_4_156384328_156384629_chr4_155463176_155463477_500bp|NUMT_4_156384800_156384907_chr4_155463648_155463755_500bp|NUMT_4_156384977_156385069_chr4_155463825_155463917_500bp|NUMT_4_156385175_156385367_chr4_155464023_155464215_500bp|NUMT_4_156385525_156385862_chr4_155464373_155464710_500bp|NUMT_4_156386064_156386515_chr4_155464912_155465363_500bp|NUMT_4_156386632_156386738_chr4_155465480_155465586_500bp|NUMT_4_156386782_156386868_chr4_155465630_155465716_500bp|NUMT_4_156386913_156387297_chr4_155465761_155466145_500bp|NUMT_4_156387335_156387611_chr4_155466183_155466459_500bp
+chr4	160044110	160045171	+	NUMT_4_160965762_160965823_chr4_160044610_160044671_500bp
+chr4	162420867	162422041	+	NUMT_4_163342519_163342693_chr4_162421367_162421541_500bp
+chr4	163228539	163229649	+	NUMT_4_164150191_164150301_chr4_163229039_163229149_500bp
+chr4	17061385	17062664	+	NUMT_4_17063508_17063787_chr4_17061885_17062164_500bp
+chr4	179068940	179070088	+	NUMT_4_179990594_179990742_chr4_179069440_179069588_500bp
+chr4	181236903	181238040	+	NUMT_4_182158556_182158693_chr4_181237403_181237540_500bp
+chr4	25717414	25718497	+	NUMT_4_25719536_25719619_chr4_25717914_25717997_500bp
+chr4	25718764	25721217	+	NUMT_4_25720886_25721042_chr4_25719264_25719420_500bp|NUMT_4_25721540_25721744_chr4_25719918_25720122_500bp|NUMT_4_25722088_25722339_chr4_25720466_25720717_500bp
+chr4	27729924	27731075	+	NUMT_4_27732046_27732197_chr4_27730424_27730575_500bp
+chr4	30884496	30885679	+	NUMT_4_30886618_30886801_chr4_30884996_30885179_500bp
+chr4	47771772	47772864	+	NUMT_4_47774289_47774381_chr4_47772272_47772364_500bp
+chr4	49245534	49247180	+	NUMT_4_49248051_49248579_chr4_49246034_49246562_500bp|NUMT_4_49248640_49248697_chr4_49246623_49246680_500bp
+chr4	49548276	49549922	+	NUMT_4_49550793_49550850_chr4_49548776_49548833_500bp|NUMT_4_49550911_49551439_chr4_49548894_49549422_500bp
+chr4	5404147	5405217	+	NUMT_4_5406374_5406444_chr4_5404647_5404717_500bp
+chr4	55327660	55328790	+	NUMT_4_56194327_56194457_chr4_55328160_55328290_500bp
+chr4	64605887	64612382	+	NUMT_4_65472105_65472313_chr4_64606387_64606595_500bp|NUMT_4_65472741_65472898_chr4_64607023_64607180_500bp|NUMT_4_65473283_65473828_chr4_64607565_64608110_500bp|NUMT_4_65473875_65474016_chr4_64608157_64608298_500bp|NUMT_4_65474092_65474877_chr4_64608374_64609159_500bp|NUMT_4_65475027_65475270_chr4_64609309_64609552_500bp|NUMT_4_65475371_65475437_chr4_64609653_64609719_500bp|NUMT_4_65475554_65476249_chr4_64609836_64610531_500bp|NUMT_4_65476261_65476398_chr4_64610543_64610680_500bp|NUMT_4_65476517_65476686_chr4_64610799_64610968_500bp|NUMT_4_65476753_65477600_chr4_64611035_64611882_500bp
+chr4	66064844	66065956	+	NUMT_4_66931062_66931174_chr4_66065344_66065456_500bp
+chr4	68572003	68573099	+	NUMT_4_69438221_69438317_chr4_68572503_68572599_500bp
+chr4	78008022	78009261	+	NUMT_4_78929676_78929915_chr4_78008522_78008761_500bp
+chr4	81733183	81734347	+	NUMT_4_82654837_82655001_chr4_81733683_81733847_500bp
+chr4	87675610	87676695	+	NUMT_4_88597262_88597347_chr4_87676110_87676195_500bp
+chr4	89731356	89732506	+	NUMT_4_90653007_90653157_chr4_89731856_89732006_500bp
+chr4	92701328	92703030	+	NUMT_4_93622979_93623350_chr4_92701828_92702199_500bp|NUMT_4_93623411_93623518_chr4_92702260_92702367_500bp|NUMT_4_93623566_93623681_chr4_92702415_92702530_500bp
+chr5	106552863	106554022	+	NUMT_5_105889064_105889223_chr5_106553363_106553522_500bp
+chr5	119126899	119127948	+	NUMT_5_118463094_118463143_chr5_119127399_119127448_500bp
+chr5	121030487	121031817	+	NUMT_5_120366682_120366747_chr5_121030987_121031052_500bp|NUMT_5_120366816_120367012_chr5_121031121_121031317_500bp
+chr5	123759779	123762238	+	NUMT_5_123095973_123096006_chr5_123760279_123760312_500bp|NUMT_5_123096496_123097432_chr5_123760802_123761738_500bp
+chr5	134922809	134929027	+	NUMT_5_134258999_134264217_chr5_134923309_134928527_500bp
+chr5	163009010	163010119	+	NUMT_5_162436516_162436625_chr5_163009510_163009619_500bp
+chr5	166529922	166530961	+	NUMT_5_165957427_165957466_chr5_166530422_166530461_500bp
+chr5	170635061	170636123	+	NUMT_5_170062565_170062627_chr5_170635561_170635623_500bp
+chr5	5394922	5397461	+	NUMT_5_5395535_5396043_chr5_5395422_5395930_500bp|NUMT_5_5396189_5396303_chr5_5396076_5396190_500bp|NUMT_5_5396435_5397074_chr5_5396322_5396961_500bp
+chr5	60761039	60762524	+	NUMT_5_60057366_60057571_chr5_60761539_60761744_500bp|NUMT_5_60057663_60057851_chr5_60761836_60762024_500bp
+chr5	73775392	73776432	+	NUMT_5_73071717_73071757_chr5_73775892_73775932_500bp
+chr5	80649522	80652868	+	NUMT_5_79945841_79948187_chr5_80650022_80652368_500bp
+chr5	8618602	8620256	+	NUMT_5_8619214_8619868_chr5_8619102_8619756_500bp
+chr5	8620383	8621512	+	NUMT_5_8620995_8621124_chr5_8620883_8621012_500bp
+chr5	8621600	8623073	+	NUMT_5_8622212_8622503_chr5_8622100_8622391_500bp|NUMT_5_8622586_8622685_chr5_8622474_8622573_500bp
+chr5	94566956	94571418	+	NUMT_5_93903161_93906623_chr5_94567456_94570918_500bp
+chr5	98409290	98412085	+	NUMT_5_97745494_97745576_chr5_98409790_98409872_500bp|NUMT_5_97745707_97745940_chr5_98410003_98410236_500bp|NUMT_5_97746055_97746870_chr5_98410351_98411166_500bp|NUMT_5_97746883_97747043_chr5_98411179_98411339_500bp|NUMT_5_97747189_97747289_chr5_98411485_98411585_500bp
+chr5	100045438	100055545	+	NUMT_5_99381642_99390437_chr5_100045938_100054733_500bp|NUMT_5_99390466_99390749_chr5_100054762_100055045_500bp
+chr6	119158839	119159921	+	NUMT_6_119480504_119480586_chr6_119159339_119159421_500bp
+chr6	127311638	127312693	+	NUMT_6_127633283_127633338_chr6_127312138_127312193_500bp
+chr6	133150071	133151294	+	NUMT_6_133471710_133471933_chr6_133150571_133150794_500bp
+chr6	143077309	143078440	+	NUMT_6_143398946_143399077_chr6_143077809_143077940_500bp
+chr6	144728437	144729641	+	NUMT_6_145050073_145050145_chr6_144728937_144729009_500bp|NUMT_6_145050188_145050277_chr6_144729052_144729141_500bp
+chr6	153665072	153670280	+	NUMT_6_153986707_153986897_chr6_153665572_153665762_500bp|NUMT_6_153987532_153987573_chr6_153666397_153666438_500bp|NUMT_6_153988158_153988297_chr6_153667023_153667162_500bp|NUMT_6_153988402_153988464_chr6_153667267_153667329_500bp|NUMT_6_153988589_153988779_chr6_153667454_153667644_500bp|NUMT_6_153989033_153989250_chr6_153667898_153668115_500bp|NUMT_6_153989633_153989729_chr6_153668498_153668594_500bp|NUMT_6_153990341_153990384_chr6_153669206_153669249_500bp|NUMT_6_153990656_153990915_chr6_153669521_153669780_500bp
+chr6	156547336	156548553	+	NUMT_6_156868970_156869187_chr6_156547836_156548053_500bp
+chr6	1705564	1706665	+	NUMT_6_1706298_1706399_chr6_1706064_1706165_500bp
+chr6	32705666	32707401	+	NUMT_6_32673943_32674007_chr6_32706166_32706230_500bp|NUMT_6_32674094_32674447_chr6_32706317_32706670_500bp|NUMT_6_32674471_32674678_chr6_32706694_32706901_500bp
+chr6	43490667	43491727	+	NUMT_6_43458905_43458965_chr6_43491167_43491227_500bp
+chr6	51986479	51987566	+	NUMT_6_51851777_51851864_chr6_51986979_51987066_500bp
+chr6	61573613	61575129	+	NUMT_6_62284018_62284534_chr6_61574113_61574629_500bp
+chr6	74224983	74226042	+	NUMT_6_74935199_74935258_chr6_74225483_74225542_500bp
+chr6	74818708	74819754	+	NUMT_6_75528924_75528970_chr6_74819208_74819254_500bp
+chr6	88554805	88555917	+	NUMT_6_89265024_89265136_chr6_88555305_88555417_500bp
+chr6	91726220	91728023	+	NUMT_6_92436438_92436775_chr6_91726720_91727057_500bp|NUMT_6_92436780_92436882_chr6_91727062_91727164_500bp|NUMT_6_92436881_92437029_chr6_91727163_91727311_500bp|NUMT_6_92437028_92437241_chr6_91727310_91727523_500bp
+chr6	94446618	94447942	+	NUMT_6_95156836_95157160_chr6_94447118_94447442_500bp
+chr6_GL000251v2_alt	4118977	4120712	+	NUMT_6_cox_hap2_4119583_4120087_chr6_GL000251v2_alt_4119477_4119981_500bp|NUMT_6_cox_hap2_4120111_4120318_chr6_GL000251v2_alt_4120005_4120212_500bp
+chr6_GL000252v2_alt	3950269	3952005	+	NUMT_6_dbb_hap3_3956354_3956859_chr6_GL000252v2_alt_3950769_3951274_500bp|NUMT_6_dbb_hap3_3956883_3957090_chr6_GL000252v2_alt_3951298_3951505_500bp
+chr6_GL000253v2_alt	4125474	4127208	+	NUMT_6_mann_hap4_4131594_4132044_chr6_GL000253v2_alt_4125974_4126424_500bp|NUMT_6_mann_hap4_4132121_4132328_chr6_GL000253v2_alt_4126501_4126708_500bp
+chr6_GL000254v2_alt	4004904	4006640	+	NUMT_6_mcf_hap5_4010989_4011494_chr6_GL000254v2_alt_4005404_4005909_500bp|NUMT_6_mcf_hap5_4011518_4011725_chr6_GL000254v2_alt_4005933_4006140_500bp
+chr6_GL000255v2_alt	3899941	3901676	+	NUMT_6_qbl_hap6_3906037_3906541_chr6_GL000255v2_alt_3900441_3900945_500bp|NUMT_6_qbl_hap6_3906565_3906772_chr6_GL000255v2_alt_3900969_3901176_500bp
+chr6_GL000256v2_alt	4106296	4108031	+	NUMT_6_ssto_hap7_4106094_4106158_chr6_GL000256v2_alt_4106796_4106860_500bp|NUMT_6_ssto_hap7_4106245_4106598_chr6_GL000256v2_alt_4106947_4107300_500bp|NUMT_6_ssto_hap7_4106622_4106829_chr6_GL000256v2_alt_4107324_4107531_500bp
+chr7	111084901	111085980	+	NUMT_7_110725457_110725536_chr7_111085401_111085480_500bp
+chr7	112372146	112373668	+	NUMT_7_112012701_112012766_chr7_112372646_112372711_500bp|NUMT_7_112012841_112013223_chr7_112372786_112373168_500bp
+chr7	112373908	112375443	+	NUMT_7_112014463_112014998_chr7_112374408_112374943_500bp
+chr7	117263463	117264874	+	NUMT_7_116904017_116904082_chr7_117263963_117264028_500bp|NUMT_7_116904293_116904428_chr7_117264239_117264374_500bp
+chr7	141172604	141173713	+	NUMT_7_140872904_140873013_chr7_141173104_141173213_500bp
+chr7	141800908	141805975	+	NUMT_7_141501208_141501408_chr7_141801408_141801608_500bp|NUMT_7_141501872_141501997_chr7_141802072_141802197_500bp|NUMT_7_141502035_141502266_chr7_141802235_141802466_500bp|NUMT_7_141502861_141503015_chr7_141803061_141803215_500bp|NUMT_7_141503280_141503668_chr7_141803480_141803868_500bp|NUMT_7_141503871_141504146_chr7_141804071_141804346_500bp|NUMT_7_141504271_141504381_chr7_141804471_141804581_500bp|NUMT_7_141504769_141504854_chr7_141804969_141805054_500bp|NUMT_7_141504966_141505178_chr7_141805166_141805378_500bp|NUMT_7_141505226_141505275_chr7_141805426_141805475_500bp
+chr7	142664701	142668193	+	NUMT_7_142373033_142374058_chr7_142665201_142666226_500bp|NUMT_7_142374142_142374646_chr7_142666310_142666814_500bp|NUMT_7_142374849_142375525_chr7_142667017_142667693_500bp
+chr7	145996833	145997928	+	NUMT_7_145694426_145694521_chr7_145997333_145997428_500bp
+chr7	150131501	150132660	+	NUMT_7_149829090_149829249_chr7_150132001_150132160_500bp
+chr7	153968163	153969320	+	NUMT_7_153665748_153665905_chr7_153968663_153968820_500bp
+chr7	36228243	36229352	+	NUMT_7_36268352_36268461_chr7_36228743_36228852_500bp
+chr7	45251471	45252627	+	NUMT_7_45291570_45291726_chr7_45251971_45252127_500bp
+chr7	57166888	57174322	+	NUMT_7_57235095_57235467_chr7_57167388_57167760_500bp|NUMT_7_57235767_57236433_chr7_57168060_57168726_500bp|NUMT_7_57236758_57236957_chr7_57169051_57169250_500bp|NUMT_7_57237047_57237160_chr7_57169340_57169453_500bp|NUMT_7_57237438_57237589_chr7_57169731_57169882_500bp|NUMT_7_57237716_57237979_chr7_57170009_57170272_500bp|NUMT_7_57238152_57238248_chr7_57170445_57170541_500bp|NUMT_7_57238542_57238685_chr7_57170835_57170978_500bp|NUMT_7_57238901_57239044_chr7_57171194_57171337_500bp|NUMT_7_57239312_57239477_chr7_57171605_57171770_500bp|NUMT_7_57239549_57239923_chr7_57171842_57172216_500bp|NUMT_7_57240522_57240682_chr7_57172815_57172975_500bp|NUMT_7_57240758_57240929_chr7_57173051_57173222_500bp|NUMT_7_57241081_57241178_chr7_57173374_57173471_500bp|NUMT_7_57241290_57241529_chr7_57173583_57173822_500bp
+chr7	57185265	57186918	+	NUMT_7_57253472_57253692_chr7_57185765_57185985_500bp|NUMT_7_57253738_57254125_chr7_57186031_57186418_500bp
+chr7	57187026	57190175	+	NUMT_7_57255233_57255523_chr7_57187526_57187816_500bp|NUMT_7_57256058_57256805_chr7_57188351_57189098_500bp|NUMT_7_57256893_57257125_chr7_57189186_57189418_500bp|NUMT_7_57257221_57257382_chr7_57189514_57189675_500bp
+chr7	57190630	57198318	+	NUMT_7_57258837_57258941_chr7_57191130_57191234_500bp|NUMT_7_57259252_57259705_chr7_57191545_57191998_500bp|NUMT_7_57260020_57260227_chr7_57192313_57192520_500bp|NUMT_7_57260301_57260410_chr7_57192594_57192703_500bp|NUMT_7_57260706_57260833_chr7_57192999_57193126_500bp|NUMT_7_57261013_57261270_chr7_57193306_57193563_500bp|NUMT_7_57261311_57261545_chr7_57193604_57193838_500bp|NUMT_7_57261841_57261989_chr7_57194134_57194282_500bp|NUMT_7_57262192_57262326_chr7_57194485_57194619_500bp|NUMT_7_57262612_57263334_chr7_57194905_57195627_500bp|NUMT_7_57263799_57263963_chr7_57196092_57196256_500bp|NUMT_7_57264039_57264241_chr7_57196332_57196534_500bp|NUMT_7_57264362_57264519_chr7_57196655_57196812_500bp|NUMT_7_57264599_57265029_chr7_57196892_57197322_500bp|NUMT_7_57265456_57265525_chr7_57197749_57197818_500bp
+chr7	63186565	63187630	+	NUMT_7_62647443_62647508_chr7_63187065_63187130_500bp
+chr7	64103685	64113169	+	NUMT_7_63564563_63564779_chr7_64104185_64104401_500bp|NUMT_7_63564821_63565079_chr7_64104443_64104701_500bp|NUMT_7_63565249_63565359_chr7_64104871_64104981_500bp|NUMT_7_63565615_63565768_chr7_64105237_64105390_500bp|NUMT_7_63565848_63566055_chr7_64105470_64105677_500bp|NUMT_7_63566388_63566702_chr7_64106010_64106324_500bp|NUMT_7_63566841_63567208_chr7_64106463_64106830_500bp|NUMT_7_63567571_63567711_chr7_64107193_64107333_500bp|NUMT_7_63567880_63567972_chr7_64107502_64107594_500bp|NUMT_7_63568540_63568679_chr7_64108162_64108301_500bp|NUMT_7_63568767_63569176_chr7_64108389_64108798_500bp|NUMT_7_63569338_63570083_chr7_64108960_64109705_500bp|NUMT_7_63570541_63570924_chr7_64110163_64110546_500bp|NUMT_7_63571331_63571660_chr7_64110953_64111282_500bp|NUMT_7_63571924_63572277_chr7_64111546_64111899_500bp|NUMT_7_63572439_63572587_chr7_64112061_64112209_500bp|NUMT_7_63572637_63572784_chr7_64112259_64112406_500bp|NUMT_7_63573003_63573047_chr7_64112625_64112669_500bp
+chr7	67627484	67628547	+	NUMT_7_67092971_67093034_chr7_67627984_67628047_500bp
+chr7	68097236	68098361	+	NUMT_7_67562723_67562848_chr7_68097736_68097861_500bp
+chr7	68265858	68266986	+	NUMT_7_67731345_67731473_chr7_68266358_68266486_500bp
+chr7	68736028	68737133	+	NUMT_7_68201515_68201620_chr7_68736528_68736633_500bp
+chr7	69330218	69331368	+	NUMT_7_68795704_68795854_chr7_69330718_69330868_500bp
+chr7	69331587	69334504	+	NUMT_7_68797073_68797666_chr7_69332087_69332680_500bp|NUMT_7_68798102_68798250_chr7_69333116_69333264_500bp|NUMT_7_68798764_68798990_chr7_69333778_69334004_500bp
+chr8	99495370	99496453	+	NUMT_8_100508098_100508181_chr8_99495870_99495953_500bp
+chr8	103082555	103083648	+	NUMT_8_104095283_104095376_chr8_103083055_103083148_500bp
+chr8	103083691	103086131	+	NUMT_8_104096419_104096462_chr8_103084191_103084234_500bp|NUMT_8_104097139_104097239_chr8_103084911_103085011_500bp|NUMT_8_104097483_104097662_chr8_103085255_103085434_500bp|NUMT_8_104097792_104097859_chr8_103085564_103085631_500bp
+chr8	103088071	103089199	+	NUMT_8_104100799_104100927_chr8_103088571_103088699_500bp
+chr8	103089434	103090919	+	NUMT_8_104102162_104102332_chr8_103089934_103090104_500bp|NUMT_8_104102565_104102647_chr8_103090337_103090419_500bp
+chr8	110932831	110935447	+	NUMT_8_111945560_111946060_chr8_110933331_110933831_500bp|NUMT_8_111946452_111946870_chr8_110934223_110934641_500bp|NUMT_8_111946901_111947176_chr8_110934672_110934947_500bp
+chr8	111248157	111249305	+	NUMT_8_112260886_112261034_chr8_111248657_111248805_500bp
+chr8	120223813	120224910	+	NUMT_8_121236552_121236649_chr8_120224313_120224410_500bp
+chr8	13352897	13354021	+	NUMT_8_13210906_13211030_chr8_13353397_13353521_500bp
+chr8	133754953	133757098	+	NUMT_8_134767696_134767848_chr8_133755453_133755605_500bp|NUMT_8_134767875_134767919_chr8_133755632_133755676_500bp|NUMT_8_134767936_134768160_chr8_133755693_133755917_500bp|NUMT_8_134768266_134768398_chr8_133756023_133756155_500bp|NUMT_8_134768637_134768841_chr8_133756394_133756598_500bp
+chr8	16056498	16057575	+	NUMT_8_15914507_15914584_chr8_16056998_16057075_500bp
+chr8	18848802	18850178	+	NUMT_8_18706812_18707188_chr8_18849302_18849678_500bp
+chr8	20550696	20551906	+	NUMT_8_20408707_20408917_chr8_20551196_20551406_500bp
+chr8	27902860	27903982	+	NUMT_8_27760877_27760999_chr8_27903360_27903482_500bp
+chr8	32805389	32806467	+	NUMT_8_32663407_32663485_chr8_32805889_32805967_500bp
+chr8	33011005	33016179	+	NUMT_8_32869023_32869094_chr8_33011505_33011576_500bp|NUMT_8_32869202_32869446_chr8_33011684_33011928_500bp|NUMT_8_32869474_32869702_chr8_33011956_33012184_500bp|NUMT_8_32869752_32869832_chr8_33012234_33012314_500bp|NUMT_8_32869877_32869949_chr8_33012359_33012431_500bp|NUMT_8_32870073_32870320_chr8_33012555_33012802_500bp|NUMT_8_32870321_32870379_chr8_33012803_33012861_500bp|NUMT_8_32870423_32870530_chr8_33012905_33013012_500bp|NUMT_8_32870741_32871063_chr8_33013223_33013545_500bp|NUMT_8_32871196_32871408_chr8_33013678_33013890_500bp|NUMT_8_32871681_32871774_chr8_33014163_33014256_500bp|NUMT_8_32872209_32872274_chr8_33014691_33014756_500bp|NUMT_8_32872386_32872590_chr8_33014868_33015072_500bp|NUMT_8_32872639_32872780_chr8_33015121_33015262_500bp|NUMT_8_32873058_32873197_chr8_33015540_33015679_500bp
+chr8	36277118	36280059	+	NUMT_8_36135136_36135397_chr8_36277618_36277879_500bp|NUMT_8_36135806_36136731_chr8_36278288_36279213_500bp|NUMT_8_36136798_36137077_chr8_36279280_36279559_500bp
+chr8	40070090	40071187	+	NUMT_8_39928109_39928167_chr8_40070590_40070648_500bp|NUMT_8_39928167_39928206_chr8_40070648_40070687_500bp
+chr8	46826986	46831550	+	NUMT_8_47739108_47739239_chr8_46827486_46827617_500bp|NUMT_8_47739510_47739709_chr8_46827888_46828087_500bp|NUMT_8_47740037_47740122_chr8_46828415_46828500_500bp|NUMT_8_47740183_47740451_chr8_46828561_46828829_500bp|NUMT_8_47740588_47740924_chr8_46828966_46829302_500bp|NUMT_8_47741127_47741170_chr8_46829505_46829548_500bp|NUMT_8_47741313_47741511_chr8_46829691_46829889_500bp|NUMT_8_47741967_47742348_chr8_46830345_46830726_500bp|NUMT_8_47742411_47742456_chr8_46830789_46830834_500bp|NUMT_8_47742504_47742672_chr8_46830882_46831050_500bp
+chr8	46837644	46839516	+	NUMT_8_47749766_47750252_chr8_46838144_46838630_500bp|NUMT_8_47750551_47750638_chr8_46838929_46839016_500bp
+chr8	48400195	48401261	+	NUMT_8_49313255_49313321_chr8_48400695_48400761_500bp
+chr8	52751253	52752457	+	NUMT_8_53664313_53664517_chr8_52751753_52751957_500bp
+chr8	67580364	67581500	+	NUMT_8_68493099_68493235_chr8_67580864_67581000_500bp
+chr8	67581640	67583156	+	NUMT_8_68494375_68494623_chr8_67582140_67582388_500bp|NUMT_8_68494749_68494891_chr8_67582514_67582656_500bp
+chr8	67583690	67588263	+	NUMT_8_68496425_68496729_chr8_67584190_67584494_500bp|NUMT_8_68496853_68496940_chr8_67584618_67584705_500bp|NUMT_8_68497290_68497408_chr8_67585055_67585173_500bp|NUMT_8_68497632_68497748_chr8_67585397_67585513_500bp|NUMT_8_68498062_68498163_chr8_67585827_67585928_500bp|NUMT_8_68498320_68498600_chr8_67586085_67586365_500bp|NUMT_8_68499186_68499295_chr8_67586951_67587060_500bp|NUMT_8_68499331_68499435_chr8_67587096_67587200_500bp|NUMT_8_68499488_68499639_chr8_67587253_67587404_500bp|NUMT_8_68499803_68499840_chr8_67587568_67587605_500bp|NUMT_8_68499860_68499998_chr8_67587625_67587763_500bp
+chr8	69102473	69103731	+	NUMT_8_70015208_70015314_chr8_69102973_69103079_500bp|NUMT_8_70015383_70015466_chr8_69103148_69103231_500bp
+chr8	72985209	72986354	+	NUMT_8_73897944_73898089_chr8_72985709_72985854_500bp
+chr8	76201263	76202639	+	NUMT_8_77113998_77114041_chr8_76201763_76201806_500bp|NUMT_8_77114172_77114374_chr8_76201937_76202139_500bp
+chr8	76644960	76646169	+	NUMT_8_77557695_77557904_chr8_76645460_76645669_500bp
+chr8	97907580	97908655	+	NUMT_8_98920308_98920383_chr8_97908080_97908155_500bp
+chr9	129878360	129879416	+	NUMT_9_132641139_132641195_chr9_129878860_129878916_500bp
+chr9	18336144	18337233	+	NUMT_9_18336642_18336731_chr9_18336644_18336733_500bp
+chr9	18825578	18826628	+	NUMT_9_18826076_18826126_chr9_18826078_18826128_500bp
+chr9	33655403	33659630	+	NUMT_9_33655901_33655951_chr9_33655903_33655953_500bp|NUMT_9_33656633_33656990_chr9_33656635_33656992_500bp|NUMT_9_33657020_33657662_chr9_33657022_33657664_500bp|NUMT_9_33657749_33658251_chr9_33657751_33658253_500bp|NUMT_9_33658280_33659128_chr9_33658282_33659130_500bp
+chr9	34998644	34999794	+	NUMT_9_34999141_34999291_chr9_34999144_34999294_500bp
+chr9	5090743	5098896	+	NUMT_9_5091243_5091331_chr9_5091243_5091331_500bp|NUMT_9_5092095_5092261_chr9_5092095_5092261_500bp|NUMT_9_5092352_5092442_chr9_5092352_5092442_500bp|NUMT_9_5092634_5093005_chr9_5092634_5093005_500bp|NUMT_9_5093074_5093128_chr9_5093074_5093128_500bp|NUMT_9_5093204_5093442_chr9_5093204_5093442_500bp|NUMT_9_5093693_5094098_chr9_5093693_5094098_500bp|NUMT_9_5094373_5094530_chr9_5094373_5094530_500bp|NUMT_9_5094593_5094714_chr9_5094593_5094714_500bp|NUMT_9_5094850_5094954_chr9_5094850_5094954_500bp|NUMT_9_5094996_5095234_chr9_5094996_5095234_500bp|NUMT_9_5095532_5095650_chr9_5095532_5095650_500bp|NUMT_9_5096262_5096490_chr9_5096262_5096490_500bp|NUMT_9_5096512_5096652_chr9_5096512_5096652_500bp|NUMT_9_5097128_5098094_chr9_5097128_5098094_500bp|NUMT_9_5098296_5098396_chr9_5098296_5098396_500bp
+chr9	5099239	5101417	+	NUMT_9_5099739_5100019_chr9_5099739_5100019_500bp|NUMT_9_5100195_5100345_chr9_5100195_5100345_500bp|NUMT_9_5100368_5100598_chr9_5100368_5100598_500bp|NUMT_9_5100807_5100917_chr9_5100807_5100917_500bp
+chr9	5106546	5111199	+	NUMT_9_5107046_5107201_chr9_5107046_5107201_500bp|NUMT_9_5107545_5107683_chr9_5107545_5107683_500bp|NUMT_9_5107825_5107898_chr9_5107825_5107898_500bp|NUMT_9_5108236_5108403_chr9_5108236_5108403_500bp|NUMT_9_5108528_5108745_chr9_5108528_5108745_500bp|NUMT_9_5109299_5109493_chr9_5109299_5109493_500bp|NUMT_9_5109773_5109831_chr9_5109773_5109831_500bp|NUMT_9_5110107_5110257_chr9_5110107_5110257_500bp|NUMT_9_5110326_5110699_chr9_5110326_5110699_500bp
+chr9	77964684	77965844	+	NUMT_9_80580100_80580260_chr9_77965184_77965344_500bp
+chr9	78740511	78743993	+	NUMT_9_81355927_81356087_chr9_78741011_78741171_500bp|NUMT_9_81356253_81356634_chr9_78741337_78741718_500bp|NUMT_9_81356708_81356831_chr9_78741792_78741915_500bp|NUMT_9_81357246_81357345_chr9_78742330_78742429_500bp|NUMT_9_81357642_81357734_chr9_78742726_78742818_500bp|NUMT_9_81358140_81358409_chr9_78743224_78743493_500bp
+chr9	78810402	78811454	+	NUMT_9_81425818_81425870_chr9_78810902_78810954_500bp
+chr9	80563169	80566266	+	NUMT_9_83178584_83179111_chr9_80563669_80564196_500bp|NUMT_9_83179560_83179943_chr9_80564645_80565028_500bp|NUMT_9_83180018_83180182_chr9_80565103_80565267_500bp|NUMT_9_83180574_83180681_chr9_80565659_80565766_500bp
+chr9	82426891	82428529	+	NUMT_9_85042306_85042806_chr9_82427391_82427891_500bp|NUMT_9_85042830_85042944_chr9_82427915_82428029_500bp
+chr9	92108508	92112169	+	NUMT_9_94871290_94871404_chr9_92109008_92109122_500bp|NUMT_9_94871428_94871648_chr9_92109146_92109366_500bp|NUMT_9_94872268_94872433_chr9_92109986_92110151_500bp|NUMT_9_94872814_94872972_chr9_92110532_92110690_500bp|NUMT_9_94873047_94873176_chr9_92110765_92110894_500bp|NUMT_9_94873685_94873794_chr9_92111403_92111512_500bp|NUMT_9_94873885_94873951_chr9_92111603_92111669_500bp
+chr9	92538569	92540101	+	NUMT_9_95301351_95301619_chr9_92539069_92539337_500bp|NUMT_9_95301662_95301883_chr9_92539380_92539601_500bp
+chr9	64045337	64048893	+	NUMT_Un_gl000211_77390_78007_chr9_64045837_64046454_500bp|NUMT_Un_gl000211_78174_78297_chr9_64046621_64046744_500bp|NUMT_Un_gl000211_78465_78685_chr9_64046912_64047132_500bp|NUMT_Un_gl000211_78783_78908_chr9_64047230_64047355_500bp|NUMT_Un_gl000211_79457_79795_chr9_64047904_64048242_500bp|NUMT_Un_gl000211_79855_79946_chr9_64048302_64048393_500bp
+chrUn_GL000214v1	90334	92006	+	NUMT_Un_gl000214_90834_91388_chrUn_GL000214v1_90834_91388_500bp|NUMT_Un_gl000214_91449_91506_chrUn_GL000214v1_91449_91506_500bp
+chrUn_GL000218v1	14338	18020	+	NUMT_Un_gl000218_14838_14895_chrUn_GL000218v1_14838_14895_500bp|NUMT_Un_gl000218_14956_15540_chrUn_GL000218v1_14956_15540_500bp|NUMT_Un_gl000218_15613_15864_chrUn_GL000218v1_15613_15864_500bp|NUMT_Un_gl000218_16035_16255_chrUn_GL000218v1_16035_16255_500bp|NUMT_Un_gl000218_16353_16495_chrUn_GL000218v1_16353_16495_500bp|NUMT_Un_gl000218_17031_17369_chrUn_GL000218v1_17031_17369_500bp|NUMT_Un_gl000218_17429_17520_chrUn_GL000218v1_17429_17520_500bp
+chrX	102772691	102773771	+	NUMT_X_102028119_102028199_chrX_102773191_102773271_500bp
+chrX	102785510	102786607	+	NUMT_X_102040938_102041035_chrX_102786010_102786107_500bp
+chrX	102802424	102803481	+	NUMT_X_102057852_102057909_chrX_102802924_102802981_500bp
+chrX	102804880	102805926	+	NUMT_X_102060308_102060354_chrX_102805380_102805426_500bp
+chrX	102808907	102810385	+	NUMT_X_102064335_102064391_chrX_102809407_102809463_500bp|NUMT_X_102064504_102064556_chrX_102809576_102809628_500bp|NUMT_X_102064592_102064698_chrX_102809664_102809770_500bp|NUMT_X_102064762_102064813_chrX_102809834_102809885_500bp
+chrX	111416498	111417661	+	NUMT_X_110660226_110660281_chrX_111416998_111417053_500bp|NUMT_X_110660303_110660389_chrX_111417075_111417161_500bp
+chrX	126471204	126473784	+	NUMT_X_125605687_125606435_chrX_126471704_126472452_500bp|NUMT_X_125606450_125606715_chrX_126472467_126472732_500bp|NUMT_X_125606714_125607267_chrX_126472731_126473284_500bp
+chrX	126728548	126730226	+	NUMT_X_125863031_125863204_chrX_126729048_126729221_500bp|NUMT_X_125863339_125863709_chrX_126729356_126729726_500bp
+chrX	126730296	126732349	+	NUMT_X_125864779_125864915_chrX_126730796_126730932_500bp|NUMT_X_125865769_125865832_chrX_126731786_126731849_500bp
+chrX	143429881	143434610	+	NUMT_X_142518175_142518219_chrX_143430381_143430425_500bp|NUMT_X_142518275_142518346_chrX_143430481_143430552_500bp|NUMT_X_142518434_142518485_chrX_143430640_143430691_500bp|NUMT_X_142518655_142518762_chrX_143430861_143430968_500bp|NUMT_X_142519051_142519183_chrX_143431257_143431389_500bp|NUMT_X_142519654_142519895_chrX_143431860_143432101_500bp|NUMT_X_142520433_142520667_chrX_143432639_143432873_500bp|NUMT_X_142520754_142520826_chrX_143432960_143433032_500bp|NUMT_X_142521142_142521266_chrX_143433348_143433472_500bp|NUMT_X_142521414_142521512_chrX_143433620_143433718_500bp|NUMT_X_142521744_142521904_chrX_143433950_143434110_500bp
+chrX	143543299	143544343	+	NUMT_X_142631644_142631688_chrX_143543799_143543843_500bp
+chrX	15727231	15728409	+	NUMT_X_15745854_15746032_chrX_15727731_15727909_500bp
+chrX	26824434	26825508	+	NUMT_X_26843051_26843125_chrX_26824934_26825008_500bp
+chrX	5168340	5170699	+	NUMT_X_5086881_5087093_chrX_5168840_5169052_500bp|NUMT_X_5087516_5088240_chrX_5169475_5170199_500bp
+chrX	55038053	55039138	+	NUMT_X_55064986_55065071_chrX_55038553_55038638_500bp
+chrX	55178252	55184527	+	NUMT_X_55205185_55205511_chrX_55178752_55179078_500bp|NUMT_X_55206018_55206066_chrX_55179585_55179633_500bp|NUMT_X_55206221_55206414_chrX_55179788_55179981_500bp|NUMT_X_55206592_55206979_chrX_55180159_55180546_500bp|NUMT_X_55207544_55207846_chrX_55181111_55181413_500bp|NUMT_X_55207901_55208168_chrX_55181468_55181735_500bp|NUMT_X_55208301_55208642_chrX_55181868_55182209_500bp|NUMT_X_55208729_55208812_chrX_55182296_55182379_500bp|NUMT_X_55208837_55208944_chrX_55182404_55182511_500bp|NUMT_X_55208970_55209297_chrX_55182537_55182864_500bp|NUMT_X_55209413_55209494_chrX_55182980_55183061_500bp|NUMT_X_55209665_55210460_chrX_55183232_55184027_500bp
+chrX	62839587	62840637	+	NUMT_X_62059557_62059607_chrX_62840087_62840137_500bp
+chrX	62841012	62842870	+	NUMT_X_62060982_62061223_chrX_62841512_62841753_500bp|NUMT_X_62061587_62061840_chrX_62842117_62842370_500bp
+chrX	70125625	70126807	+	NUMT_X_69345975_69346157_chrX_70126125_70126307_500bp
+chrX	70126914	70128113	+	NUMT_X_69347264_69347463_chrX_70127414_70127613_500bp
+chrX	84403430	84404494	+	NUMT_X_83658938_83659002_chrX_84403930_84403994_500bp
+chrX	9805148	9806234	+	NUMT_X_9773688_9773774_chrX_9805648_9805734_500bp
+chrY	11131811	11135491	+	NUMT_Y_13287987_13288044_chrY_11132311_11132368_500bp|NUMT_Y_13288105_13288722_chrY_11132429_11133046_500bp|NUMT_Y_13288762_13288994_chrY_11133086_11133318_500bp|NUMT_Y_13289184_13289403_chrY_11133508_11133727_500bp|NUMT_Y_13289459_13289626_chrY_11133783_11133950_500bp|NUMT_Y_13289838_13289975_chrY_11134162_11134299_500bp|NUMT_Y_13290178_13290667_chrY_11134502_11134991_500bp
+chrY	11444934	11446013	+	NUMT_Y_13601110_13601189_chrY_11445434_11445513_500bp
+chrY	4344281	4345351	+	NUMT_Y_4212822_4212892_chrY_4344781_4344851_500bp
+chrY	8363457	8365025	+	NUMT_Y_8231998_8232078_chrY_8363957_8364037_500bp|NUMT_Y_8232401_8232566_chrY_8364360_8364525_500bp
+chrY	8366128	8367696	+	NUMT_Y_8234669_8234994_chrY_8366628_8366953_500bp|NUMT_Y_8235057_8235237_chrY_8367016_8367196_500bp
+chrY	8369036	8372748	+	NUMT_Y_8237577_8237649_chrY_8369536_8369608_500bp|NUMT_Y_8238256_8238353_chrY_8370215_8370312_500bp|NUMT_Y_8238380_8238604_chrY_8370339_8370563_500bp|NUMT_Y_8238806_8239068_chrY_8370765_8371027_500bp|NUMT_Y_8239282_8239365_chrY_8371241_8371324_500bp|NUMT_Y_8239386_8239557_chrY_8371345_8371516_500bp|NUMT_Y_8239611_8239705_chrY_8371570_8371664_500bp|NUMT_Y_8240078_8240289_chrY_8372037_8372248_500bp
+chrY	9141396	9142461	+	NUMT_Y_8979505_8979570_chrY_9141896_9141961_500bp

--- a/3rd-party-tools/aou_mito_single_sample/check_overlapping_homoplasmies.R
+++ b/3rd-party-tools/aou_mito_single_sample/check_overlapping_homoplasmies.R
@@ -1,0 +1,167 @@
+#!/usr/bin/env Rscript
+# 
+# Identifies variants that overlap other variants. If overlapping variants are found,
+# only the first longest allele is kept as this is likely to have the largest impact
+# on read mapping.
+#
+# USAGE: check_variant_bounds.R S_OUT MTVCF, NUCVCF, FORCE_NO_DUPES
+#
+args = commandArgs(trailingOnly=TRUE)
+library(data.table)
+
+get_ranges <- function(table) {
+  # Gets positions of each alleles start and end.
+  table[['pos_A1_start']] <- table[['POS']]
+  table[['pos_A1_end']] <- table[['POS']] + nchar(table[['REF']]) - 1
+  table[['pos_A2_start']] <- table[['POS']]
+  table[['pos_A2_end']] <- table[['POS']] + nchar(table[['ALT']]) - 1
+  table <- table[order(table[['pos_A1_start']]),c('CHROM','pos_A1_start', 
+                                                  'pos_A1_end', 'pos_A2_start', 'pos_A2_end', 'idx')]
+  return(table)
+}
+
+read_vcf <- function(path) {
+  # Reads a VCF. Ignores the header.
+  dt <- fread(path, skip = "#CHROM", header=T)
+  setnames(dt, '#CHROM','CHROM')
+  dt <- as.data.frame(dt)
+  dt[['idx']] <- seq_len(nrow(dt))
+  return(dt)
+}
+
+write_vcf <- function(x, path, s) {
+  # Writes a custom VCF.
+  x_out <- x[,c('CHROM','POS','ID','REF','ALT','QUAL','FILTER','INFO','FORMAT',s)]
+  if(nrow(x_out) > 0) {
+    x_out[['ID']] <- '.'
+    x_out[['QUAL']] <- '.'
+    x_out[['FILTER']] <- 'PASS'
+    x_out[['INFO']] <- '.'
+    x_out[['FORMAT']] <- '.'
+    x_out[[s]] <- '.'
+  }
+  names(x_out)[1] <- '#CHROM'
+  write('##fileformat=VCFv4.2', path)
+  write.table(x_out, file=path, append=T, sep='\t', quote=F, row.names=F)
+}
+
+check_overlap <- function(table, make_bins=F) {
+  # For each site in a given chromosome, checks if there are overlaps.
+  # ONLY WORKS PER-CHROMSOME. Makes no attempt at checking if multiple
+  # chromosomes are provided.
+  # make_bins=T makes this function produce "overlap IDs", thus allowing the output
+  # to be used to pull out all members of an overlapping set, rather than
+  # just outputting the variants that overlap with some independent set.
+  #
+  # OUTPUT: a vector of length nrow(table) containing nonzero overlap IDs for
+  # any overlapping variant sites
+  if(make_bins) {
+    overlaps <- rep(0, nrow(table))
+  } else {
+    overlaps <- rep(F, nrow(table))
+  }
+  if(nrow(table) < 1) return(overlaps)
+  cache_idx <- 1
+  bin_idx <- 1
+  for(idx in seq_along(table[['pos_A1_start']])) {
+    if(make_bins) {
+      if(overlaps[idx] != 0) {
+        this_bin_idx <- overlaps[idx]
+      } else {
+        this_bin_idx <- bin_idx
+      }
+    }
+    this_start <- table[['pos_A1_start']][idx]
+    this_end <- table[['pos_A1_end']][idx]
+    for(idx2 in cache_idx:nrow(table)) {
+      if(idx == idx2) next
+      else {
+        q_start <- table[['pos_A1_start']][idx2]
+        q_end <- table[['pos_A1_end']][idx2]
+        if(q_start > this_end) break
+        else if(q_end < this_start) {
+          cache_idx <- cache_idx + 1; next
+        } else {
+          if(make_bins) {
+            overlaps[idx] <- this_bin_idx
+            overlaps[idx2] <- this_bin_idx
+          } else {
+            overlaps[idx] <- T
+            overlaps[idx2] <- T
+          }
+        }
+      }
+    }
+    bin_idx <- bin_idx + 1
+  }
+  return(overlaps)
+}
+
+if(length(args) != 4) {
+  stop('ERROR: Must have 4 input arguments in the following order: S_OUT, MTVCF, NUCVCF, FORCE_NO_DUPES')
+}
+
+mt_in <- read_vcf(args[2])
+s <- names(mt_in)[10]
+mt_vcf <- get_ranges(mt_in)
+if(nrow(mt_vcf) > 0) {
+  split_mt <- split(mt_vcf, mt_vcf[['CHROM']])
+} else {
+  split_mt <- list('chrM'=mt_vcf)
+}
+tf_overlap <- unlist(lapply(split_mt, check_overlap))
+bin_id_overlap <- lapply(split_mt, check_overlap, make_bins=T)
+if (sum(unlist(bin_id_overlap) != 0) != sum(tf_overlap)) {
+  stop('ERROR: somehow the results from binning and T/F outputs from check_overlap disagree.')
+}
+if (any(tf_overlap)) { # if FORCE_NO_DUPES is enabled, fails here if there are overlaps
+  if(args[4]) {
+    stop(paste0('ERROR: Mito homoplasmies VCF has ', sum(tf_overlap), ' variants which are overlapping. This will produce malformed consensus results.'))
+  } else {
+    warning(paste0('WARNING: Mito homoplasmies VCF has ', sum(tf_overlap), ' variants which are overlapping. This will produce malformed consensus results.'))
+  }
+}
+write.table(data.frame(x=sum(tf_overlap)), paste0(args[1], ".mtdna_consensus_overlaps.txt"), quote=F, col.names=F, row.names=F)
+
+tabs_for_removal <- lapply(names(split_mt), function(x) { 
+  # For each chromosome, for each duplicate group, flags the non-first
+  # variant for removal. Ordering is based on the input VCF order.
+  tab <- split_mt[[x]]
+  tab[['binid']] <- bin_id_overlap[[x]]
+  tab <- tab[tab[['binid']] != 0,]
+  if(nrow(tab) == 0){
+    return(tab)
+  } else {
+    split_tab <- split(tab, tab[['binid']])
+    split_tab_f <- lapply(split_tab, function(x)x[x[['idx']] != min(x[['idx']]),])
+    return(do.call(rbind, split_tab_f))
+  }
+})
+tab_removal <- do.call(rbind, tabs_for_removal)
+t2 <- tab_removal[,c('pos_A1_start','idx','binid')]
+variants_for_removal <- merge(x=mt_in,y=t2,by="idx",all.y=TRUE)
+if(nrow(t2) != nrow(variants_for_removal)) {
+  stop('ERROR: Some variants are missing or duplicate in mito VCF or in VCF for removal.')
+}
+if(length(unique(variants_for_removal[['idx']])) != nrow(variants_for_removal)) {
+  stop('ERROR: Some variant IDs were duplicated.')
+}
+if(any(variants_for_removal[['POS']] != variants_for_removal[['pos_A1_start']])) {
+  stop('ERROR: duplicate variants do not have the same positions as the original variants.')
+}
+allbins <- unique(unlist(bin_id_overlap))
+allbins <- allbins[allbins != 0]
+if(any(!allbins %in% variants_for_removal[['binid']])) {
+  stop('ERROR: all duplicate bins must be represented in removal.')
+}
+if(sum(tf_overlap) - length(allbins) != nrow(variants_for_removal)) {
+  stop('ERROR: the number of variants to remove must be the total number of dupes - the number of bins.')
+}
+write_vcf(variants_for_removal, 'overlapping_variants_to_remove.vcf', s)
+
+nuc_vcf <- get_ranges(read_vcf(args[3]))
+tf_overlap <- unlist(lapply(split(nuc_vcf, nuc_vcf[['CHROM']]), check_overlap))
+if (any(tf_overlap)) {
+  warning(paste0('WARNING: nucDNA homoplasmies VCF has ', sum(tf_overlap), ' variants which are overlapping. This will produce malformed consensus results.'))
+}
+write.table(data.frame(x=sum(tf_overlap)), paste0(args[1], ".nucdna_consensus_overlaps.txt"), quote=F, col.names=F, row.names=F)

--- a/3rd-party-tools/aou_mito_single_sample/check_variant_bounds.R
+++ b/3rd-party-tools/aou_mito_single_sample/check_variant_bounds.R
@@ -1,0 +1,187 @@
+#!/usr/bin/env Rscript
+# 
+# Identifies variants that should fail because they span the edge of an interval
+# or because they overlap other variants. If overlapping variants are found,
+# only the first longest allele is kept as this is likely to have the largest impact
+# on read mapping.
+#
+# USAGE: check_variant_bounds.R VCF INTERVALS REJECTS
+#
+# 221104: updated to deal with 0-length variant callsets
+#
+args = commandArgs(trailingOnly=TRUE)
+library(data.table)
+
+## Helper functions
+get_ranges <- function(table) {
+  # Gets positions of each alleles start and end.
+  table[['pos_A1_start']] <- table[['POS']]
+  table[['pos_A1_end']] <- table[['POS']] + nchar(table[['REF']]) - 1
+  table[['pos_A2_start']] <- table[['POS']]
+  table[['pos_A2_end']] <- table[['POS']] + nchar(table[['ALT']]) - 1
+  table <- table[order(table[['pos_A1_start']]),c('CHROM','REF','ALT','pos_A1_start', 
+                                                  'pos_A1_end', 'pos_A2_start', 'pos_A2_end')]
+  return(table)
+}
+
+read_vcf <- function(path) {
+  # Reads a VCF. Saves the header and the VCF file.
+  header <- readLines(path)
+  header <- header[1:(grep('^#CHROM', header)[1]-1)]
+  dt <- fread(path, skip = "#CHROM", header=T)
+  setnames(dt, '#CHROM','CHROM')
+  return(list('table' = as.data.frame(dt), 'header' = header))
+}
+
+write_vcf <- function(tab, header, path) {
+  # Outputs a VCF file and includes a provided header.
+  nm <- names(tab)
+  nm[nm == 'CHROM'] <- '#CHROM'
+  header <- c(header, paste0(nm, collapse = '\t'))
+  if(nrow(tab) == 0) {
+    output <- header
+  } else {
+    data <- sapply(seq_len(nrow(tab)), function(x)paste0(unlist(tab[x,]), collapse='\t'))
+    output <- c(header, data)
+  }
+  writeLines(output, path)
+}
+
+assign_target <- function(chr, start, targets) {
+  # Maps a site to a target table. Throws an error if the site is not mapped
+  # to exactly one target.
+  tab_out <- targets[((targets[['chr']] == chr) & 
+                       (targets[['start']] <= start) &
+                       (targets[['end']] >= start)),]
+  if(nrow(tab_out) != 1) {
+    stop('ERROR: should have exactly 1 match.')
+  }
+  return(data.frame('name' = tab_out[['name']], 
+                    'start' = tab_out[['start']], 
+                    'end' = tab_out[['end']]))
+}
+
+make_var_id <- function(tab, pos) {
+  # Convert an imported VCF file into variant ID format.
+  return(paste(tab[['CHROM']], tab[[pos]], 
+               tab[['REF']], tab[['ALT']], sep=':'))
+}
+
+check_overlap <- function(table) {
+  # For each site in a given chromosome, checks if there are overlaps.
+  # ONLY WORKS PER-CHROMSOME. Makes no attempt at checking if multiple
+  # chromosomes are provided.
+  # This function always produces "overlap IDs", thus allowing the output
+  # to be used to pull out all members of an overlapping set, rather than
+  # just outputting the variants that overlap with some independent set.
+  #
+  # OUTPUT: a vector of length nrow(table) containing nonzero overlap IDs for
+  # any overlapping variant sites
+  overlaps <- rep(0, nrow(table))
+  id <- 1
+  incr <- F
+  if(nrow(table) < 1) return(overlaps)
+  cache_idx <- 1
+  for(idx in seq_along(table[['pos_A1_start']])) {
+    this_start <- table[['pos_A1_start']][idx]
+    this_end <- table[['pos_A1_end']][idx]
+    for(idx2 in cache_idx:nrow(table)) {
+      if(idx == idx2) next
+      else {
+        q_start <- table[['pos_A1_start']][idx2]
+        q_end <- table[['pos_A1_end']][idx2]
+        if(q_start > this_end) break
+        else if(q_end < this_start) {
+          cache_idx <- cache_idx + 1; next
+        } else {
+          overlaps[idx] <- id
+          overlaps[idx2] <- id
+          incr <- T
+        }
+      }
+    }
+    if (incr) { id <- id + 1; incr <- F }
+  }
+  return(overlaps)
+}
+
+make_failures <- function(tab) {
+  # For each set of overlapping variants, keep only one of the variants
+  # with the longest reference allele. 
+  # OUTPUT: failed variants as a vector in CHR:POS:REF:ALT format.
+  #
+  # TODO: currently does not do this per-chromosome, so theoretically
+  # if two sets have failed across two chromosomes these may be considered one
+  # set here. This is a conservative issue, producing loss of n-1 extra variants
+  # for each n sets that are merged. In practice, this issue has not arisen. This
+  # issue will not impact single-contig lists.
+  print('nucDNA overlapping variants:')
+  print(tab)
+  if(nrow(tab) == 0) return(vector('character',0))
+  else {
+    lens <- sapply(split(tab, tab[['dupe_idx']]), nrow)
+    if(any(lens == 1)) {
+      stop('ERROR: variants entering make_failures should be in sets of at least 2.')
+    }
+    new_tabs <- lapply(split(tab, tab[['dupe_idx']]), function(x) {
+      x[['len']] <- x[['pos_A1_end']] - x[['pos_A1_start']]
+      idx_max <- which(x[['len']] == max(x[['len']]))[1]
+      tf_not_max <- !(1:nrow(x) %in% idx_max)
+      return(x[tf_not_max,])
+    })
+    lens_new <- sapply(new_tabs, nrow)
+    if (!all(lens_new + 1 == lens)) {
+      stop('ERROR: issues with make_failures result in unexpected number of drops.')
+    }
+    return(make_var_id(rbindlist(new_tabs), 'pos_A1_start'))
+  }
+}
+
+## Verify arguments
+if(length(args) != 3) {
+  stop('ERROR: Must have 3 input arguments in the following order: VCF INTERVALS REJ')
+}
+
+## Get failures which are out of bounds of the intervals file
+nuc_vcf <- read_vcf(args[1])
+
+## If there are no variants, then skip this whole thing and output the original VCF
+if (nrow(nuc_vcf[[1]]) == 0) {
+  print('No variant calls found.')
+  write_vcf(nuc_vcf[[1]], nuc_vcf[[2]], args[3])
+
+} else {
+  nuc_ranges <- get_ranges(nuc_vcf[[1]]) # ranges of each variant in the VCF
+  nuc_intervals <- read.table(args[2], comment.char='@', sep='\t', row.names = NULL,
+                              stringsAsFactors=F, col.names=c('chr','start','end','strand','name'))
+  if (nrow(nuc_intervals) == 0) {
+    stop('ERROR: Cannot square getting an intervals file with 0 records and actual variant calls.')
+  }
+  s_intervals <- split(nuc_intervals,nuc_intervals[['chr']])
+  res_tab <- lapply(1:nrow(nuc_ranges), function(x) { # maps of each variant in the VCF to the interval from which it comes from
+    assign_target(nuc_ranges[['CHROM']][x], nuc_ranges[['pos_A1_start']][x], 
+                  s_intervals[[nuc_ranges[['CHROM']][x]]]) 
+  })
+  res_tab <- rbindlist(res_tab)
+  failures <- nuc_ranges[(nuc_ranges[['pos_A1_start']] < res_tab[['start']]) | 
+                          (nuc_ranges[['pos_A1_end']] > res_tab[['end']]),]
+  failures <- make_var_id(failures, 'pos_A1_start')
+
+  ## Get sites which are overlapping
+  by_chr <- split(nuc_ranges, nuc_ranges[['CHROM']])
+  idx_dupe <- lapply(by_chr, check_overlap)
+  pos_dupe <- sapply(idx_dupe, function(x)any(x != 0))
+  filtered_dupe_list <- rbindlist(lapply(names(pos_dupe[pos_dupe]), function(x) {
+    tab <- by_chr[[x]]
+    tab[['dupe_idx']] <- idx_dupe[[x]]
+    return(tab)
+  }))
+  dupe_fails <- make_failures(filtered_dupe_list[filtered_dupe_list[['dupe_idx']] != 0,])
+  failures <- unique(c(dupe_fails, failures))
+
+  ## Output failed variants
+  print('Removing the following variants:')
+  print(failures) # contains duplicates and variants that span the boundary of the interval
+  write_vcf(nuc_vcf[[1]][make_var_id(nuc_vcf[[1]], 'POS') %in% failures,], nuc_vcf[[2]], args[3])
+}
+

--- a/3rd-party-tools/aou_mito_single_sample/fix_liftover_revised.py
+++ b/3rd-party-tools/aou_mito_single_sample/fix_liftover_revised.py
@@ -1,0 +1,2007 @@
+import hail as hl
+import pandas as pd
+import re
+import argparse
+import subprocess
+from copy import deepcopy
+from datetime import datetime
+hl._set_flags(no_whole_stage_codegen='1')
+
+
+NONREF = '<NON_REF>'
+NONINDEL = ['N','A','T','G','C', NONREF]
+MTREF = 'mt_GRCh38'
+META_KEYS = ['Description', 'Number', 'Type']
+
+
+def global_modify_meta(meta):
+    """
+    A global bookkeeping of how the metadata has been updated. All functions that modify the VCF make these changes.
+    Provide the original metadata to these functions and run this at the end, AFTER the metadata has
+    been trimmed for missing fields.
+    """
+    _, _, _, ROW_drop_fields, _, _, ENTRY_drop_fields = get_fields_for_flipping(meta)
+    meta = deepcopy(meta)
+    meta['format'].update({'OriginalSelfRefAlleles': {'Description': 'For allele individual pairs, these are the original alleles (called relative to self reference) which needed swapping for mapping to GRCh38.',
+                                                      'Number': 'R', 'Type': 'String'},
+                           'SwappedFieldIDs': {'Description': 'These fields were reversed in order (or flipped) when mapping from self reference back to GRCh38.',
+                                               'Number': '1', 'Type': 'String'}})
+    
+    info_dict = meta['info']
+    for x in ROW_drop_fields:
+        _ = info_dict.pop(x, None)
+    format_dict = meta['format']
+    for x in ENTRY_drop_fields:
+        _ = format_dict.pop(x, None)
+    meta.update({'info': info_dict, 'format': format_dict})
+
+    TLOD_entry = meta['info']['TLOD']
+    meta['info'].update({'TLOD': {'Description': TLOD_entry['Description'] + ' Set to missing for reversed alleles.',
+                                  'Number': TLOD_entry['Number'], 'Type': TLOD_entry['Type']}})
+
+    meta['filter'].update({'FailedPicardLiftoverVcf' : {'Description': 'If the variant failed LiftoverVCF.', 'Number': '1', 'Type': 'String'},
+                           'InsertionSharesForceCalledDeletion': {'Description': 'An insertion that ordinarily passes Liftover but shares its first base with a force called deletion (an insertion in GRCh38).',
+                                                'Number': '1', 'Type': 'String'},
+                           'InsertionSharesForceCalledInsertion': {'Description': 'An insertion that ordinarily passes Liftover but shares its first base with a force called insertion (a deletion in GRCh38).',
+                                                'Number': '1', 'Type': 'String'},
+                           'AddGRCh38RefDeleToRefSiteIns': {'Description': 'An insertion sharing a first base with GRCh38 deletion (force called insertion) resolved by replacing REF with the GRCh38 deletion REF. The self ref ALT must start with the same sequence as the GRCh38 REF. Should be fixed by left shifting.',
+                                                            'Number': '1', 'Type': 'String'},
+                           'ComplexSwapField': {'Description': 'In this instance, the self reference ALT allele was not the GRCh38 reference, so a more complicated approach was taken to reproduce the fields in SwappedFields. For insertions, this means constructing new ALT alleles.',
+                                                'Number': '1', 'Type': 'String'},
+                           'NewInsertionHaplotype': {'Description': 'Here, variants modified an insertion relative to GRCh38 (called reference in the self reference). To return to self reference, a custom haplotype was created here. ' +\
+                                                                    'For example, if the homoplasmic insertion on GRCh38 is A>ATG, and in the self reference calls we see a T>TA, we need to combine these to get a A>ATAG variant.',
+                                                     'Number': '1', 'Type':'String'},
+                           'SwapFirstAlleleIndel': {'Description': 'This variant is an indel in which the first site was reference in self reference but not in GRCh38. The first site was swapped to GRCh38.',
+                                                    'Number': '1', 'Type':'String'},
+                           'ReplaceInternalBaseDeletion': {'Description': 'This variant is a deletion in which some internal bases (e.g., not the first base) were replaced to match GRCh38.',
+                                                            'Number': '1', 'Type':'String'},
+                           'FancyFieldInversion': {'Description': 'Added to records which were reversed and for which AF is not just 1 minus original, but rather total minus original where total is 1 minus sum(AF) of all other variants at that site.',
+                                                   'Number': '1', 'Type':'String'},
+                           'DeletionSpannedHomoplasmicInsertion': {'Description': 'Added to records which are heteroplasmic deletions that spanned homoplasmic insertions on only one side.',
+                                                                   'Number': '1', 'Type':'String'},
+                           'LiftoverSuccessEntrySwap': {'Description': 'These are records which passed Liftover but shared a position with a homoplasmic indel and thus needed entry field swapping.',
+                                                        'Number': '1', 'Type':'String'},
+                           'ForceCalledHomoplasmy': {'Description': 'A homoplasmy in the self minus reference that was reversed and force minus called.',
+                                                     'Number': '1', 'Type':'String'},
+                           'LeftShiftedIndel': {'Description': 'An indel that was modified by bcftools norm.',
+                                                'Number': '1', 'Type': 'String'},
+                           'FailedDuplicateVariant' : {'Description': 'Variants that were lifted using custom pipeline but became duplicate with variants ' + \
+                                                                      'lifted successfully via Picard during custom LiftOver approach. ' + \
+                                                                      'We keep the Picard LiftOver variant and reject the one created via the custom pipeline. ' + \
+                                                                      'Currently only added to the rejected VCF (without error) if duplication ' + \
+                                                                      'occurs with a non homoplasmy that was left shifted. Locus is in self ref coordinates, alleles are ' + \
+                                                                      'the target alleles for GRCh38 (so may not be accurate for self reference!!!).', 
+                                                      'Number': '1', 'Type': 'String'}})
+
+    disallowed_chars = ['"', '-']
+    for k, v in meta.items():
+        for k2, v2 in v.items():
+            descr = v2['Description']
+            for char in disallowed_chars:
+                descr = descr.replace(char, ' ')
+            v2.update({'Description': descr})
+            v.update({k2: v2})
+        meta.update({k: v})
+    
+    return meta
+
+
+def global_consistancy_checks(mt, allow_NONREF, genome, debug):
+    # apply checks to info fields
+    if not debug and mt.aggregate_rows(hl.agg.any(mt.info.SwappedAlleles)):
+        raise ValueError('ERROR: at least one rejected row has SwappedAlleles set to True. This is abnormal and unsupported.')
+    
+    # AF field should never be NA
+    if not debug and mt.aggregate_entries(~hl.agg.all(hl.if_else(hl.all(mt.AF.map(hl.is_defined)),True,False,missing_false=True))):
+        raise ValueError('ERROR: AF should not contain any missing values.')
+
+    # apply checks to alleles
+    # alleles must all be length 2
+    if mt.aggregate_rows(~hl.agg.all(hl.len(mt.alleles) == 2)):
+        raise ValueError('ERROR: all alleles for swapping must have exactly 2 entries.')
+
+    # at least one allele should be non-INDEL
+    if mt.aggregate_rows(~hl.agg.all(hl.any(hl.map(lambda x: hl.literal(NONINDEL).contains(x), mt.alleles)))):
+        raise NotImplementedError('ERROR: only sites that have at least one non-INDEL allele are supported.')
+
+    # there should not be any duplicates
+    if mt.count_rows() != mt.rows().distinct().count():
+        raise ValueError('ERROR: input VCF should have distinct row keys. Duplicates found.')
+
+    # aside from NONREF, the first character of both alleles should be the same
+    has_nonref = hl.any(hl.map(lambda x: x == NONREF, mt.alleles))
+    same_first_character = mt.alleles[0][0] == mt.alleles[1][0]
+    is_indel = hl.any(hl.map(lambda x: ~hl.literal(NONINDEL).contains(x), mt.alleles))
+    if mt.aggregate_rows(~hl.agg.all(~is_indel | (has_nonref | same_first_character))):
+        raise ValueError('ERROR: All alleles, except NONREF, should share the same first character.')
+
+    # if NONREF is not allowed, throw an error if any NONREF alleles are found
+    if not allow_NONREF:
+        if mt.aggregate_rows(hl.agg.any(has_nonref)):
+            raise ValueError('ERROR: NON_REF calls are not allowed. Either re-check calling pipeline or set --allow-nonref.')
+    
+    # all reference alleles must match expectation
+    confirm_ref(mt, genome)
+
+
+def compatiblify_sample_name(s):
+    s = re.sub('[^A-Za-z0-9]{1,}', '', s)
+    if len(s) == 0:
+        return 'sref'
+    elif re.search('^[0-9]', s):
+        return 'X' + s
+    else:
+        return s
+
+
+def confirm_reference_indels(mt, indels):
+    indels = indels.annotate(self_ref_alleles = [indels.alt_allele, indels.ref_allele]).key_by('coord_s', 'self_ref_alleles')
+    indels_not_found = indels.anti_join(mt.rows())
+    if indels_not_found.count() > 0:
+        str_for_error = 'ERROR: The following self-reference based indels were expected to be found in the rejected Liftover variants set, but were not found:' + \
+            ', '.join((hl.str(indels_not_found.coord_s.position) + indels_not_found.alt_allele + indels_not_found.ref_allele).collect())
+        raise ValueError(str_for_error)
+
+
+def fai_to_len(fai):
+    with open(fai) as f:
+        line = f.readline()
+    return int(line.split('\t')[1])
+
+
+def get_nonkey_fields(ht):
+    return [x for x in ht.row if x not in ht.key]
+
+
+def transpose_locus(locus, by, ref):
+    """ Shifts a locus by "by" bases. by can be negative to shift backwards.
+    """
+    return hl.locus(locus.contig, locus.position+by, ref)
+
+
+def add_filter(mt, filter_name):
+    """
+    Adds a filter to all rows of an mt, removing PASS when present.
+    Throws an error if the filter was already present.
+    """
+    if mt.aggregate_rows(hl.agg.any(mt.filters.contains(filter_name))):
+        raise ValueError(f"ERROR: tried to add filter {filter_name} which was already present in a record.")
+    mt2 = mt.annotate_rows(filters = mt.filters.add(filter_name))
+    mt2 = mt2.annotate_rows(filters = mt2.filters.remove('PASS'))
+    return mt2
+
+
+def drop_info(mt, to_drop):
+    return mt.annotate_rows(info = mt.info.drop(*to_drop))
+
+
+def is_snv(mt):
+    """
+    Returns a BooleanExpression of rows that are SNVs.
+    """
+    return hl.all(mt.alleles.map(lambda x: hl.literal(NONINDEL).contains(x)))
+
+
+def is_insertion(table):
+    return hl.literal(NONINDEL).contains(table.alleles[0]) & ~hl.literal(NONINDEL).contains(table.alleles[1])
+
+
+def is_deletion(table):
+    return hl.literal(NONINDEL).contains(table.alleles[1]) & ~hl.literal(NONINDEL).contains(table.alleles[0])
+
+
+def get_fields_for_flipping(meta):
+    ROW_R_fields = [k for k,v in meta['info'].items() if v['Number'] == 'R']
+    ROW_BOOL_fields = ['SwappedAlleles']
+    ROW_custom_fields = {'AS_SB_TABLE':'\\|'} # in field : delimiter format
+    ROW_drop_fields = []
+    ENTRY_R_fields = [k for k,v in meta['format'].items() if v['Number'] == 'R']
+    ENTRY_1minus_fields = ['AF'] # assumes that these fields are entry Arrays
+    ENTRY_drop_fields = []
+
+    return ROW_R_fields, ROW_BOOL_fields, ROW_custom_fields, ROW_drop_fields, ENTRY_R_fields, ENTRY_1minus_fields, ENTRY_drop_fields
+
+
+def add_missing_new_entry_fields(mt):
+    to_add = ['OriginalSelfRefAlleles', 'SwappedFieldIDs']
+    if all([x not in mt.entry for x in to_add]):
+        mt2 = mt.annotate_entries(OriginalSelfRefAlleles = hl.missing('array<str>'),
+                                  SwappedFieldIDs = hl.missing('tstr'))
+    else:
+        raise NotImplementedError('add_missing_new_entry_fields() is only intended for adding fields to an mt without them.')
+    return mt2
+
+
+def enforce_corrected_spec_in_uncorrected_mt(mt, skip_entry_add=False):
+    if mt.count_rows() > 0:
+        raise NotImplementedError('enforce_corrected_spec_in_uncorrected_mt() is only intended for use on empty MatrixTables.')
+    mt2 = mt.key_rows_by().drop('locus','alleles','grch38_seq').rename({'locus_grch38':'locus'})
+    mt2 = mt2.annotate_rows(alleles = hl.missing('array<str>')).key_rows_by('locus','alleles')
+    if not skip_entry_add:
+        mt2 = add_missing_new_entry_fields(mt2)
+
+    return mt2
+
+
+def unify_dicts(dict1, dict2, to_keep):
+    """ Does NOT resolve if the values of each key in to_keep are the same. Throws an error.
+    """
+    dict1_copy = deepcopy(dict1)
+    dict2_copy = deepcopy(dict2)
+
+    to_keep_in_1 = [x for x in to_keep if x in dict1_copy.keys()]
+    to_keep_in_2 = [x for x in to_keep if x in dict2_copy.keys()]
+    to_keep_in_both = [x for x in to_keep_in_1 if x in to_keep_in_2]
+
+    # make sure overlaps are the same
+    if not all([dict1_copy[x][y] == dict2_copy[x][y] for x in to_keep_in_both for y in META_KEYS]):
+        raise ValueError('ERROR: overlapping values in metadata for success and failure VCF metadata are not the same.')
+    
+    dict_out = deepcopy(dict1_copy)
+    dict_out = {key: dict_out[key] for key in to_keep_in_1}
+    dict_out.update({key: dict_out[key] for key in to_keep_in_2})
+    return dict_out
+
+
+def unify_info(mt1, mt2, cols_to_keep):
+    # subset info to only the subset of cols_to_keep present in each
+    to_keep_in_1 = [x for x in cols_to_keep if x in mt1.info.keys()]
+    info1 = mt1.info.select(*to_keep_in_1)
+    to_keep_in_2 = [x for x in cols_to_keep if x in mt2.info.keys()]
+    info2 = mt2.info.select(*to_keep_in_2)
+
+    #force info1 to have all fields of interest
+    to_add_to_1 = [x for x in to_keep_in_2 if x not in to_keep_in_1]
+    info1_f = info1.annotate(**{x: hl.missing(info2[x].dtype) for x in to_add_to_1})
+    # force info2 to have the same spec as info1_f
+    info2_f = force_spec(info1_f, info2)
+    
+    mt1 = mt1.annotate_rows(info = info1_f)
+    mt2 = mt2.annotate_rows(info = info2_f)
+    return mt1.persist(), mt2.persist()
+
+
+def force_spec(reference, to_force):
+    """
+    Removes or adds fields to "to_force" so that the spec matches reference.
+    Assumes to_force and reference are structs.
+    """
+    to_add = {}
+    for col in reference.keys():
+        if col not in to_force.keys():
+            to_add.update({col: hl.missing(reference[col].dtype)})
+
+    to_force2 = to_force.annotate(**to_add)
+    return to_force2.select(*reference.keys())
+
+
+def read_mito_vcf(vcf, reference, avoid_dropping_gt=False, debug=False):
+    vcf_mt = hl.import_vcf(vcf, reference_genome=reference)
+    vcf_meta = hl.get_vcf_metadata(vcf)
+    if (not avoid_dropping_gt) and ('GT' in vcf_mt.entry):
+        vcf_mt = vcf_mt.drop('GT')
+        del vcf_meta['format']['GT']
+    if debug and 'AF' not in vcf_mt.entry:
+        vcf_mt = vcf_mt.annotate_entries(AF = hl.missing('array<float64>'))
+    return vcf_mt, vcf_meta
+
+
+def read_chain_file(chain_file, reference, self_reference):
+    """
+    Imports a chain file while ensuring that unsupported features are not found, namely:
+    - Chain files must have no breaks
+    - Chain files must always start at 0 in both source and target
+    - Single block chain files only
+    """
+    # confirm that the chain file does not have any offset starts or breaks
+    with open(chain_file) as f:
+        lines = f.readlines()
+    lines_filt = [line for line in lines if re.search('^chain', line)]
+    if len(lines_filt) != 1:
+        raise ValueError('ERROR: only single block chain files are currently supported.')
+    ls = [line.split() for line in lines_filt]
+    tf = [(linesplit[5] == "0") & (linesplit[10] == "0") for linesplit in ls]
+    if not all(tf):
+        raise ValueError('ERROR: chain file must start at 0 for both source and target.')
+
+    chain_in = pd.read_csv(chain_file, sep='\t', skiprows=1, names=['bases_in_block', 'ns', 'nt'])
+    chain_in.iat[chain_in.shape[0]-1, 1] = 0
+    chain_in.iat[chain_in.shape[0]-1, 2] = 0
+    chain_in['coord_s'] = chain_in.bases_in_block.cumsum() + chain_in.ns.shift(1).fillna(0).cumsum()
+    chain_in['coord_t'] = chain_in.bases_in_block.cumsum() + chain_in.nt.shift(1).fillna(0).cumsum()
+    chain_in = chain_in.astype(int)
+
+    if chain_in[(chain_in.ns > 0) & (chain_in.nt > 0)].shape[0] != 0:
+        raise ValueError('Chain files should not have breaks -- e.g., each ungapped block should be followed by a gap in EITHER the source or target, but not both.')
+
+    ht = hl.Table.from_pandas(chain_in)
+    ht = ht.annotate(coord_s = hl.locus('chrM', hl.int32(ht.coord_s), self_reference),
+                     coord_t = hl.locus('chrM', hl.int32(ht.coord_t), reference))
+    return ht
+
+
+def get_insertion_sites(ht, reference, self_reference):
+    """ Outputs locus-allele table of locations where insertions were made relative to reference genome.
+    Chain file should indicate how to convert from self_reference to reference.
+    """
+    ht2 = ht.filter(ht.ns > 0)
+    ht2 = ht2.annotate(ref_allele = hl.get_sequence('chrM', ht2.coord_t.position, 
+                                                    before=0, after=0, reference_genome=reference),
+                     alt_allele = hl.get_sequence('chrM', ht2.coord_s.position, 
+                                                  before=0, after=hl.int32(ht2.ns), reference_genome=self_reference))
+    
+    httest = ht2.annotate(tf = ht2.alt_allele.matches("^" + ht2.ref_allele))
+    if httest.aggregate(hl.agg.any(~httest.tf)):
+        raise ValueError('ERROR: found instance where the first allele of insertions in self-reference (relative to GRCh38) differs from the corresponding site in GRCh38. This does not make sense.')
+    
+    return ht2
+
+
+def get_deletion_sites(ht, reference, self_reference):
+    """ Outputs locus-allele table of locations where deletions were made relative to reference genome.
+    Chain file should indicate how to convert from self_reference to reference.
+    """
+    ht2 = ht.filter(ht.nt > 0)
+    ht2 = ht2.annotate(ref_allele = hl.get_sequence('chrM', ht2.coord_t.position, 
+                                                    before=0, after=hl.int32(ht2.nt), reference_genome=reference),
+                       alt_allele = hl.get_sequence('chrM', ht2.coord_s.position, 
+                                                    before=0, after=0, reference_genome=self_reference))
+
+    httest = ht2.annotate(tf = ht2.ref_allele.matches("^" + ht2.alt_allele))
+    if httest.aggregate(hl.agg.any(~httest.tf)):
+        raise ValueError('ERROR: found instance where the first allele of deletions in self-reference (relative to GRCh38) differs from the left-most nucleotide of the deleted seqeunce in GRCh38. This does not make sense.')
+    
+    return ht2
+
+
+def explode_indel(ht, locus_expr, len_expr, reference, target_name):
+    """ All provided expressions should refer to the INSERTION. Thus, if
+    the self genome has an insertion relative to GRCh38, provide expressions
+    corresponding to self.
+    """
+    ht2 = ht.annotate(tmp = hl.range(locus_expr.position, hl.int32(len_expr+locus_expr.position+1)),
+                      coord_end = hl.locus('chrM', hl.int32(len_expr+locus_expr.position), reference))
+    ht2 = ht2.explode('tmp')
+    ht2 = ht2.annotate(tmp = hl.locus('chrM', ht2.tmp, reference))
+    ht2 = ht2.annotate(tmp_2 = hl.get_sequence('chrM', ht2.tmp.position, 
+                                               before=0, after=0, reference_genome=reference))
+    ht2 = ht2.rename({'tmp': target_name, 'tmp_2': f'{target_name}_seq'}).key_by(target_name)
+
+    if ht2.count() != ht2.distinct().count():
+        raise ValueError('ERROR: When exploding indels, duplicate keys were created.')
+    
+    return ht2
+
+
+def dele_spans_insertion(mt, exploded_insertions, reference_genome, ignore_identical, filter_to_same_start_span_rhs=False, filter_to_lhs_span=False):
+    """ Returns a filtered (but otherwise unchanged) mt where rows span an insertion.
+    This means if that row has the start/end position outside the insertion and the other inside.
+    Some specific cases and expected behavior, for a reference insertion GRCh38 513 G>GCACA -> Self 513-517 GCACA
+    1. Self 503:ATCC>A --- not spanning
+    2. Self 509:CCCA>C --- not spanning
+    3. Self 509:CCCAG>C --- not spanning**
+    4. Self 511:CAGC>C --- spanning
+    5. Self 511:CAGCA>C --- spanning
+    6. Self 511:CAGCACA>G --- not spanning**
+    7. Self 511:CAGCACAC>G --- not spanning
+    8. Self 513:GCACA>G --- handled by ignore_identical
+    9. Self 513:GCACAC>G --- spanning
+    10. Self 513:GC>G --- not spanning
+    11. Self 516:CA>C --- not spanning
+    12. Self 517:ACA>A --- spanning
+    13. Self 518:CACA>C --- not spanning
+
+    We have tested this with the new filter_to_lhs_span flag. This flag returns cases where the start
+    of the deletion is upstream of the insertion; it will not return cases where the deletion
+    ends at the end of the insertion.
+
+    ignore_identical: if True, will filter out alleles in mt that are the same as the reference insertion
+    """
+    expl_tmp = exploded_insertions.annotate(is_in_insert = True)
+    dedup_expl = expl_tmp.key_by('coord_s', 'ref_allele', 'alt_allele').distinct().key_by('coord_s')
+    ht = mt.rows()
+    ht = ht.filter(hl.literal(NONINDEL).contains(ht.alleles[1]) & ~hl.literal(NONINDEL).contains(ht.alleles[0]))
+    
+    # for testing with K1481
+    # df = pd.DataFrame({'pos':[503,509,509,511,511,511,511,513,513,513,516,517,518],
+    #                    'ref':['ATCC','CCCA','CCCAG','CAGC','CAGCA','CAGCACA','CAGCACAC','GCACA','GCACAC','GC','CA','ACA','CACA'],
+    #                    'alt':['A','C','C','C','C','G','G','G','G','G','C','A','C']})
+    # ht_custom = hl.Table.from_pandas(df)
+    # ht = ht_custom.annotate(locus = hl.locus('chrM',hl.int32(ht_custom.pos),reference_genome), 
+    #                         alleles=[ht_custom.ref, ht_custom.alt]).key_by('locus','alleles')
+    # df_dedup_expl = pd.DataFrame({'bases_in_block': [6], 'ns': [4], 'nt': [0], 
+    #                               'coord_s': [hl.locus('chrM', 513, reference_genome=reference_genome)],
+    #                               'coord_t': [hl.locus('chrM', 513, reference_genome='GRCh38')],
+    #                               'coord_end': [hl.locus('chrM', 517, reference_genome=reference_genome)],
+    #                               'ref_allele': ['a'], 'alt_allele': ['b'],
+    #                               'is_in_insert': [True]})
+    # dedup_expl = hl.Table.from_pandas(df_dedup_expl).key_by('coord_s')
+    # expl_tmp = dedup_expl.annotate(sites = hl.map(lambda x: hl.locus('chrM', x, reference_genome=reference_genome), hl.range(513, 513+5)))
+    # expl_tmp = expl_tmp.explode('sites').key_by('sites')
+    
+    if ignore_identical:
+        dedup_for_filt = dedup_expl.annotate(alleles = [dedup_expl.alt_allele, dedup_expl.ref_allele]).key_by('coord_s','alleles')
+        ht = ht.anti_join(dedup_for_filt)
+    ht = ht.annotate(dele_start = ht.locus)
+    ht = ht.annotate(dele_end = hl.locus('chrM', ht.dele_start.position + hl.len(ht.alleles[0]) - 1, reference_genome=reference_genome))
+    if ht.aggregate(~hl.agg.all(hl.is_defined(ht.dele_start) & hl.is_defined(ht.dele_end))):
+        raise ValueError('ERROR: Deletion start and end coordinates in self-reference came up as undefined.')
+    ht = ht.annotate(start_in = expl_tmp[ht.dele_start].is_in_insert, end_in = expl_tmp[ht.dele_end].is_in_insert,
+                     start_at = dedup_expl[ht.dele_start].is_in_insert, end_at = (dedup_expl.key_by('coord_end'))[ht.dele_end].is_in_insert,
+                     end_at_start = dedup_expl[ht.dele_end].is_in_insert).persist()
+    if filter_to_same_start_span_rhs:
+        tf_rhs = hl.is_defined(ht.start_at) & ~hl.is_defined(ht.end_at) & ~hl.is_defined(ht.end_in)
+        ht = ht.filter(tf_rhs)
+    elif filter_to_lhs_span:
+        tf_lhs = ~hl.is_defined(ht.start_in) & ~hl.is_defined(ht.start_at) & hl.is_defined(ht.end_in) & ~(hl.is_defined(ht.end_at) | hl.is_defined(ht.end_at_start))
+        ht = ht.filter(tf_lhs)
+    else:
+        tf_basic = (hl.is_defined(ht.start_in) & ~hl.is_defined(ht.end_in)) | \
+                    (~hl.is_defined(ht.start_in) & hl.is_defined(ht.end_in)) | \
+                    (hl.is_defined(ht.start_at) & hl.is_defined(ht.end_at))
+        tf_extra = ~hl.is_defined(ht.start_at) & ~hl.is_defined(ht.start_in) & \
+                (hl.is_defined(ht.end_at) | hl.is_defined(ht.end_at_start))
+        ht = ht.filter(tf_basic & ~tf_extra)
+    return mt.semi_join_rows(ht)
+
+
+def get_ref_locus_end(locus, allele, exploded_insertions, self_ref, ref):
+    """ Gets the end position of a self-ref allele in ref coordinates.
+    Also explicitly accounts for the case where the end of the allele is the end of
+    an insertion relative to reference.
+    """
+    exploded_insertions_dedup = exploded_insertions.key_by('coord_end').distinct()
+    self_ref_position_last_base = locus.position + hl.len(allele) - 1
+    self_ref_locus_last_base = hl.locus('chrM', self_ref_position_last_base, reference_genome=self_ref)
+    last_base_is_insertion_end = hl.is_defined(exploded_insertions_dedup[self_ref_locus_last_base])
+    locus_last_base_ref = hl.if_else(last_base_is_insertion_end, 
+                                     transpose_locus(hl.liftover(transpose_locus(self_ref_locus_last_base, 1, self_ref), ref), -1, ref),
+                                     hl.liftover(self_ref_locus_last_base, ref))
+    return locus_last_base_ref
+
+
+def check_missing_row_field(mt, expr):
+    if re.search('^array<.+>$', str(expr.dtype)):
+        # this is an array
+        return mt.aggregate_rows(hl.agg.any(hl.any(hl.map(lambda x: hl.is_defined(x), expr))))
+    else:
+        return mt.aggregate_rows(hl.agg.any(hl.is_defined(expr)))
+
+
+def inject_success_variants_to_fix(failed_mt, success_mt, homoplasmies_ht, self_ref):
+    """ Scans success mt for any variants that should actually fail.
+    These approaches are bespoke, and will have to be added on a case-by-case basis.
+    Currently supported:
+    - If an insertion is present at the first base of a force-called deletion
+    - If an insertion is present at the first base of a force-called insertion
+
+    NOTE this expects that failed_mt and success_mt share the same spec
+    """
+    success_mt = success_mt.annotate_rows(locus_self = hl.liftover(success_mt.locus, self_ref))
+    success_mt = success_mt.key_rows_by('locus_self')
+    n_original_success = success_mt.count_rows()
+    n_original_failed = failed_mt.count_rows()
+    n_changed = 0
+
+    if success_mt.aggregate_rows(~hl.agg.all(hl.is_defined(success_mt.locus) & hl.is_defined(success_mt.alleles) & hl.is_defined(success_mt.locus_self))):
+        raise ValueError('Success MT must have defined locus, alleles, and self lifted locus.')
+    
+    # insertion present at the first base of a force-called deletion
+    force_called_dele = homoplasmies_ht.filter(is_deletion(homoplasmies_ht))
+    force_called_dele = force_called_dele.key_by()
+    success_mt_f1 = success_mt.filter_rows(is_insertion(success_mt)).semi_join_rows(force_called_dele.key_by('locus'))
+    success_mt_f1_merge = success_mt_f1.key_rows_by().drop('locus').rename({'locus_self':'locus'})
+    success_mt_f1_merge = success_mt_f1_merge.select_rows(*[x for x in failed_mt.row]).key_rows_by('locus','alleles')
+    failed_mt = failed_mt.union_rows(add_filter(success_mt_f1_merge, 'InsertionSharesForceCalledDeletion'))
+    success_mt_tmp = success_mt.filter_rows(~is_insertion(success_mt))
+    success_mt = success_mt_tmp.union_rows(success_mt.filter_rows(is_insertion(success_mt)).anti_join_rows(force_called_dele.key_by('locus')))
+    n_changed+=success_mt_f1.count_rows()
+
+    # insertion is at the first base of a force-called insertion (reference deletion)
+    # NOTE we currently only deal with a very specific case of insertion success spike-in. It must:
+    # - be mapped to a reference deletion (e.g., share a locus)
+    # - share the same first base as the reference deletion
+    # - if the reference deletion has a REF allele of length N, the first N bases of the ALT allele of the insertion should be identical to the reference deletion REF allele
+    # For example: REF HOM GCA > G and SELF HET G > GCACA -> GCA > GCACA -> G > GCA
+    # Others will be allowed in here, but will fail later.
+    force_called_ins = homoplasmies_ht.filter(is_insertion(homoplasmies_ht))
+    force_called_ins = force_called_ins.key_by()
+
+    success_mt_f2 = success_mt.filter_rows(is_insertion(success_mt)).semi_join_rows(force_called_ins.key_by('locus'))
+    success_mt_f2_merge = success_mt_f2.key_rows_by().drop('locus').rename({'locus_self':'locus'})
+    success_mt_f2_merge = success_mt_f2_merge.select_rows(*[x for x in failed_mt.row]).key_rows_by('locus','alleles')
+    failed_mt = failed_mt.union_rows(add_filter(success_mt_f2_merge, 'InsertionSharesForceCalledInsertion'))
+    success_mt_tmp = success_mt.filter_rows(~is_insertion(success_mt))
+    success_mt = success_mt_tmp.union_rows(success_mt.filter_rows(is_insertion(success_mt)).anti_join_rows(force_called_ins.key_by('locus')))
+    n_changed+=success_mt_f2.count_rows()
+
+    success_mt = success_mt.key_rows_by(*['locus','alleles']).drop('locus_self')
+    
+    # bookkeeping
+    n_final_success = success_mt.count_rows() 
+    n_final_failed = failed_mt.count_rows()
+    if n_original_success - n_final_success != n_changed:
+        raise ValueError('ERROR: Unexpected number of records lost from success MT when injecting success variants into failed MT.')
+    if n_final_failed - n_original_failed != n_changed:
+        raise ValueError('ERROR: Unexpected number of records gained in success MT when injecting success variants into failed MT.')
+    if n_final_failed + n_final_success != n_original_failed + n_original_success:
+        raise ValueError('ERROR: Records lost or gained when injecting success variants into failed MT.')
+    
+    return failed_mt.persist(), success_mt.persist(), n_changed
+
+
+def swap_alleles(mt, meta_file, allow_NONREF, log, fail_on_complex=False, suppress_complex_warning=False, original_self_alleles=None):
+    mt = mt.persist()
+    if mt.count_rows() == 0:
+        return enforce_corrected_spec_in_uncorrected_mt(mt), 0
+    
+    # identify fields with values per allele including reference (R) -- info fields to flip
+    ROW_R_fields, ROW_BOOL_fields, ROW_custom_fields, _, ENTRY_R_fields, ENTRY_1minus_fields, _ = get_fields_for_flipping(meta_file)
+    
+    # grch38 coordinates must be defined
+    if mt.aggregate_rows(~hl.agg.all(hl.is_defined(mt.locus_grch38) & hl.is_defined(mt.grch38_seq))):
+        raise ValueError('ERROR: GRCh38 locus and sequence at every site for swap must be defined.')
+    # the current reference must not be the grch38 reference
+    if mt.aggregate_rows(~hl.agg.all(mt.alleles[0] != mt.grch38_seq)):
+        raise ValueError('ERROR: GRCh38 sequence matches self-reference sequence at >1 site, which makes no sense given these are tagged as MismatchedRefAllele.')
+    # the current alternate should either be <NON_REF> or the grch38 reference
+    # if not, a warning will be raised as this CAN happen when a self-reference changed allele is altered
+    straightforward_case = [NONREF, mt.grch38_seq] if allow_NONREF else [mt.grch38_seq]
+    mt = mt.annotate_rows(to_test = straightforward_case)
+    ct_fail_alt = mt.filter_rows(~mt.to_test.contains(mt.alleles[1])).count_rows()
+    if ct_fail_alt > 0:
+        warn_str = 'WARNING: ' + str(ct_fail_alt) + ' self-reference alternate sites did not match the GRCh38 reference.'
+        if fail_on_complex:
+            raise ValueError(warn_str + ' This is not supported.')
+        else:
+            if not suppress_complex_warning:
+                print(warn_str + ' We will replace the reference with GRCh38 and replace the array fields with corresponding values from reference calls.', file=log)
+        # this identifies specific locus / allele pairs with issues
+        # locus/allele pairs without isssue will be sent to the straightforward pipeline
+        loci_of_issue = mt.filter_rows(~mt.to_test.contains(mt.alleles[1])).rows()        
+        # meanwhile, here we get any site sharing a locus with the problematic sites
+        loci_of_issue_2 = loci_of_issue.annotate(tf_issue=True)
+        mt_with_issue = mt.key_rows_by('locus').semi_join_rows(loci_of_issue.key_by('locus')).key_rows_by('locus','alleles')
+        mt_with_issue = mt_with_issue.annotate_rows(row_with_issue = hl.is_defined(loci_of_issue_2[mt_with_issue.row_key].tf_issue))
+        
+        # Now deal with other fields: for each locus, does the reference get called?
+        # GRCh38 reference will only be called in the ALT position (asserted above)
+        # if so, pull them from there
+        mt_with_issue = mt_with_issue.annotate_rows(grch38_is_called = mt_with_issue.grch38_seq == mt_with_issue.alleles[1])
+        
+        # if not, throw an error -- forcing calls at all reference sites should ensure this does NOT happen
+        ht_ref_specified = mt_with_issue.group_rows_by(mt_with_issue.locus).aggregate(n_with_grch38 = hl.agg.sum(~mt_with_issue.grch38_is_called)).entries()
+        n_ref_not_specified = ht_ref_specified.filter(ht_ref_specified.n_with_grch38 == 0).count()
+        if n_ref_not_specified > 0:
+            raise ValueError('ERROR: ' + str(n_ref_not_specified) + ' sites with non-GRCh38 ALT calls have no GRCh38 calls anywhere. This should never happen as long as reference alleles were force called with Mutect.')
+        
+        # for each locus, identify the right site from which to pull data
+        loci_with_grch38_called = mt_with_issue.filter_rows(mt_with_issue.grch38_is_called).key_rows_by('locus')
+        loci_with_grch38_called = loci_with_grch38_called.annotate_rows(row_found = True)
+
+        # confirm that loci_with_grch38_called has one row per original site
+        n_failed = loci_of_issue.key_by('locus').anti_join(loci_with_grch38_called.rows()).count() > 0
+        if n_failed > 0:
+            raise ValueError('ERROR: ' + str(n_failed) + ' sites on self-reference did not have either a ' + NONREF + ' call or an ALT matching GRCh38.')
+
+        # update the mt
+        mt_with_issue = mt_with_issue.annotate_rows(flipped_row_data = loci_with_grch38_called.rows()[mt_with_issue.locus])
+        mt_with_issue = mt_with_issue.annotate_entries(flipped_entries = loci_with_grch38_called[mt_with_issue.locus, mt_with_issue.col_key])
+        mt_with_issue = mt_with_issue.annotate_rows(updated_alleles = [mt_with_issue.grch38_seq, mt_with_issue.alleles[1]])
+        
+        # remove rows found in mt as these will be processed in the straightforward pipeline
+        mt = mt.anti_join_rows(loci_of_issue)
+        mt_with_issue = mt_with_issue.anti_join_rows(mt.rows())
+
+
+        mt_with_issue = complex_swap_field(mt_with_issue, ROW_BOOL_fields=ROW_BOOL_fields, ROW_R_fields=ROW_R_fields, 
+                                           ROW_custom_fields=ROW_custom_fields, ENTRY_R_fields=ENTRY_R_fields, 
+                                           flipped_idx=1, skip_locus_change=False, original_self_alleles=original_self_alleles)
+        mt_with_issue = mt_with_issue.drop('to_test', 'row_with_issue', 'grch38_is_called', 'grch38_seq')
+
+    # for the straightforward cases:
+    # remove '<NON_REF>' records if there is another option available
+    htr = mt.rows()
+    n_per_allele = htr.group_by(htr.locus).aggregate(count_loc = hl.agg.count())
+    possible_ns = list(n_per_allele.aggregate(hl.agg.collect_as_set(n_per_allele.count_loc)))
+    if any([x not in [1, 2] for x in possible_ns]):
+        raise ValueError('ERROR: the straightforward case pipeline should only see at most 2 records per locus (one from ' + NONREF + 'and one from GRCh38).')
+    mt = mt.annotate_rows(n_per_locus = n_per_allele[mt.locus].count_loc)
+    mt = mt.filter_rows((mt.n_per_locus == 2) & (mt.alleles[1] == NONREF), keep=False)
+
+    # change alleles
+    mt = mt.annotate_rows(new_alleles = [mt.grch38_seq, mt.alleles[0]])
+    mt = mt.annotate_entries(OriginalSelfRefAlleles = mt.alleles if original_self_alleles is None else mt[original_self_alleles])
+    mt = mt.key_rows_by().drop(*['locus','alleles']).rename({'locus_grch38': 'locus', 'new_alleles':'alleles'}).key_rows_by('locus','alleles')
+
+    # swap info fields
+    # anything that gets reversed has a TLOD that is not longer interpretable
+    info_str = mt.info.annotate(**{x: ~mt.info[x] for x in ROW_BOOL_fields})
+    info_str = info_str.annotate(**{x: hl.reversed(info_str[x]) for x in ROW_R_fields})
+    info_str = info_str.annotate(**{k: hl.literal(re.sub('\\\\','',v)).join(hl.reversed(info_str[k].split(v))) for k,v in ROW_custom_fields.items()})
+    if 'TLOD' in info_str.keys():
+        info_str = info_str.annotate(TLOD = hl.missing(info_str.TLOD.dtype))
+    mt = mt.annotate_rows(info = info_str)
+
+    # swap entry fields -- this is the only place 1-entry occurs!
+    mt = mt.annotate_entries(**{x: hl.map(lambda x: 1-x, mt[x]) for x in ENTRY_1minus_fields})
+    mt = mt.annotate_entries(**{x: hl.reversed(mt[x]) for x in ENTRY_R_fields})
+    mt = mt.drop('grch38_seq', 'to_test', 'n_per_locus')
+    mt = mt.annotate_entries(SwappedFieldIDs = ','.join([*ROW_BOOL_fields, *ROW_R_fields, *list(ROW_custom_fields.keys()), *ENTRY_R_fields, *['1-' + x for x in ENTRY_1minus_fields]]))
+
+    if ct_fail_alt > 0:
+        mt = mt.union_rows(mt_with_issue)
+
+    return mt, ct_fail_alt
+
+
+def fix_ref_insertions(mt, mt_meta, insertions_in, self_reference, allow_NONREF, log):
+    mt = mt.persist()
+    if mt.count_rows() == 0:
+        return enforce_corrected_spec_in_uncorrected_mt(mt.drop('is_reversed_grch38_to_self')), 0
+    
+    mt = mt.annotate_rows(locus_grch38 = insertions_in[mt.locus].coord_t,
+                          grch38_seq = insertions_in[mt.locus].ref_allele,
+                          self_ref_insertion_seq = insertions_in[mt.locus].alt_allele,
+                          start_coord_self_ref = insertions_in[mt.locus].coord_s,
+                          end_coord_self_ref = insertions_in[mt.locus].coord_end)
+
+    # checks
+    # verifying the sites tagged as being reference
+    if mt.aggregate_rows(~hl.agg.all(mt.is_reversed_grch38_to_self == ((mt.start_coord_self_ref == mt.locus) & (hl.reversed(mt.alleles) == [mt.grch38_seq, mt.self_ref_insertion_seq])))):
+        raise ValueError('ERROR: the sites where expected reference is the same as the reversed self-ref site are not the same as those annotated with is_reversed_grch38_to_self.')
+    # ensuring that all sites with shared locus as the reference insertion have the same first base
+    mt_test = mt.filter_rows(mt.start_coord_self_ref == mt.locus)
+    mt_test = mt_test.annotate_rows(per_site_unique_first_base = hl.set(mt_test.alleles.map(lambda x: x[0])))
+    if mt_test.aggregate_rows(~hl.agg.all(mt_test.per_site_unique_first_base.length() == 1)):
+        raise ValueError('ERROR: Each row should have alleles with the same first character.')
+    mt_test = mt_test.annotate_rows(per_site_unique_first_base = hl.array(mt_test.per_site_unique_first_base)[0])
+    mt_test_rows = mt_test.rows()
+    ht_first_base_locus = mt_test_rows.group_by(mt_test_rows.locus
+                                     ).aggregate(unique_first_base = hl.agg.collect_as_set(mt_test_rows.per_site_unique_first_base))
+    if ht_first_base_locus.aggregate(~hl.agg.all(ht_first_base_locus.unique_first_base.length() == 1)):
+        raise ValueError('ERROR: All sites at the same locus as the self-ref insertion relative to GRCh38 should have the same first character of both alleles.')
+    mt_test = mt_test.filter_rows(~mt_test.is_reversed_grch38_to_self)
+    # heteroplasmies sharing the same first site as a homoplasmic insertion (grch38) are supported only if they are indels
+    if mt_test.count_rows() > 0:
+        # we now allow heteroplasmic insertions that share the first site with a homoplasmic reference insertion
+        #if mt_test.aggregate_rows(hl.agg.any((hl.len(mt_test.alleles[1]) > 1) | (hl.len(mt_test.alleles[0]) == 1))):
+            #raise ValueError('ERROR: Only heteroplasmic deletions can be found at the first site of a left-aligned insertion (relative to GRCh38; deletion in self-reference). Investigate why this has happened here.')
+        print('NOTE: There is a heteroplasmic indel at the same starting position as a homoplasmic insertion relative to GRCh38.', file=log)
+    if allow_NONREF:
+        raise NotImplementedError('ERROR: allow_NONREF is not implemented for fix_ref_insertions, as we currently enforce one-to-one mapping between haplotypes and variants.')
+    ht_test = mt.group_rows_by(mt.locus_grch38).aggregate(n = hl.agg.count_where(mt.is_reversed_grch38_to_self)).entries()
+    if ht_test.aggregate(~hl.agg.all(ht_test.n == 1)):
+        raise ValueError('ERROR: Each GRCh38 locus should have exactly 1 variant that is classified as the reversed to-self-reference variant via is_reversed_grch38_to_self.')
+    
+    # produce haplotypes
+    ht_haplos = produce_pseudo_haplotypes(mt.rows(), 'locus_grch38', MTREF, self_reference)
+
+    # enforce a one-to-one mapping between haplotypes and self-reference variants
+    ht_haplos_ct = ht_haplos.group_by(*ht_haplos.key).aggregate(n = hl.agg.count())
+    if ht_haplos_ct.aggregate(~hl.agg.all(ht_haplos_ct.n == 1)):
+        raise ValueError('ERROR: Haplotype table should contain one entry per self-reference locus-allele pair.')
+    ht_haplos_grch38_ct = ht_haplos.group_by(ht_haplos.locus, ht_haplos.alleles).aggregate(n = hl.agg.count())
+    if ht_haplos_grch38_ct.aggregate(~hl.agg.all(ht_haplos_grch38_ct.n == 1)):
+        raise ValueError('ERROR: Haplotype table should contain one entry per unique haplotype.')
+    # confirm that grch38 reference information all makes sense
+    ht_haplos_pos0 = ht_haplos.group_by(ht_haplos.locus).aggregate(n = hl.agg.count_where(ht_haplos.position_0_source_of_alt_data))
+    if ht_haplos_pos0.aggregate(~hl.agg.all(ht_haplos_pos0.n == 1)):
+        raise ValueError('ERROR: position_0_source_of_alt_data should only be true for one variant per GRCh38 locus, denoting the reference allele.')
+    # ensure all sites in mt got a haplotype
+    if mt.anti_join_rows(ht_haplos).count_rows() > 0:
+        raise ValueError('ERROR: there are sites in the rejected variant list that did not get a haplotype when dealing with insertions relative to GRCh38.')
+    if ht_haplos.anti_join(mt.rows()).count() > 0:
+        raise ValueError('ERROR: there are created haplotypes that do not match the original sites for fixing insertions relative to GRCh38.')
+    
+    # add information to mt
+    mt = mt.annotate_rows(haplo_data = ht_haplos[mt.row_key])
+    
+    # produce warning regarding custom haplotypes and add filter
+    mt_custom_haplos = mt.filter_rows(~mt.haplo_data.position_0_source_of_alt_data)
+    n_new_haplotypes = mt_custom_haplos.count_rows()
+    if n_new_haplotypes > 0:
+        str_original = hl.str(mt_custom_haplos.locus.position) + ':' + hl.literal('>').join(mt_custom_haplos.alleles)
+        str_custom_haplos = hl.str(mt_custom_haplos.haplo_data.locus.position) + ':' + hl.literal('>').join(mt_custom_haplos.haplo_data.alleles)
+        str_join = ', '.join((str_original + ' -> ' + str_custom_haplos).collect())
+        print('WARNING: ' + str(n_new_haplotypes) + ' new GRCh38 ALT alleles were created due to variation influencing self-reference insertions relative to GRCh38.', file=log)
+        print('The new alleles are (self -> GRCh38): ' + str_join, file=log)
+        mt_custom_haplos = add_filter(mt_custom_haplos, 'NewInsertionHaplotype')
+        mt = mt.filter_rows(mt.haplo_data.position_0_source_of_alt_data).union_rows(mt_custom_haplos)
+
+    # reconfigure mt for swap_alleles -- for new haplos, ensure alt allele for new haplos is the desired alt allele and shift start position back to shared start for variant
+    mt = mt.annotate_rows(locus_grch38 = mt.haplo_data.locus)
+    mt = mt.annotate_rows(original_self_alleles = mt.alleles)
+    mt = mt.key_rows_by()
+    # swap alleles assumes that alleles[0] will not be the true reference
+    mt = mt.annotate_rows(fake_a0 = hl.if_else(mt.grch38_seq == 'G', 'A', 'G'))
+    mt = mt.annotate_rows(alleles = hl.if_else(mt.haplo_data.position_0_source_of_alt_data, mt.alleles, 
+                                               [mt.fake_a0, mt.haplo_data.alleles[1]]),
+                          locus = hl.if_else(mt.haplo_data.position_0_source_of_alt_data, mt.locus, 
+                                             mt.start_coord_self_ref)).key_rows_by('locus','alleles')
+    mt_res, n_complex_from_swap = swap_alleles(mt, mt_meta, allow_NONREF=allow_NONREF, log=log, fail_on_complex=False, suppress_complex_warning=True, original_self_alleles='original_self_alleles')
+    
+    # final checks
+    if n_complex_from_swap != n_new_haplotypes:
+        raise ValueError('ERROR: Expected that all new haplotypes created would be reported as a complex swap.')
+    if mt_res.aggregate_rows(~hl.agg.all(mt_res.haplo_data.locus == mt_res.locus)) | mt_res.aggregate_rows(~hl.agg.all(mt_res.haplo_data.alleles == mt_res.alleles)):
+        raise ValueError('ERROR: swap_alleles did not produce locus / allele pairs as expected.')
+
+    mt_res = mt_res.drop('self_ref_insertion_seq', 'start_coord_self_ref', 'end_coord_self_ref', 'is_reversed_grch38_to_self', 'haplo_data', 'original_self_alleles', 'fake_a0')
+    return mt_res, n_new_haplotypes
+
+
+def produce_pseudo_haplotypes(ht, incr, incr_reference, self_reference):
+    """ Takes a ht with locus, allele coding and produces all possible haplotypes given variants.
+    incr is used as the grouping mechanism -- rows with the same incr
+    are combined into haplotypes.
+
+    Assumes that within each incr, loci are provided sequentially.
+
+    Also outputs alternate alleles that go in to each haplotype. Useful for
+    deciding which fields to bin for recomputing INFO and FORMAT fields.
+
+    Assumes that any variant at the first site in an insertion is the self-reference > GRCh38 conversion.
+
+    NOTE In rare cases there may be a heteroplasmic variant located at the start site of the insertion (relative to GRCh38)
+    EXAMPLE: GRCh38 500 G > GCATA (96%) -> Self 500 GCATA > G with a GCA > G at 1%
+    Here we only support deletions -- insertions and SNVs (500 G > GT or 500 G > A) should be resolved with traditional Liftover
+    NOTE In the above case, swapping Self 500 GCATA > G back to G > GCATA simply involves flipping alleles
+    However, flipping alleles in GCA > G is inapppropriate because this G is not the same as reference G at this site; implicitly its G for GTA (the rest of the homoplasmic insertion).
+    Instead, we change GCA > G* (* = self-ref G) to G > GTA; GTA gets the same information as G* while G inherits GRCh38 G information.
+    """
+    ht = ht.key_by()
+    ht = ht.select(site = ht.locus.position,
+                   site_start = ht.start_coord_self_ref.position,
+                   site_end = ht.end_coord_self_ref.position,
+                   incr = ht[incr].position,
+                   alt_allele = ht.alleles[1],
+                   alleles = ht.alleles.filter(lambda x: x != NONREF),
+                   self_ref_insertion_seq = ht.self_ref_insertion_seq,
+                   is_reversed_grch38_to_self = ht.is_reversed_grch38_to_self)
+    df = ht.to_pandas()
+
+    # newdf = pd.DataFrame({'site':[205, 205, 206, 207, 208, 208], 'incr':205,
+    #                       'alt_allele':['T', 'T', 'C', 'ATC', 'C', 'T'], 
+    #                       'alleles':[['TCAA','T'], ['TCA', 'T'], ['CAA','C'],['A','ATC'], ['A', 'C'], ['A', 'T']], 
+    #                       'self_ref_insertion_seq':'TCAA',
+    #                       'site_start': [205, 205, 205, 205, 205 , 205],
+    #                       'site_end': [208, 208, 208, 208, 208, 208],
+    #                       'is_reversed_grch38_to_self': [True, False, False, False, False, False]})
+    # df = df.append(newdf)
+    df = df.sort_values(by='site', axis=0)
+
+    if not all((df.site_end - df.site_start + 1) == df.self_ref_insertion_seq.str.len()):
+        raise ValueError('ERROR: site_start and site_end must point to the coordinates of the first and last elements of the provided insertion.')
+    df_test = df.groupby(df['incr'], sort=False).agg(is_reversed_grch38_to_self=('is_reversed_grch38_to_self', lambda x: list(x)))
+    if not all(df_test.is_reversed_grch38_to_self.map(lambda x: sum(x)) == 1):
+        raise ValueError('ERROR: every GRCh38 site (incr) must have a single allele that is labeled is_reversed_grch38_to_self.')
+    df = df.groupby(df['site'], sort=False).agg(incr_position = ('incr', 'unique'),
+                                                alt_array=('alt_allele', lambda x: list(x)),
+                                                allele_array=('alleles', lambda x: list(x)),
+                                                is_reversed_grch38_to_self=('is_reversed_grch38_to_self', lambda x: list(x)),
+                                                self_ref_insertion_seq=('self_ref_insertion_seq', 'unique'),
+                                                site_start=('site_start','unique'),
+                                                site_end=('site_end','unique'))
+
+    if any(df.incr_position.apply(len) > 1) | any(df.self_ref_insertion_seq.apply(len) > 1) | any(df.site_start.apply(len) > 1) | any(df.site_end.apply(len) > 1):
+        raise ValueError('ERROR: you should have one incr_position, self_ref_insertion_seq, site_start, site_end per self locus.')
+    else:
+        df.incr_position = df.incr_position.apply(lambda x: x[0])
+        df.self_ref_insertion_seq = df.self_ref_insertion_seq.apply(lambda x: x[0])
+        df.site_start = df.site_start.apply(lambda x: x[0])
+        df.site_end = df.site_end.apply(lambda x: x[0])
+        df = df.reset_index()
+    
+    def replace_substring(series):
+        to_replace = series.self_ref_insertion_seq
+        if (len(series.alt_array) != len(series.allele_array)) | (len(series.alt_array) != len(series.is_reversed_grch38_to_self)):
+            raise ValueError('alt_array, allele_array, is_reversed_grch38_to_self must all have the same length.')
+        grch38_ref_holder = []
+        grch38_alt_holder = []
+        site_of_reference_holder = []
+        for alt, allele, is_rev_reference in zip(series.alt_array, series.allele_array, series.is_reversed_grch38_to_self):
+            if is_rev_reference:
+                if (series.site != series.site_start):
+                    raise ValueError('A reference allele should start at the same site as the start of the locus.')
+                grch38_ref_holder.append(alt[0])
+                grch38_alt_holder.append(to_replace)
+                site_of_reference_holder.append(True)
+            else:
+                to_replace_start = series.site - series.site_start
+                if to_replace_start == 0:
+                    # we now support heteroplasmic insertions
+                    #if (len(allele[0]) == 1) | (len(allele[1]) > 1):
+                        #raise ValueError('Only heteroplasmic deletions are supported at the first site of an insertion.')
+                    if (len(allele[0]) == 0) & (len(allele[1]) == 0):
+                        raise ValueError('Only heteroplasmic indels are supported at the first site of an insertion.')
+                to_replace_end = to_replace_start + len(allele[0])
+                if ((to_replace_start + len(allele[0])) > len(to_replace)) | ((to_replace_start == 0) & ((to_replace_start + len(allele[0])) == len(to_replace))):
+                    raise ValueError('Deletions should not be longer than the insertion they are contained within.')
+                grch38_ref_holder.append(to_replace[0])
+                grch38_alt_holder.append(to_replace[0:to_replace_start] + alt + to_replace[to_replace_end:])
+                site_of_reference_holder.append(False)
+        if len(set(grch38_ref_holder)) > 1:
+            raise ValueError('There should be only a single grch38 reference allele per site.')
+        else:
+            grch38_ref = grch38_ref_holder[0]
+        return {'grch38_ref': grch38_ref, 'grch38_alt': grch38_alt_holder, 'get_data_from_self_pos_0': site_of_reference_holder}
+
+    result_holder = df.apply(replace_substring, axis=1)
+    df['grch38_ref'] = result_holder.apply(lambda x: x['grch38_ref'])
+    df['grch38_alt'] = result_holder.apply(lambda x: x['grch38_alt'])
+    df['get_data_from_self_pos_0'] = result_holder.apply(lambda x: x['get_data_from_self_pos_0'])
+    df['paired_allele_alt'] = df.apply(lambda x: list(zip(x.grch38_alt, x.allele_array, x.get_data_from_self_pos_0)),1)
+    ht_new = hl.Table.from_pandas(df).explode('paired_allele_alt')
+    ht_new = ht_new.select(locus = hl.locus('chrM', hl.int32(ht_new.incr_position), incr_reference),
+                           alleles = [ht_new.grch38_ref, ht_new.paired_allele_alt[0]],
+                           locus_self_ref = hl.locus('chrM', hl.int32(ht_new.site), self_reference),
+                           alleles_self_ref = ht_new.paired_allele_alt[1],
+                           position_0_source_of_alt_data = ht_new.paired_allele_alt[2])
+    return ht_new.key_by('locus_self_ref','alleles_self_ref')
+
+
+def produce_ref_deletions_table(mt, deletions):
+    ht = mt.select_rows().select_entries('AD').entries().key_by('locus','alleles')
+    exploded_dele = explode_indel(deletions, deletions.coord_t, deletions.nt, MTREF, 'sites')
+    exploded_dele = exploded_dele.annotate(ref_alleles = [exploded_dele.ref_allele, exploded_dele.alt_allele])
+    exploded_dele = exploded_dele.key_by('sites', 'ref_alleles')
+    exploded_dele = exploded_dele.anti_join(ht).key_by('coord_t','ref_alleles')
+    exploded_dele = exploded_dele.annotate(DP = ht[exploded_dele.key].AD).key_by()
+    exploded_dele = exploded_dele.select(reference_position = exploded_dele.sites.position,
+                                         original_deletion_position = exploded_dele.coord_t.position,
+                                         ref_allele = exploded_dele.ref_alleles[0],
+                                         alt_allele = exploded_dele.ref_alleles[1],
+                                         ref_allele_depth = exploded_dele.DP[0],
+                                         alt_allele_depth = exploded_dele.DP[1])
+    return exploded_dele
+
+
+def make_first_indel_site_ref(mt, mt_meta, matching_homoplasmies, reference_coordinate_snvs, self_ref, ref, exploded_insertions, allow_NONREF):
+    mt = mt.persist()
+    if mt.count_rows() == 0:
+        return enforce_corrected_spec_in_uncorrected_mt(mt), add_missing_new_entry_fields(mt), 0
+    ROW_R_fields, ROW_BOOL_fields, ROW_custom_fields, _, ENTRY_R_fields, _, _ = get_fields_for_flipping(mt_meta)
+
+    reference_coordinate_snvs = reference_coordinate_snvs.annotate_rows(row_found=True)
+    mt = mt.annotate_rows(allele_lens = hl.map(lambda x: x.length(), mt.alleles))
+    mt = mt.annotate_rows(allele_idx_swap = mt.allele_lens.index(1)) # 0 indicates insertion
+    mt = mt.annotate_rows(grch38_array = [mt.grch38_seq, mt.alleles[mt.allele_idx_swap]]).key_rows_by('locus_grch38', 'grch38_array')
+    mt = mt.annotate_rows(flipped_row_data = reference_coordinate_snvs.rows()[mt.row_key])
+    mt = mt.annotate_entries(flipped_entries = reference_coordinate_snvs[mt.row_key, mt.col_key]).key_rows_by('locus', 'alleles')
+
+    if allow_NONREF:
+        raise argparse.ArgumentError('ERROR: allow_NONREF is currnetly not supported for make_first_indel_site_ref().')
+    if mt.aggregate_rows(~hl.agg.all(hl.is_defined(mt.allele_idx_swap))):
+        raise ValueError('ERROR: when procesing indels to alter the first site to reference, an allele of length 1 must always be present.')
+    if mt.aggregate_rows(~hl.agg.all(hl.is_defined(mt.locus_grch38) & hl.is_defined(mt.grch38_seq))):
+        raise ValueError('ERROR: GRCh38 locus and sequence at every site for swap must be defined.')
+    if mt.aggregate_rows(~hl.agg.all(hl.is_defined(mt.flipped_row_data))):
+        raise ValueError('ERROR: Must successfully obtain row data from homoplasmy table.')
+    # the current reference must not be the grch38 reference
+    if mt.aggregate_rows(~hl.agg.all(mt.alleles[mt.allele_idx_swap] != mt.grch38_seq)):
+        raise ValueError('ERROR: GRCh38 sequence matches self-reference single-site sequence at >1 site, which makes no sense given these have failed to Liftover and are in the first-site remapping pipeline.')
+    # ensure all loci in mt are in matching_homoplasmies
+    if mt.key_rows_by('locus').anti_join_rows(matching_homoplasmies.rows().key_by('locus')).count_rows() > 0:
+        raise ValueError('ERROR: All loci in input mt should have corresponding homoplasmies.')
+
+    # Prooduce new alleles
+    mt = mt.annotate_rows(updated_alleles = hl.map(lambda x: x.replace('^[A-Z]{1}', mt.grch38_seq), mt.alleles))
+    if mt.aggregate_rows(~hl.agg.all(hl.map(lambda x: x[0], mt.updated_alleles)[0] == hl.map(lambda x: x[0], mt.updated_alleles)[1])):
+        raise ValueError('ERROR: changing first site of indel did not produce matching first site in resultant alleles.')
+    mt = mt.annotate_rows(ref_end_position = get_ref_locus_end(mt.locus, mt.updated_alleles[0], exploded_insertions, self_ref, ref))
+    #mt = mt.annotate_rows(ref_end_position = hl.liftover(hl.locus('chrM', mt.locus.position + mt.updated_alleles[0].length() - 1, reference_genome=self_ref), ref))
+    if mt.aggregate_rows(~hl.agg.all(hl.is_defined(mt.ref_end_position))):
+        raise ValueError('ERROR: the end position of all REF allele should be liftover-compatible.')
+    mt = mt.annotate_rows(expected_ref = hl.get_sequence('chrM', mt.locus_grch38.position, before=0, after=mt.ref_end_position.position-mt.locus_grch38.position, reference_genome=ref))
+    
+    # Do swap
+    mt_new = complex_swap_field(mt, ROW_BOOL_fields=ROW_BOOL_fields, ROW_R_fields=ROW_R_fields, 
+                                ROW_custom_fields=ROW_custom_fields, ENTRY_R_fields=ENTRY_R_fields, 
+                                flipped_idx=0, skip_locus_change=True)
+    mt_new = mt_new.drop('grch38_array', 'allele_lens', 'ref_end_position')
+    mt_new = add_filter(mt_new, 'SwapFirstAlleleIndel')
+
+    # check if any deletions still need to have in-body SNPs fixed
+    mt_needs_fixing = mt_new.filter_rows(mt_new.expected_ref != mt_new.alleles[0])
+    if mt_needs_fixing.aggregate_rows(hl.agg.any(mt_needs_fixing.allele_idx_swap == 0)):
+        raise ValueError('ERROR: any records that have a different reference allele than GRCh38 must be deletions.')
+    mt_needs_fixing = mt_needs_fixing.drop('expected_ref', 'allele_idx_swap')
+    mt_needs_fixing = mt_needs_fixing.select_rows(*get_nonkey_fields(mt_needs_fixing.rows()))
+    n_for_in_body = mt_needs_fixing.count_rows()
+
+    # change locus
+    mt_new = mt_new.anti_join_rows(mt_needs_fixing.rows())
+    mt_new = mt_new.key_rows_by().drop('locus').rename({'locus_grch38': 'locus'}).key_rows_by('locus','alleles')
+    mt_new = mt_new.drop('allele_idx_swap', 'grch38_seq', 'expected_ref')
+
+    return mt_new, mt_needs_fixing, n_for_in_body
+
+
+def recode_deletion_allele(failed_candidates, piped_from_first_indel_site, exploded_insertions, reference, self_reference, 
+                           allow_NONREF, allow_spanning=False, override_processed=False, override_swap=False, self_homoplasmies=None, mt_meta=None):
+    """ This function does not change INFO/entry fields. See Notes on liftover field changes.md.
+    override_processed True indicates that alleles has already been processed into GRCh38.
+    """
+    if failed_candidates is not None: 
+        failed_candidates = failed_candidates.annotate_entries(OriginalSelfRefAlleles = failed_candidates.alleles,
+                                                               SwappedFieldIDs = hl.missing('tstr'))
+        mt = failed_candidates.union_rows(piped_from_first_indel_site)
+    else:
+        mt = piped_from_first_indel_site
+    if mt.count_rows() == 0:
+        return enforce_corrected_spec_in_uncorrected_mt(mt, skip_entry_add=True), mt, 0
+    
+    if allow_NONREF:
+        raise argparse.ArgumentError('ERROR: allow_NONREF is currently not supported for recode_deletion_allele().')
+    if mt.aggregate_rows(~hl.agg.all(is_deletion(mt))):
+        raise ValueError('All records input to recode_deletion_allele must be deletions.')
+    
+    # rows without GRCh38 locus defined fail
+    mt_failed = mt.filter_rows(~hl.is_defined(mt.locus_grch38))
+    mt = mt.filter_rows(hl.is_defined(mt.locus_grch38))
+
+    # rows containing a deletion that spans a reference insertion fail
+    if not allow_spanning:
+        mt_failed = mt_failed.union_rows(dele_spans_insertion(mt, exploded_insertions, self_reference, False))
+        mt = mt.anti_join_rows(dele_spans_insertion(mt, exploded_insertions, self_reference, False).rows())
+
+    # we now explicitly deal with the edge case of a deletion ending at the end of a reference insertion
+    if override_processed:
+        mt = mt.annotate_rows(locus_last_base_grch38 = hl.locus('chrM', mt.locus_grch38.position + hl.len(mt.alleles[0]) - 1, reference_genome=reference))
+    else:
+        mt = mt.annotate_rows(locus_last_base_grch38 = get_ref_locus_end(mt.locus, mt.alleles[0], exploded_insertions, self_reference, reference))
+    cols_to_rm = ['locus_last_base_grch38']
+
+    # rows without a defined grch38 position for the last base of the deletion fail
+    mt_failed = mt_failed.union_rows(mt.filter_rows(~hl.is_defined(mt.locus_last_base_grch38)).drop(*cols_to_rm)).persist()
+    mt = mt.filter_rows(hl.is_defined(mt.locus_last_base_grch38))
+
+    mt = mt.annotate_rows(candidate_grch38_allele = hl.get_sequence('chrM', mt.locus_grch38.position, 
+                                                                    before=0, after=mt.locus_last_base_grch38.position-mt.locus_grch38.position, 
+                                                                    reference_genome=reference))
+    cols_to_rm.append('candidate_grch38_allele')
+
+    # rows with no defined candidate allele or one of size 1 fail
+    mt_failed = mt_failed.union_rows(mt.filter_rows(~hl.is_defined(mt.candidate_grch38_allele) | (hl.len(mt.candidate_grch38_allele)<=1)).drop(*cols_to_rm))
+    mt = mt.filter_rows(hl.is_defined(mt.candidate_grch38_allele) & (hl.len(mt.candidate_grch38_allele)>1))
+
+    # rows where the first character of each allele are different fail
+    same_first_chars = (mt.candidate_grch38_allele[0] == mt.alleles[0][0]) & (mt.candidate_grch38_allele[0] == mt.alleles[1])
+    mt_failed = mt_failed.union_rows(mt.filter_rows(~same_first_chars).drop(*cols_to_rm))
+    mt = mt.filter_rows(same_first_chars)
+
+    # if candidate sequence is longer or shorter than original, this indicates indel was present
+    num_indel_in_dele = mt.aggregate_rows(hl.agg.count_where(hl.len(mt.alleles[0]) != hl.len(mt.candidate_grch38_allele)))
+
+    # store original alleles in OriginalSelfRefAlleles. No alleles have swapped info fields so SwappedFieldIDs remains.
+    mt = mt.annotate_entries(OriginalSelfRefAlleles = hl.if_else(hl.is_defined(mt.OriginalSelfRefAlleles), mt.OriginalSelfRefAlleles, mt.alleles))
+    mt = mt.annotate_rows(new_alleles = [mt.candidate_grch38_allele, mt.alleles[1]])
+    mt = mt.key_rows_by().drop('locus','alleles').rename({'new_alleles': 'alleles', 'locus_grch38': 'locus'}).key_rows_by('locus','alleles')
+    mt = add_filter(mt, 'ReplaceInternalBaseDeletion')
+    mt = mt.drop(*cols_to_rm, 'grch38_seq').persist()
+
+    # if the variant shares a start with any homoplasmy, we need to perform swap alleles
+    if not override_swap:
+        ref_homoplasmies = self_homoplasmies.annotate_rows(locus_ref = hl.liftover(self_homoplasmies.locus, reference)).key_rows_by('locus_ref')
+        ref_homoplasmies_indel = ref_homoplasmies.filter_rows(~is_snv(ref_homoplasmies))
+        ref_homoplasmies_indel = ref_homoplasmies_indel.annotate_rows(row_found = True)
+        ref_homoplasmies_snv = ref_homoplasmies.filter_rows(is_snv(ref_homoplasmies))
+
+        # there should not be any homoplasmic SNVs where REF matches the first base of this deletion -- this should already be taken care of
+        mt_shares_homoplasmic_snv = mt.key_rows_by('locus')
+        mt_shares_homoplasmic_snv = mt_shares_homoplasmic_snv.annotate_rows(mapped_alleles = ref_homoplasmies_snv.rows()[mt_shares_homoplasmic_snv.row_key].alleles)
+        mt_shares_homoplasmic_snv = mt_shares_homoplasmic_snv.filter_rows(hl.is_defined(mt_shares_homoplasmic_snv.mapped_alleles))
+        if mt_shares_homoplasmic_snv.aggregate_rows(~hl.agg.all(mt_shares_homoplasmic_snv.mapped_alleles[0][0] != mt_shares_homoplasmic_snv.alleles[1])):
+            raise ValueError('ERROR: Found some homoplasmic SNVs where the self-ref REF allele matches the deletion ALT allele in recode_deletion_allele().')
+        
+        mt_for_swap = mt.key_rows_by('locus').semi_join_rows(ref_homoplasmies_indel.rows())
+        mt_no_need = mt.key_rows_by('locus').anti_join_rows(ref_homoplasmies_indel.rows()).key_rows_by('locus','alleles')
+        
+        mt_for_swap = mt_for_swap.annotate_rows(flipped_row_data = ref_homoplasmies_indel.rows()[mt_for_swap.row_key])
+        mt_for_swap = mt_for_swap.annotate_entries(flipped_entries = ref_homoplasmies_indel[mt_for_swap.row_key, mt_for_swap.col_key]).key_rows_by('locus', 'alleles')
+        if mt_for_swap.aggregate_rows(~hl.agg.all(hl.is_defined(mt_for_swap.flipped_row_data.row_found))):
+            raise ValueError('ERROR: all candidates of successfully Liftedover loci for flipping must have mapped.')
+        if mt_for_swap.aggregate_entries(~hl.agg.all(~hl.is_defined(mt_for_swap.SwappedFieldIDs))):
+            raise ValueError('ERROR: SwappedFieldIDs should not be defined for variants that are candidates for flipping in recode_deletion_allele().')
+
+        ROW_R_fields, ROW_BOOL_fields, ROW_custom_fields, _, ENTRY_R_fields, _, _ = get_fields_for_flipping(mt_meta)
+        mt_for_swap_swapped = complex_swap_field(mt_for_swap, ROW_BOOL_fields=ROW_BOOL_fields, ROW_R_fields=ROW_R_fields,
+                                                 ROW_custom_fields=ROW_custom_fields, ENTRY_R_fields=ENTRY_R_fields, flipped_idx=1,
+                                                 skip_locus_change=True, skip_allele_change=True, original_self_alleles='OriginalSelfRefAlleles')
+
+        mt = mt_no_need.union_rows(mt_for_swap_swapped).persist()
+
+    return mt, mt_failed, num_indel_in_dele
+
+
+def complex_swap_field(mt, ROW_BOOL_fields, ROW_R_fields, ROW_custom_fields, ENTRY_R_fields, flipped_idx, skip_locus_change, original_self_alleles=None, skip_allele_change=False, keep_flipped_fields=False):
+    """ This function performes field ComplexSwapField swaps. This swap is characterized by
+    using the information from a mapped force-call allele to fill the REF position fields
+    for a given allele.
+
+    Expects that updated_alleles have already been computed for each bespoke application.
+    flipped_idx indicates which data point is used from flipped_row_data and flipped_entries.
+    """
+    if skip_locus_change and skip_allele_change:
+        # if both are enabled we are just changing INFO and ENTRY fields
+        row_reqd = ['info', 'flipped_row_data', 'locus', 'alleles']
+    elif skip_allele_change and not skip_locus_change:
+        raise ValueError('ERROR: complex_swap_field does not support skipping just allele change. Either skip locus change only, or skip both to just change INFO/ENTRY.')
+    else:
+        row_reqd = ['info', 'flipped_row_data', 'locus', 'alleles', 'locus_grch38', 'updated_alleles']
+    entry_reqd = ['flipped_entries']
+    
+    if not all([x in mt.row for x in row_reqd]) or not all([x in mt.entry for x in entry_reqd]):
+        raise ValueError('ERROR: The following row fields are required for input to complex_swap_field: ' + \
+                         ','.join(row_reqd) + ' and the following entry fields are required: ' + ','.join(entry_reqd))
+
+    # ensure annotations were found for all rows
+    if mt.aggregate_rows(~hl.agg.all(hl.is_defined(mt.flipped_row_data.row_found))):
+        raise ValueError('ERROR: The appropriate reference data was not found for all loci to be repaired.')
+
+    # edit rows
+    def custom_flip_expr(expr, replace, orientation=None):
+        """
+        Updated on 2/5/22 to ignore orientation and always replace the reference position with
+        reference data from "replace".
+        """
+        #return hl.if_else(hl.is_defined(expr), hl.if_else(orientation == 0, [replace[0], expr[1]], [expr[0], replace[0]]), expr)
+        return hl.if_else(hl.is_defined(expr), [replace[flipped_idx], expr[1]], expr)
+
+
+    info_str = mt.info.annotate(**{x: ~mt.info[x] for x in ROW_BOOL_fields})
+    info_str = info_str.annotate(**{x: custom_flip_expr(info_str[x], mt.flipped_row_data.info[x]) for x in ROW_R_fields})
+    ROW_custom_fields_dct = {}
+    for k, v in ROW_custom_fields.items():
+        new_val = hl.literal(re.sub('\\\\','',v)).join(custom_flip_expr(info_str[k].split(v), mt.flipped_row_data.info[k].split(v)))
+        ROW_custom_fields_dct.update({k: new_val})
+    info_str = info_str.annotate(**ROW_custom_fields_dct)
+    mt_new = mt.annotate_rows(info = info_str).persist()
+
+    # edit entries
+    mt_new = mt_new.annotate_entries(**{x: custom_flip_expr(mt_new[x], mt_new.flipped_entries[x]) for x in ENTRY_R_fields})
+
+    # apply new alleles
+    if skip_locus_change and skip_allele_change:
+        mt_new = mt_new.annotate_entries(OriginalSelfRefAlleles = hl.missing('array<str>') if original_self_alleles is None else mt_new[original_self_alleles])
+    else:
+        mt_new = mt_new.annotate_entries(OriginalSelfRefAlleles = mt_new.alleles if original_self_alleles is None else mt_new[original_self_alleles])
+        mt_new = mt_new.key_rows_by().drop('alleles').rename({'updated_alleles':'alleles'}).key_rows_by('locus','alleles')
+        if not skip_locus_change:
+            mt_new = mt_new.key_rows_by().drop('locus').rename({'locus_grch38': 'locus'}).key_rows_by('locus','alleles')
+    
+    mt_new = mt_new.annotate_entries(SwappedFieldIDs = ','.join([*ROW_BOOL_fields, *ROW_R_fields, *list(ROW_custom_fields.keys()), *ENTRY_R_fields]))
+    if not keep_flipped_fields:
+        mt_new = mt_new.drop('flipped_entries', 'flipped_row_data')
+    mt_new = add_filter(mt_new, 'ComplexSwapField')
+
+    return mt_new
+
+
+def fancy_flip_entries(mt, mt_meta, success_vcf, debug=False):
+    """
+    We modify the rows with 1-AF... annotations using information from other alleles at that locus.
+
+    Changed on 2/6/22 to group by locus rather than locus, reference allele pair.
+    """
+    ENTRY_1minus_fields = get_fields_for_flipping(mt_meta)[5]
+
+    # Produce a list of loci that need fancy flipping -- these are loci with > 1 site in which 1 entry was swapped using 1-x
+    # NOTE We integrate with success VCF in case there are other alleles at the site
+    # NOTE We define "same site" as records with the same locus and reference allele.
+    mt = mt.annotate_rows(has_oneminus = hl.agg.any(mt.SwappedFieldIDs.matches(','.join(['1-' + x for x in ENTRY_1minus_fields]))))
+    success_ht = success_vcf.entries().select(*ENTRY_1minus_fields)
+    success_ht = success_ht.annotate(SwappedFieldIDs = '', has_oneminus=False)
+    ht_for_flip = mt.entries().select(*ENTRY_1minus_fields, 'SwappedFieldIDs', 'has_oneminus')
+    joint_ht_for_flip = success_ht.union(ht_for_flip)
+    joint_ht_for_flip = joint_ht_for_flip.annotate(ref_allele = joint_ht_for_flip.alleles[0])
+    per_locus_info = joint_ht_for_flip.group_by(joint_ht_for_flip.locus#, joint_ht_for_flip.ref_allele
+                                     ).aggregate(n = hl.agg.count(),
+                                                 n_oneminus = hl.agg.count_where(joint_ht_for_flip.has_oneminus))
+    
+    # Checks
+    if per_locus_info.aggregate(hl.agg.any(per_locus_info.n_oneminus > 1)):
+        raise ValueError('ERROR: No locus should have more than one allele with entries that were flipped.')
+    
+    # Locations to flip are those with >1 record at the location (if there is only 1, then the 1-AF is correct) and that has a site with 1-x having been done
+    locs_to_fancy_flip = per_locus_info.filter((per_locus_info.n > 1) & (per_locus_info.n_oneminus > 0))
+    
+    if locs_to_fancy_flip.count() > 0:
+        # pull in entry info for all records matching locus/ref allele with the sites that need to be fixed
+        joint_ht_for_flip = joint_ht_for_flip.key_by('locus')#, 'ref_allele')
+        joint_ht_used_for_flip = joint_ht_for_flip.semi_join(locs_to_fancy_flip)
+
+        # Separate sites that will not be modified but will be used to fix the 1-x sites
+        # This makes sense because the correction we are doing is to change the 1 in 1-x by (1-total), where
+        # total is the sum of x across all other sites at that location (which were not flipped).
+        jht_helper = joint_ht_used_for_flip.filter(~joint_ht_used_for_flip.has_oneminus)
+
+        # Compute sums. Array agg won't work if array lengths are not equal.
+        jht_sums = jht_helper.group_by(*jht_helper.key).aggregate(**{x + '_sum': hl.agg.array_sum(jht_helper[x]).map(lambda y: 1-y) for x in ENTRY_1minus_fields})
+
+        # Add the new totals and re-invert the originally 1-x fields
+        joint_ht_flipped = joint_ht_used_for_flip.filter(joint_ht_used_for_flip.has_oneminus)
+        joint_ht_flipped = joint_ht_flipped.annotate(**{f'{x}_new_total': jht_sums[joint_ht_flipped.key][x + '_sum'] for x in ENTRY_1minus_fields})
+        joint_ht_flipped = joint_ht_flipped.annotate(**{f'{x}_reinverted': joint_ht_flipped[x].map(lambda y: 1-y) for x in ENTRY_1minus_fields}).persist()
+
+        # Checks
+        tf_vec = [joint_ht_flipped.aggregate(~hl.agg.all(joint_ht_flipped[f'{x}_new_total'].length() == joint_ht_flipped[f'{x}_reinverted'].length())) for x in ENTRY_1minus_fields]
+        if any(tf_vec):
+            raise ValueError('ERROR: for all entry fields to invert and all sites, new total must have the same array length as the actual field.')
+        
+        # Produce new entry fields
+        joint_ht_flipped = joint_ht_flipped.annotate(**{f'{x}_fixed': hl.zip(joint_ht_flipped[f'{x}_new_total'], joint_ht_flipped[f'{x}_reinverted']).map(lambda tup : tup[0]-tup[1]) for x in ENTRY_1minus_fields})
+        joint_ht_flipped = joint_ht_flipped.key_by('locus', 'alleles')
+
+        mt_noflip = mt.anti_join_rows(joint_ht_flipped)
+        mt_flipped = mt.semi_join_rows(joint_ht_flipped)
+        mt_flipped = mt_flipped.annotate_entries(**{f'{x}_fixed': joint_ht_flipped[mt_flipped.row_key][f'{x}_fixed'] for x in ENTRY_1minus_fields})
+
+        # Checks        
+        if mt_flipped.aggregate_rows(~hl.agg.all(mt_flipped.has_oneminus)):
+            raise ValueError('ERROR: all records which get fancy flipped entries should have already been logged as flipped in SwappedFieldIDs.')
+        tf_vec_same_len = [mt_flipped.aggregate_entries(~hl.agg.all(mt_flipped[x].length() == mt_flipped[f'{x}_fixed'].length())) for x in ENTRY_1minus_fields]
+        if any(tf_vec_same_len):
+            raise ValueError('ERROR: all entries must have the same array length as the fancy flipped version they will be replaced by.')
+        tf_vec_any_none = [mt_flipped.aggregate_entries(~hl.agg.all(hl.is_defined(mt_flipped[f'{x}_fixed']))) for x in ENTRY_1minus_fields]
+        if not debug and any(tf_vec_any_none):
+            raise ValueError('ERROR: missingness in fancy flipped results is not allowed.')
+        tf_vec_any_nonearray = [mt_flipped.aggregate_entries(~hl.agg.all(hl.all(mt_flipped[f'{x}_fixed'].map(hl.is_defined)))) for x in ENTRY_1minus_fields]
+        if not debug and any(tf_vec_any_nonearray):
+            raise ValueError('ERROR: missingness in array of fancy flipped results is not allowed.')
+        mt_flipped = add_filter(mt_flipped, 'FancyFieldInversion')
+        
+        # clean up
+        mt_flipped = mt_flipped.drop(*ENTRY_1minus_fields)
+        mt_flipped = mt_flipped.rename({f'{x}_fixed': x for x in ENTRY_1minus_fields})
+        n_fancy_flip = mt_flipped.count_rows()
+        mt_joined = mt_noflip.union_rows(mt_flipped.select_entries(*mt_noflip.entry))
+    else:
+        mt_joined = mt
+        n_fancy_flip = 0
+
+    mt_joined = mt_joined.drop('has_oneminus').persist()
+    return mt_joined, n_fancy_flip
+
+
+def resolve_deletion_boundary_cases(mt, mt_meta, exploded_insertions, self_homoplasmies, insertions_table, ref, self_ref, allow_NONREF):
+    """ Thus function only supports:
+    - Spanning deletions where first base is the same as a reference insertion and last base is outside
+    - Deletions where the first base is BEFORE the insetion and the last base is within or after
+
+    All others are piped to failure.
+    """
+    mt = mt.persist()
+    if mt.count_rows() == 0:
+        return enforce_corrected_spec_in_uncorrected_mt(mt, skip_entry_add=False), add_missing_new_entry_fields(mt), 0, 0, 0, 0
+    ROW_R_fields, ROW_BOOL_fields, ROW_custom_fields, _, ENTRY_R_fields, _, _ = get_fields_for_flipping(mt_meta)
+    
+    if mt.anti_join_rows(dele_spans_insertion(mt, exploded_insertions, self_ref, False, False).rows()).count_rows() > 0:
+        raise ValueError('ERROR: All inputted variants to resolve_deletion_boundary_cases() must be deletions that span insertion boundaries.')
+
+    mt_fixable_1 = dele_spans_insertion(mt, exploded_insertions, self_ref, False, True).annotate_rows(fixtype=1)
+    mt_fixable_2_orig = dele_spans_insertion(mt, exploded_insertions, self_ref, False, False, True).annotate_rows(fixtype=2)
+    self_homoplasmies = self_homoplasmies.annotate_rows(row_found=True)
+    self_inserts = self_homoplasmies.filter_rows(is_deletion(self_homoplasmies))
+    insertions_table = insertions_table.annotate(alleles = [insertions_table.alt_allele, insertions_table.ref_allele]).key_by('coord_s', 'alleles')
+    self_inserts = self_inserts.annotate_rows(ns = insertions_table[self_inserts.row_key].ns)
+    self_inserts = self_inserts.key_rows_by('locus')
+
+    # 1 refers to spanning deletions where the first base is same as an insertion
+    mt_fixable_1 = mt_fixable_1.key_rows_by('locus')
+    mt_fixable_1 = mt_fixable_1.annotate_rows(flipped_row_data = self_inserts.rows()[mt_fixable_1.row_key])
+    mt_fixable_1 = mt_fixable_1.annotate_entries(flipped_entries = self_inserts[mt_fixable_1.row_key, mt_fixable_1.col_key]).key_rows_by('locus', 'alleles')
+
+    # 2 is deletions where first base is upstream and second base is within
+    # we do not currently handle this type of spanning deletion where the first base overlaps a SNV, so fail this
+    mt_fixable_2_orig = mt_fixable_2_orig.key_rows_by('locus'
+                                        ).anti_join_rows(self_homoplasmies.filter_rows(is_snv(self_homoplasmies)).rows().key_by('locus')
+                                        ).key_rows_by('locus','alleles')
+    mt_fixable_2 = mt_fixable_2_orig.annotate_rows(delelen = hl.len(mt_fixable_2_orig.alleles[0]))
+    mt_fixable_2 = mt_fixable_2.annotate_rows(internal_positions = hl.range(mt_fixable_2.locus.position, mt_fixable_2.locus.position+(mt_fixable_2.delelen-1)))
+    mt_fixable_2 = mt_fixable_2.annotate_rows(internal_positions = hl.map(lambda x: hl.locus('chrM', x, self_ref), mt_fixable_2.internal_positions))
+    mt_fixable_2 = mt_fixable_2.explode_rows('internal_positions').key_rows_by('internal_positions')
+    mt_fixable_2 = mt_fixable_2.filter_rows(mt_fixable_2.locus != mt_fixable_2.internal_positions) # matches must be internal
+    mt_fixable_2 = mt_fixable_2.annotate_rows(flipped_row_data = self_inserts.rows()[mt_fixable_2.row_key])
+    mt_fixable_2 = mt_fixable_2.annotate_entries(flipped_entries = self_inserts[mt_fixable_2.row_key, mt_fixable_2.col_key]).key_rows_by('locus', 'alleles')
+    mt_fixable_2 = mt_fixable_2.annotate_rows(idx_last = mt_fixable_2.internal_positions.position - mt_fixable_2.locus.position)
+    mt_fixable_2 = mt_fixable_2.filter_rows(hl.is_defined(mt_fixable_2.flipped_row_data.row_found))
+    
+    mt_fixable = mt_fixable_1.union_rows(mt_fixable_2.drop('delelen', 'internal_positions', 'idx_last')).persist()
+    mt_unfixable = mt.anti_join_rows(mt_fixable.rows())
+
+    # flags specific to type 1
+    if mt_fixable_1.aggregate_rows(~hl.agg.all((mt_fixable_1.flipped_row_data.ns > 0) & ((mt_fixable_1.flipped_row_data.ns+1) < mt_fixable_1.alleles[0].length()))):
+        raise NotImplementedError('ERROR: All records for fixing must have ns > 0 and < length of the allele to repair.')
+    if mt_fixable_1.aggregate_rows(~hl.agg.all(mt_fixable_1.locus_grch38 == mt_fixable_1.flipped_row_data.locus_grch38)):
+        raise NotImplementedError('ERROR: annotated locus_grch38 must be the same between the force-called homoplasmy and variants to fix.')
+    # ensure all loci in mt are in matching_homoplasmies
+    if mt_fixable_1.key_rows_by('locus').anti_join_rows(self_inserts.rows()).count_rows() > 0:
+        raise ValueError('ERROR: All loci for repair should have corresponding homoplasmic insertions.')
+    
+    # flags specific to type 2
+    if mt_fixable_2_orig.anti_join_rows(mt_fixable_2.rows()).count_rows() > 0:
+        raise ValueError('ERROR: some rows tagged for fixing due to spanning left-side insertion boundary were lost.')
+    # idxlast must be within the length of the allele
+    if mt_fixable_2.filter_rows((mt_fixable_2.idx_last + 1) >= (mt_fixable_2.delelen)).count_rows() > 0:
+        raise ValueError('ERROR: computed truncation point for a heteroplasmic deletion spanning homoplasmic insertion is too long -- this should always be internal to the allele (not at or after the end).')
+    if mt_fixable_2.filter_rows(mt_fixable_2.idx_last == 0).count_rows() > 0:
+        raise ValueError('ERROR: computed truncation point for a heteroplasmic deletion spanning homoplasmic insertion is too short -- this should always be internal to the allele (not at the start).')
+
+    # flags for all
+    if mt_fixable.rows().count() != mt_fixable.rows().distinct().count():
+        raise ValueError('ERROR: MT for fixing has duplicate entries. Check dele_spans_insertion() and/or mapping to mt_fixable_2.')
+    if allow_NONREF:
+        raise argparse.ArgumentError('ERROR: allow_NONREF is currnetly not supported for make_first_indel_site_ref().')
+    if mt_fixable.aggregate_rows(~hl.agg.all(hl.literal(NONINDEL).contains(mt_fixable.alleles[1]))):
+        raise NotImplementedError('ERROR: resolve_deletion_boundary_cases() can only handle deletions.')
+    if mt_fixable.aggregate_rows(~hl.agg.all(hl.is_defined(mt_fixable.flipped_row_data.ns))):
+        raise NotImplementedError('ERROR: All records for fixing must have available ns.')
+    if mt_fixable.aggregate_rows(~hl.agg.all(hl.is_defined(mt_fixable.locus_grch38) & hl.is_defined(mt_fixable.grch38_seq))):
+        raise ValueError('ERROR: GRCh38 locus and sequence at every site for swap must be defined.')
+    # alleles should not be the same as respective homoplasmies
+    if mt_fixable.aggregate_rows(~hl.agg.all(mt_fixable.alleles != mt_fixable.flipped_row_data.alleles)):
+        raise ValueError('ERROR: Alleles to fix should not be force-call reference alleles.')
+    # the current reference must not be the grch38 reference
+    if mt_fixable.aggregate_rows(~hl.agg.all((mt_fixable.alleles[0] != mt_fixable.grch38_seq) & (mt_fixable.alleles[1] == mt_fixable.grch38_seq))):
+        raise ValueError('ERROR: GRCh38 sequence matches self-reference single-site sequence at >1 site and/or does not match self-ref ALT at >1 site.')
+
+    ### fix type 1
+    mt_fixable_1 = mt_fixable_1.annotate_rows(region_removal = mt_fixable_1.alleles[0][0:hl.int32(mt_fixable_1.flipped_row_data.ns+1)])
+
+    if mt_fixable_1.aggregate_rows(~hl.agg.all(mt_fixable_1.region_removal == mt_fixable_1.flipped_row_data.alleles[0])):
+        raise ValueError('ERROR: Computed region for replacement must be identical to the self REF allele of the corresponding homoplasmy.')
+
+    # Produce new alleles
+    mt_fixable_1 = mt_fixable_1.annotate_rows(updated_alleles = [mt_fixable_1.flipped_row_data.alleles[1] + mt_fixable_1.alleles[0][hl.int32(mt_fixable_1.flipped_row_data.ns+1):], mt_fixable_1.alleles[1]])
+    if mt_fixable_1.aggregate_rows(~hl.agg.all(hl.map(lambda x: x[0], mt_fixable_1.updated_alleles)[0] == hl.map(lambda x: x[0], mt_fixable_1.updated_alleles)[1])):
+        raise ValueError('ERROR: changing first site of indel did not produce matching first site in resultant alleles.')
+    mt_fixable_1 = mt_fixable_1.annotate_rows(ref_end_position = get_ref_locus_end(mt_fixable_1.locus, mt_fixable_1.alleles[0], exploded_insertions, self_ref, ref))
+    if mt_fixable_1.aggregate_rows(~hl.agg.all(hl.is_defined(mt_fixable_1.ref_end_position))):
+        raise ValueError('ERROR: the end position of all REF allele should be liftover-compatible.')
+    mt_fixable_1 = mt_fixable_1.annotate_rows(expected_ref = hl.get_sequence('chrM', mt_fixable_1.locus_grch38.position, before=0, after=mt_fixable_1.ref_end_position.position-mt_fixable_1.locus_grch38.position, reference_genome=ref))
+    mt_fixable_1 = mt_fixable_1.persist()
+
+    # Swap first allele
+    # 220615 we now skip allele change here to allow recode_deletion_allele to work if there are indels inside the RHS overhang
+    mt_new = complex_swap_field(mt_fixable_1, ROW_BOOL_fields=ROW_BOOL_fields, ROW_R_fields=ROW_R_fields, 
+                                ROW_custom_fields=ROW_custom_fields, ENTRY_R_fields=ENTRY_R_fields, 
+                                flipped_idx=1, skip_locus_change=True, skip_allele_change=True)
+    mt_new = mt_new.drop('ref_end_position', 'region_removal')
+    mt_new = add_filter(mt_new, 'DeletionSpannedHomoplasmicInsertion')
+
+    # For records that need further modification send to recode_deletion_allele()
+    mt_for_dele_recode = mt_new.filter_rows(mt_new.updated_alleles[0] != mt_new.expected_ref)
+    nrow_for_recode = mt_for_dele_recode.count_rows()
+    mt_recoded, mt_failed, num_indel_in_dele = recode_deletion_allele(None, mt_for_dele_recode, exploded_insertions, ref, self_ref, allow_NONREF, 
+                                                                      allow_spanning=True, override_processed=False, override_swap=True, 
+                                                                      self_homoplasmies=self_homoplasmies, mt_meta=mt_meta)
+    if mt_recoded.aggregate_rows(~hl.agg.all(mt_recoded.alleles[0] == mt_recoded.expected_ref)):
+        raise ValueError('ERROR: expected reference allele not generated as expected during second round recode_deletion_allele.')
+    
+    mt_fixed = mt_new.filter_rows(mt_new.updated_alleles[0] == mt_new.expected_ref)
+    mt_fixed = mt_fixed.annotate_entries(OriginalSelfRefAlleles = mt_fixed.alleles)
+    mt_fixed = mt_fixed.key_rows_by().drop('locus', 'alleles').rename({'updated_alleles':'alleles','locus_grch38': 'locus'}).key_rows_by('locus','alleles')
+    mt_fixed = mt_fixed.drop('grch38_seq', 'expected_ref')
+    mt_fixed = mt_fixed.union_rows(mt_recoded.drop('expected_ref', 'updated_alleles'))
+
+    # the resultant allele must be reference – if it doesnn't, throw an error!
+    mt_fixed_test = mt_fixed.annotate_rows(expected = hl.get_sequence('chrM',mt_fixed.locus.position, reference_genome=ref, after=hl.len(mt_fixed.alleles[0])-1))
+    if mt_fixed_test.filter_rows(mt_fixed_test.expected != mt_fixed_test.alleles[0]).count_rows() > 0:
+        raise ValueError('ERROR: produced allele from type 1 spanning deletion rescue does not match the reference.')
+
+    # Fix type 2. Note that get_ref_locus_end() can't work on the original allele, because the ending point of the deletion
+    # is inside an insertion as defined. However it does work on the truncated allele, which is at base 1 of the deletion.
+    mt_new_2 = mt_fixable_2.annotate_rows(updated_alleles = [mt_fixable_2.alleles[0][0:mt_fixable_2.idx_last+1], mt_fixable_2.alleles[1]]).persist()
+    mt_new_2 = mt_new_2.annotate_entries(OriginalSelfRefAlleles = mt_new_2.alleles, SwappedFieldIDs=hl.missing('tstr'))
+    mt_new_2 = mt_new_2.annotate_rows(ref_end_position = get_ref_locus_end(mt_new_2.locus, mt_new_2.updated_alleles[0], exploded_insertions, self_ref, ref))
+    if mt_new_2.aggregate_rows(~hl.agg.all(hl.is_defined(mt_new_2.ref_end_position))):
+        raise ValueError('ERROR: the end position of all REF allele should be liftover-compatible.')
+    mt_new_2 = mt_new_2.annotate_rows(expected_ref = hl.get_sequence('chrM', mt_new_2.locus_grch38.position, before=0, after=mt_new_2.ref_end_position.position-mt_new_2.locus_grch38.position, reference_genome=ref)).drop('ref_end_position')
+    #mt_new_2 = mt_new_2.annotate_rows(expected_ref = hl.get_sequence('chrM',mt_new_2.locus_grch38.position, reference_genome=ref, after=hl.len(mt_new_2.updated_alleles[0])-1))
+    mt_new_2 = mt_new_2.key_rows_by().drop('alleles').rename({'updated_alleles':'alleles'}).key_rows_by('locus','alleles')
+    mt_new_2 = add_filter(mt_new_2, 'DeletionSpannedHomoplasmicInsertion')
+
+    # For records that need further modification send to recode_deletion_allele()
+    mt_for_dele_recode_2 = mt_new_2.filter_rows(mt_new_2.alleles[0] != mt_new_2.expected_ref).drop('flipped_entries', 'flipped_row_data')
+    nrow_for_recode2 = mt_for_dele_recode_2.count_rows()
+    mt_recoded_2, mt_failed_2, num_indel_in_dele_2 = recode_deletion_allele(None, mt_for_dele_recode_2, exploded_insertions, ref, self_ref, allow_NONREF, 
+                                                                            allow_spanning=True, override_processed=False, override_swap=False, 
+                                                                            self_homoplasmies=self_homoplasmies, mt_meta=mt_meta)
+    if mt_recoded_2.aggregate_rows(~hl.agg.all(mt_recoded_2.alleles[0] == mt_recoded_2.expected_ref)):
+        raise ValueError('ERROR: expected reference allele not generated as expected during second round recode_deletion_allele.')
+
+    mt_fixed_2 = mt_new_2.filter_rows(mt_new_2.alleles[0] == mt_new_2.expected_ref)
+    mt_fixed_2 = mt_fixed_2.key_rows_by().drop('locus').rename({'locus_grch38': 'locus'}).key_rows_by('locus','alleles')
+    mt_fixed_2 = mt_fixed_2.drop('grch38_seq')
+    mt_fixed_2 = mt_fixed_2.drop('flipped_entries', 'flipped_row_data')
+    mt_fixed_2 = mt_fixed_2.union_rows(mt_recoded_2.key_rows_by().select_rows(*[x for x in mt_fixed_2.row]).key_rows_by('locus','alleles')).drop('expected_ref')
+    mt_fixed_2 = mt_fixed_2.drop('internal_positions', 'delelen', 'idx_last')
+    
+    # the resultant allele must be reference - if it doesn't, throw a warning and fail the allele
+    # this likely occurs if there is a weird set of reference variants. For example, 431-BG01977.
+    # We see ACT > A as reference -> makes the sequence ACTTCC -> ATCC; we see ATC > A which overlaps TCC > T.
+    # Very complex; just fail.
+    mt_fixed_2_test = mt_fixed_2.annotate_rows(expected = hl.get_sequence('chrM',mt_fixed_2.locus.position, reference_genome=ref, after=hl.len(mt_fixed_2.alleles[0])-1))
+    if mt_fixed_2_test.filter_rows(mt_fixed_2_test.expected != mt_fixed_2_test.alleles[0]).count_rows() > 0:
+        raise ValueError('ERROR: produced allele from type 2 spanning deletion rescue does not match the reference.')
+
+    mt_fixed_final = mt_fixed.union_rows(mt_fixed_2).drop('fixtype').persist()
+
+    mt_unfixable = add_missing_new_entry_fields(mt_unfixable)
+    mt_failed = mt_failed.drop('expected_ref', 'fixtype', 'updated_alleles')
+    mt_failed = mt_failed.select_rows(*[x for x in mt_failed.row if x not in mt_failed.row_key])
+    mt_failed_2 = mt_failed_2.drop('expected_ref', 'fixtype')
+    mt_failed_2 = mt_failed_2.select_rows(*[x for x in mt_unfixable.row if x not in mt_unfixable.row_key])
+    mt_failed_final = mt_unfixable.union_rows(mt_failed, mt_failed_2).persist()
+
+    if mt_fixed_final.count_rows() + mt_failed_final.count_rows() != mt.count_rows():
+        raise ValueError('ERROR: in recode_deletion_allele(), failed + success rescued variants must be the same as the inputted variant set.')
+    new_selfref_alleles = mt_fixed_final.OriginalSelfRefAlleles.collect()
+    input_selfref_alleles = mt_fixable.alleles.collect()
+    if any([x not in new_selfref_alleles for x in input_selfref_alleles]) & (len(new_selfref_alleles) != len(input_selfref_alleles)):
+        raise ValueError('ERROR: it appears that some alleles were lost during the fixing process in resolve_deletion_boundary_cases() from the set of fixable alleles.')
+
+    return mt_fixed_final, mt_failed_final, num_indel_in_dele+num_indel_in_dele_2, nrow_for_recode+nrow_for_recode2, mt_fixed.count_rows(), mt_fixed_2.count_rows()
+
+
+def flip_success_fields(mt_success, mt_meta, repaired_mt, insertions, deletions):
+    """
+    Insertions found to map to the start of reference insertions should have already been injected.
+    """
+    ROW_R_fields, ROW_BOOL_fields, ROW_custom_fields, _, ENTRY_R_fields, _, _ = get_fields_for_flipping(mt_meta)
+    insertions = insertions.annotate(alleles = [insertions.ref_allele, insertions.alt_allele], idx = 0).key_by('coord_t', 'alleles')
+    deletions = deletions.annotate(alleles = [deletions.ref_allele, deletions.alt_allele], idx = 1).key_by('coord_t', 'alleles').drop('self_ref_alleles')
+    ref_indels = insertions.union(deletions)
+    if ref_indels.anti_join(repaired_mt.rows()).count() > 0:
+        raise ValueError('ERROR: All predicted reference indels should be appropriately flipped in the repaired MT.')
+    
+    filtered_repaired_mt = repaired_mt.semi_join_rows(ref_indels)
+    filtered_repaired_mt = filtered_repaired_mt.annotate_rows(idx = ref_indels[filtered_repaired_mt.row_key].idx, row_found = True).key_rows_by('locus')
+    if filtered_repaired_mt.distinct_by_row().count_rows() != filtered_repaired_mt.count_rows():
+        raise ValueError('ERROR: there should not be any duplicated loci in the repaired MT records used to flip success VCF.')
+    mt_success_shared_locus = mt_success.key_rows_by('locus').semi_join_rows(filtered_repaired_mt.rows())
+    mt_success_shared_locus = mt_success_shared_locus.annotate_rows(flipped_row_data = filtered_repaired_mt.rows()[mt_success_shared_locus.row_key])
+    mt_success_shared_locus = mt_success_shared_locus.annotate_entries(flipped_entries = filtered_repaired_mt[mt_success_shared_locus.row_key, mt_success_shared_locus.col_key])
+    mt_success_shared_locus = mt_success_shared_locus.key_rows_by('locus','alleles').persist()
+    
+    # all success should have found a matched indel
+    if mt_success_shared_locus.aggregate_rows(~hl.agg.all(hl.is_defined(mt_success_shared_locus.flipped_row_data.row_found))):
+        raise ValueError('ERROR: all candidates of successfully Liftedover loci for flipping must have mapped.')
+    if mt_success_shared_locus.aggregate_rows(~hl.agg.all(hl.is_defined(mt_success_shared_locus.flipped_row_data.idx))):
+        raise ValueError('ERROR: all candidates of successfully Liftedover loci for flipping must have mapped.')
+    # all success should be SNVs
+    # insepcting LY3013 shows that deletions sharing the same locus, or insertions & SNVs, show the same REF measurements
+    # V911 shows that deletions sharing the same locus as SNVs also share the same REF quantities
+    if mt_success_shared_locus.aggregate_rows(~hl.agg.all(is_snv(mt_success_shared_locus))):
+        raise ValueError('ERROR: candidates of successfully Liftedover loci for flipping must be SNVs.')
+    
+    # based on indel status the single allele should be the same as the REF
+    # NOTE this check only works when the REF allele in success VCF is a single base
+    if mt_success_shared_locus.aggregate_rows(~hl.agg.all(mt_success_shared_locus.alleles[0] == mt_success_shared_locus.flipped_row_data.alleles[mt_success_shared_locus.flipped_row_data.idx])):
+        raise ValueError('ERROR: the "single allele" of the reference indel should be the same as the success VCF REF allele.')
+    # success REF allele should be the first letter of the REF allele attached
+    # NOTE this check only works when the REF allele in success VCF is a single base
+    if mt_success_shared_locus.aggregate_rows(~hl.agg.all(mt_success_shared_locus.alleles[0] == mt_success_shared_locus.flipped_row_data.alleles[0][0])):
+        raise ValueError('ERROR: the first letter of the fixed MT ref allele should be the same as the successfully lifted VCF REF allele.')
+
+    # Analysis for SNVs
+    mt_success_shared_fixed = complex_swap_field(mt_success_shared_locus, ROW_BOOL_fields=ROW_BOOL_fields, ROW_R_fields=ROW_R_fields, 
+                                                 ROW_custom_fields=ROW_custom_fields, ENTRY_R_fields=ENTRY_R_fields, flipped_idx=0, 
+                                                 skip_locus_change=True, skip_allele_change=True)
+    mt_success_shared_fixed = add_filter(mt_success_shared_fixed, 'LiftoverSuccessEntrySwap')
+    n_success_flipped = mt_success_shared_fixed.count_rows()
+    
+    mt_success_nomod = mt_success.key_rows_by('locus').anti_join_rows(filtered_repaired_mt.rows()).key_rows_by('locus','alleles')
+    mt_success_nomod = add_missing_new_entry_fields(mt_success_nomod)
+    mt_success_final = mt_success_shared_fixed.union_rows(mt_success_nomod).persist()
+
+    # make sure all previous keys are still there
+    if mt_success_final.count_rows() !=  mt_success.count_rows():
+        raise ValueError('ERROR: when flipping fields some records were lost/gained from the success VCF.')
+    if (mt_success_final.anti_join_rows(mt_success.rows()).count_rows() != 0) | (mt_success.anti_join_rows(mt_success_final.rows()).count_rows() != 0):
+        raise ValueError('ERROR: when flipping fields some records were lost/gained from the success VCF.')
+
+    return mt_success_final, n_success_flipped
+
+
+def left_align_and_normalize(mt, mt_meta, reference, reference_fasta_path):
+    """
+    Here we use bcftools norm to normalize and left-align variants. We have tested this extensively:
+
+    - MH0126875
+    A C C C C C /T T A C C T/ C C C A T <- T > TTACCT
+    A C C /C C C T T A/ C C T C C C A T <- C > CCCTTA (left shifted)
+
+    T A C C /C A C/ C C T T <- CAC > C
+    T A C /C C A/ C C C T T <- CCA > C (left shifted)
+
+    - V40776
+    T C A A A A C C /C C/ C T C <- CC > C
+    T C A A A /A C/ C C C C T C <- AC > A (left shifted)
+
+    T C A A A A C C /C C/ C C T C <- C > CC
+    T C A A A /A C/ C C C C C T C <- A > AC (left shifted)
+
+    T A C C /C A C/ C C T T <- CAC > C
+    T A C /C C A/ C C C T T <- CCA > C (left shifted)
+
+    - NWD992111
+    A C C C C C /T G C C T/ C C C C A T G <- T > TGCCT
+    A C C /C C C T G/ C C T C C C C A T G <- C > CCCTG (left shifted)
+
+    - 431-BG01977
+    C A T A C T /T C C T T/ A C T A <- T > TCCTT
+    C A T /A C T T C/ C T T A C T A <- A > ACTTC (left shifted)
+    
+    C A T A C T /T C T/ A C T A <- T > TCT
+    C A T A C /T T C/ T A C T A <- T > TTC (left shifted)
+    
+    All of these seem appropriate.
+    """
+    hl.export_vcf(mt, 'tmp.vcf', metadata=mt_meta)
+    res = subprocess.run(["bcftools", 'norm', '-f', reference_fasta_path, 'tmp.vcf', '-o', 'tmp_fixed.vcf'], 
+                         stderr=subprocess.PIPE, text=True, check=True)
+
+    if res.returncode != 0:
+        raise subprocess.SubprocessError('ERROR: bcftools returned with non-zero exit code.')
+    bcftools_split_output = [x for x in res.stderr.split('\n') if not re.search('\\[E::bcf_hdr_parse_line\\] Could not parse the header line: \\"##', x)]
+    if len(bcftools_split_output) != 2:
+        raise subprocess.SubprocessError('ERROR: bcftools stderr does not match expected format.')
+    bcftools_output = re.search('^Lines   total/split/realigned/skipped:\t([0-9]+)/([0-9]+)/([0-9]+)/([0-9]+)$', bcftools_split_output[0])
+    if not bcftools_output:
+        raise subprocess.SubprocessError('ERROR: bcftools output did not match expected format.')
+    mt_new, mt_meta_new = read_mito_vcf('tmp_fixed.vcf', reference)
+    if int(bcftools_output[1]) != mt.count_rows():
+        raise subprocess.SubprocessError('ERROR: bcftools did not count the same number of variants as was in input mt.')
+    if mt_new.count_rows() != mt.count_rows():
+        raise subprocess.SubprocessError('ERROR: bcftools appears to have lost/gained some variants.')
+    if int(bcftools_output[2]) != 0:
+        raise subprocess.SubprocessError('ERROR: bcftools split an allele. This should not happen.')
+    if int(bcftools_output[3]) != mt_new.anti_join_rows(mt.rows()).count_rows():
+        raise subprocess.SubprocessError('ERROR: the number of variants realigned by bcftools should be the same as the alleles that appear changed.')
+    if int(bcftools_output[4]) != 0:
+        raise subprocess.SubprocessError('ERROR: bcftools skipped alleles. This should not happen.')
+    
+    mt_preserved = mt_new.semi_join_rows(mt.rows())
+    mt_modified = mt_new.anti_join_rows(mt.rows())
+    mt_modified = add_filter(mt_modified, 'LeftShiftedIndel')
+    mt_out = mt_preserved.union_rows(mt_modified).persist()
+    return mt_out, mt_meta_new, int(bcftools_output[3]), res.stderr
+
+
+def rescue_duplicated_alleles(mt, success_mt, failed_mt, meta, failed_meta, self_ref):
+    # Here we filter out variants that are duplicate in mt and success mt.
+    # Currently we do not modify the success mt.
+    dupe_vars = mt.semi_join_rows(success_mt.rows())
+    if dupe_vars.count_rows() > 0:
+        # repair left shifted variants (but not homoplasmies, because these shouldn't be left-shifted and duplicated)
+        dupe_left = dupe_vars.filter_rows(dupe_vars.filters.contains('LeftShiftedIndel') & ~dupe_vars.filters.contains('ForceCalledHomoplasmy'))
+        dupe_vars = dupe_vars.anti_join_rows(dupe_left.rows())
+
+        # can insert additional repair steps here on updated dupe_vars
+
+        # remove repaired vars from mt, add to failed mt
+        dupe_to_transfer = dupe_left # can union_rows more tables here if we transfer other causes of dupes
+        n_failed = dupe_to_transfer.count_rows()
+        mt = mt.anti_join_rows(dupe_to_transfer.rows())
+        dupe_to_transfer = dupe_to_transfer.key_rows_by()
+        dupe_to_transfer = dupe_to_transfer.annotate_rows(locus = hl.liftover(dupe_to_transfer.locus, self_ref)).key_rows_by('locus','alleles')
+        dupe_to_transfer = add_filter(dupe_to_transfer, 'FailedDuplicateVariant')
+        failed_mt = failed_mt.union_rows(dupe_to_transfer)
+
+        # augment the metadata
+        filters_to_add = list(set([item for x in dupe_to_transfer.filters.collect() for item in list(x) if item not in list(failed_meta['filter'].keys())]))
+        failed_meta['filter'].update({x: meta['filter'][x] for x in filters_to_add})
+    else:
+        n_failed = 0
+    return mt, failed_mt, failed_meta, n_failed
+
+
+def fix_insertion_overlapping_ref_dele(mt, mt_meta, flipped_deletions, flipped_insertions, insertions, deletions, rely_on_left_shift=True):
+    """
+    Here we deal with insertions that overlap reference deletions.
+    NOTE This currently deals with insertions must:
+    - be mapped to a reference deletion (e.g., share a locus)
+    - share the same first base as the reference deletion
+    - if the reference deletion has a REF allele of length N, the first N bases of the ALT allele of the insertion should be identical to the reference deletion REF allele
+    For example: REF HOM GCA > G and SELF HET G > GCACA -> GCA > GCACA -> G > GCA
+    All others fail.
+    """
+    ROW_R_fields, ROW_BOOL_fields, ROW_custom_fields, _, ENTRY_R_fields, _, _ = get_fields_for_flipping(mt_meta)
+    insertions = insertions.annotate(alleles = [insertions.ref_allele, insertions.alt_allele], idx = 0).key_by('coord_t', 'alleles')
+    deletions = deletions.annotate(alleles = [deletions.ref_allele, deletions.alt_allele], idx = 1).key_by('coord_t', 'alleles').drop('self_ref_alleles')
+    ref_indels = insertions.union(deletions).key_by('coord_s')
+
+    mt_ins = mt.annotate_rows(tf_ins = is_insertion(mt)).key_rows_by('locus')
+    mt_ins = mt_ins.annotate_rows(reference_indel = ref_indels[mt_ins.row_key].alleles)
+    mt_ins = mt_ins.annotate_rows(tf_ref_indel = hl.is_defined(mt_ins.reference_indel))
+    mt_ins = mt_ins.annotate_rows(tf_ref_dele = hl.literal(NONINDEL).contains(mt_ins.reference_indel[1]) & \
+                                                ~hl.literal(NONINDEL).contains(mt_ins.reference_indel[0]))
+    mt_ins = mt_ins.annotate_rows(tf_shares_start = mt_ins.alleles[1].startswith(mt_ins.reference_indel[0]) | \
+                                                    mt_ins.reference_indel[0].startswith(mt_ins.alleles[1]))
+    mt_ins = mt_ins.annotate_rows(tf_here = mt_ins.tf_ins & mt_ins.tf_ref_indel & mt_ins.tf_ref_dele & mt_ins.tf_shares_start)
+    mt_ins = mt_ins.drop('tf_ins','reference_indel','tf_ref_indel','tf_shares_start')
+    
+    mt_to_process = mt_ins.filter_rows(mt_ins.tf_here).drop('tf_here')
+
+    mt_repaired_indelmap = flipped_deletions.semi_join_rows(ref_indels.key_by('coord_t', 'alleles'))
+    if mt_repaired_indelmap.distinct_by_row().count_rows() != mt_repaired_indelmap.count_rows():
+        raise ValueError('ERROR: there should not be any duplicated loci in the repaired MT records used.')
+    mt_to_process = mt_to_process.key_rows_by('locus_grch38')
+    flipped_deletions_proc = flipped_deletions.annotate_rows(idx = ref_indels.key_by('coord_t','alleles')[flipped_deletions.row_key].idx, row_found=True).key_rows_by('locus')
+    mt_to_process = mt_to_process.annotate_rows(flipped_row_data = flipped_deletions_proc.rows()[mt_to_process.row_key])
+    mt_to_process = mt_to_process.annotate_entries(flipped_entries = flipped_deletions_proc[mt_to_process.row_key, mt_to_process.col_key])
+    mt_to_process = mt_to_process.key_rows_by('locus','alleles')
+    mt_to_process = mt_to_process.annotate_rows(mapped_alleles = mt_to_process.flipped_row_data.alleles).persist()
+
+    # Checks
+    # all success should have found a matched indel
+    if mt_to_process.aggregate_rows(~hl.agg.all(hl.is_defined(mt_to_process.flipped_row_data.row_found))):
+        raise ValueError('ERROR: even though we filtered to deletions, there are some alleles for modification that do not map to reference deletions.')
+    if mt_to_process.aggregate_rows(~hl.agg.all(hl.is_defined(mt_to_process.flipped_row_data.idx))):
+        raise ValueError('ERROR: even though we filtered to deletions, there are some alleles for modification that do not map to reference deletions.')
+    if mt_to_process.aggregate_rows(~hl.agg.all(hl.is_defined(mt_to_process.mapped_alleles))):
+        raise ValueError('ERROR: even though we filtered to deletions, there are some alleles for modification that do not map to reference deletions.')
+    # all variants should be insertions
+    if mt_to_process.aggregate_rows(~hl.agg.all(is_insertion(mt_to_process))):
+        raise ValueError('ERROR: candidates of successfully Liftedover loci for flipping must be insertions.')
+
+    # if the shared locus is an insertion, it must be mapped to a reference deletion
+    if mt_to_process.aggregate_rows(~hl.agg.all(mt_to_process.tf_ref_dele)):
+        raise ValueError('ERROR: all candidates of successfully Liftedover loci for flipping which are insertions must be mapped to a reference deletion.')
+    # if the shared locus is an insertion, it must share the same first base as the reference deletion
+    if mt_to_process.aggregate_rows(~hl.agg.all(mt_to_process.alleles[0][0] == mt_to_process.mapped_alleles[0][0])):
+        raise ValueError('ERROR: all candidates for correction must share the same first base name reference deletion.')
+    # if the shared locus is an insertion, the reference deletion REF must be the first n bases of the insertion ALT
+    if mt_to_process.aggregate_rows(~hl.agg.all(mt_to_process.alleles[1].startswith(mt_to_process.mapped_alleles[0]) |
+                                                mt_to_process.mapped_alleles[0].startswith(mt_to_process.alleles[1]))):
+        raise ValueError('ERROR: all candidates for correction must have the same first n bases as the REF homoplasmic deletion (where n is the length of the REF homoplasmic deletion) or vice versa.')
+    
+    # based on indel status the single allele should be the same as the REF
+    # NOTE this check only works when the REF allele in success VCF is a single base
+    if mt_to_process.aggregate_rows(~hl.agg.all(mt_to_process.alleles[0] == mt_to_process.flipped_row_data.alleles[mt_to_process.flipped_row_data.idx])):
+        raise ValueError('ERROR: the "single allele" of the reference indel should be the same as the success VCF REF allele.')
+    # success REF allele should be the first letter of the REF allele attached
+    # NOTE this check only works when the REF allele in success VCF is a single base
+    if mt_to_process.aggregate_rows(~hl.agg.all(mt_to_process.alleles[0] == mt_to_process.flipped_row_data.alleles[0][0])):
+        raise ValueError('ERROR: the first letter of the fixed MT ref allele should be the same as the successfully lifted VCF REF allele.')
+
+    # Analysis for insertions
+    # NOTE we have assumed that the ref allele is a substring
+    mt_fixed = mt_to_process.annotate_rows(locus_self=mt_to_process.locus)
+    if rely_on_left_shift:
+        mt_fixed = mt_fixed.annotate_rows(updated_alleles=[mt_fixed.mapped_alleles[0], mt_fixed.alleles[1]])
+
+        if mt_fixed.aggregate_rows(~hl.agg.all((hl.len(mt_fixed.updated_alleles[0]) > 1))):
+            raise ValueError('ERROR: the new REF allele should be greater than length 1.')
+        if mt_fixed.aggregate_rows(~hl.agg.all(mt_fixed.alleles[1].startswith(mt_fixed.alleles[0]))):
+            raise ValueError('ERROR: the new REF allele should be a subset of the ALT allele.')
+    else:
+        mt_fixed = mt_fixed.annotate_rows(updated_alleles_pre=[mt_fixed.mapped_alleles[0], mt_fixed.alleles[1]])
+        mt_fixed = mt_fixed.annotate_rows(updated_alleles_1=[mt_fixed.updated_alleles_pre[0].replace('^.(?<=' + mt_fixed.updated_alleles_pre[1][0] + ')' + \
+                                                                                                     mt_fixed.updated_alleles_pre[1][1:], mt_fixed.updated_alleles_pre[1][0]),
+                                                             mt_fixed.updated_alleles_pre[1][0]],
+                                          updated_alleles_2=[mt_fixed.updated_alleles_pre[0][0], 
+                                                             mt_fixed.updated_alleles_pre[1].replace('^.(?<=' + mt_fixed.updated_alleles_pre[0][0] + ')' + \
+                                                                                                     mt_fixed.updated_alleles_pre[0][1:], mt_fixed.updated_alleles_pre[0][0])])
+        mt_fixed = mt_fixed.annotate_rows(idx_single=hl.if_else(hl.len(mt_fixed.updated_alleles_pre[0]) > hl.len(mt_fixed.updated_alleles_pre[1]), 1, 0),
+                                          idx_mult=hl.if_else(hl.len(mt_fixed.updated_alleles_pre[0]) > hl.len(mt_fixed.updated_alleles_pre[1]), 0, 1),
+                                          updated_alleles=hl.if_else(hl.len(mt_fixed.updated_alleles_pre[0]) > hl.len(mt_fixed.updated_alleles_pre[1]), 
+                                                                     mt_fixed.updated_alleles_1, mt_fixed.updated_alleles_2)).drop('updated_alleles_1','updated_alleles_2')
+        if mt_fixed.aggregate_rows(~hl.agg.all((hl.len(mt_fixed.updated_alleles_pre[1])-hl.len(mt_fixed.updated_alleles[1])) >= 1)):
+            raise ValueError('ERROR: the size by which the ALT allele shrank relative to pre must be >= 1 base.')
+        if mt_fixed.aggregate_rows(~hl.agg.all((hl.len(mt_fixed.updated_alleles_pre[mt_fixed.idx_mult])-hl.len(mt_fixed.updated_alleles[mt_fixed.idx_mult])) == (hl.len(mt_fixed.updated_alleles_pre[mt_fixed.idx_single])-1))):
+            raise ValueError('ERROR: the size by which the REF allele shrank relative to pre should be identical to the size of the shrinking of ALT allele.')
+        if mt_fixed.aggregate_rows(~hl.agg.all(hl.len(mt_fixed.updated_alleles[mt_fixed.idx_single]) == 1)):
+            raise ValueError('ERROR: the fixed REF allele should have length 1.')
+        if mt_fixed.aggregate_rows(~hl.agg.all(mt_fixed.updated_alleles[mt_fixed.idx_single] == mt_fixed.updated_alleles[mt_fixed.idx_mult][0])):
+            raise ValueError('ERROR: the fixed REF allele should be the same as the first base of the fixed ALT allele.')
+        mt_fixed = mt_fixed.drop('updated_alleles_pre','idx_single','idx_mult')
+
+    mt_fixed_adj = complex_swap_field(mt_fixed, ROW_BOOL_fields=ROW_BOOL_fields, ROW_R_fields=ROW_R_fields,
+                                      ROW_custom_fields=ROW_custom_fields, ENTRY_R_fields=ENTRY_R_fields, flipped_idx=0,
+                                      skip_locus_change=False, skip_allele_change=False)
+    mt_fixed_adj = add_filter(mt_fixed_adj, 'AddGRCh38RefDeleToRefSiteIns')
+    mt_fixed_adj = mt_fixed_adj.drop('mapped_alleles', 'tf_ref_dele', 'grch38_seq').persist()
+    n_success_flipped = mt_fixed_adj.count_rows()
+    
+    mt_failed = mt_ins.filter_rows(~mt_ins.tf_here).drop('tf_here', 'tf_ref_dele')
+
+    # make sure all previous keys are still there
+    mt_fixed_for_test = mt_fixed_adj.key_rows_by()
+    mt_fixed_for_test = mt_fixed_for_test.annotate_rows(locus_grch38=mt_fixed_for_test.locus, grch38_seq='A')
+    mt_fixed_for_test = mt_fixed_for_test.annotate_rows(alleles = hl.agg.collect(mt_fixed_for_test.OriginalSelfRefAlleles)[0])
+    mt_fixed_for_test = mt_fixed_for_test.annotate_rows(locus = mt_fixed_for_test.locus_self)
+    mt_fixed_for_test = mt_fixed_for_test.select_rows(*[x for x in mt_failed.row]).key_rows_by('locus')
+    mt_for_test = mt_fixed_for_test.union_rows(mt_failed).key_rows_by('locus','alleles').persist()
+    if mt_for_test.count_rows() !=  mt.count_rows():
+        raise ValueError('ERROR: when flipping fields for insertion rescue some records were lost/gained.')
+    if (mt_for_test.anti_join_rows(mt.rows()).count_rows() != 0) | (mt.anti_join_rows(mt_for_test.rows()).count_rows() != 0):
+        raise ValueError('ERROR: when flipping fields for insertion rescue some records were lost/gained.')
+    
+    return mt_fixed_adj.drop('locus_self').persist(), mt_failed.key_rows_by('locus','alleles').persist(), n_success_flipped
+
+
+def confirm_ref(ref_mt, ref):
+    ref_mt = ref_mt.annotate_rows(len = hl.len(ref_mt.alleles[0]))
+    ref_mt = ref_mt.annotate_rows(seq = hl.get_sequence('chrM', ref_mt.locus.position, reference_genome=ref, after=ref_mt.len-1))
+    ref_mt_f = ref_mt.filter_rows(ref_mt.seq != ref_mt.alleles[0])
+    if ref_mt_f.count_rows() > 0:
+        raise ValueError('ERROR: Final MT contains reference alleles that do not match the true reference sequence.')
+
+
+def initialize_log(logging, individual_name, debug):
+    log = open(logging, 'w')
+    print('-------------- fix_liftover.py --------------', file=log)
+    print('Pipeline for repair of complex Liftover edge cases on the mtDNA.', file=log)
+    print('Rahul Gupta, 2022', file=log)
+    print('', file=log)
+    print('Sample name: ' + str(individual_name), file=log)
+    print('Target reference: ' + str(MTREF), file=log)
+    print('Start time: ' + datetime.now().strftime('%Y-%m-%d %H:%M:%S'), file=log)
+    print('NOTE: This pipeline modifies the success VCF; be sure to use only success, rescued, and rejected VCFs from this in downstream applications.', file=log)
+    if debug:
+        print('WARNING: DEBUG MODE ENABLED. SEVERAL CONSISTANCY CHECKS ARE DISABLED.', file=log)
+    print('Starting Liftover repair pipeline...', file=log)
+    print('', file=log)
+    return log
+
+
+def write_outcome_log(s, final_mt, original_mt, failed_to_liftover, success_vcf, n_injected, complex_snp_liftover, new_haplotypes, n_for_in_body, 
+                      n_indels_in_dele, n_complex_boundary, n_dele_spans_ins, n_dupe_removed, skip_norm, stage_ct_dict, output_txt_for_wdl, output_prefix, log):
+    ct_original_success = success_vcf.count_rows()
+    ct_total = original_mt.count_rows()
+    ct_fixed = final_mt.count_rows()
+    ct_failed_liftover = failed_to_liftover.count_rows()
+    if ct_total != ct_fixed + ct_failed_liftover - n_injected:
+        raise ValueError('ERROR: the final fixed table + final failed table do not have the same number of rows as the input table.')
+    str_summary_1 = str(ct_original_success) + ' sites passed first round Liftover.'
+    str_summary_2 = str(n_injected) + ' success sites were injected into failed MT.'
+    str_summary_3 = 'Of ' + str(ct_total) + ' sites failing automated Liftover, we have repaired ' + str(ct_fixed-n_injected) + ' as well as ' + str(n_injected) + ' sites misclassified as a success.'
+    filters_to_test = ['MismatchedRefAllele', 'NoTarget', 'IndelStraddlesMultipleIntevals', 'CannotLiftOver']
+    if ct_failed_liftover > 0:
+        failed_strings = (hl.str(failed_to_liftover.locus.position) + ':' + failed_to_liftover.alleles[0] + '>' + failed_to_liftover.alleles[1]).collect()
+        set_of_all = hl.literal(set(filters_to_test))
+        ct_no_filter = failed_to_liftover.filter_rows(failed_to_liftover.filters.intersection(set_of_all).length() == 0).count_rows()
+        ct_each_filter = {x: failed_to_liftover.filter_rows(failed_to_liftover.filters.contains(x)).count_rows() for x in filters_to_test}
+        ct_snv = failed_to_liftover.filter_rows(is_snv(failed_to_liftover)).count_rows()
+        ct_indel = ct_failed_liftover - ct_snv
+    else:
+        ct_each_filter = {x: 0 for x in filters_to_test}
+    ct_fixed_each_filter = {x: final_mt.filter_rows(final_mt.filters.contains(x)).count_rows() for x in filters_to_test}
+
+    if output_txt_for_wdl:
+        # here we output text files for the elements of stage_ct_dct and for the other constants
+        tuple_list_output = [(re.sub('\\s','_',k.lower()), v) for k,v in stage_ct_dict.items()]
+        other_list_output = [('round1_failed_sites', ct_total), ('round2_failed_sites', ct_failed_liftover), ('round2_fixed_sites', ct_fixed), 
+                             ('round2_success_injected', n_injected),
+                             ('snvs_complex_liftover', complex_snp_liftover), ('ref_insertion_new_haplos',new_haplotypes),
+                             ('deletions_with_first_allele_and_internal_switches', n_for_in_body), ('hom_dele_with_indels_reverted', n_indels_in_dele),
+                             ('het_dele_span_insert_repaired_with_complex_rework', n_complex_boundary),
+                             ('het_deletions_span_insertions', n_dele_spans_ins), ('new_dupes_left_shift_failed', n_dupe_removed),
+                             ('fixed_indelStraddlesMultipleIntevals', ct_fixed_each_filter['IndelStraddlesMultipleIntevals'])]
+        full_list_output = tuple_list_output + other_list_output
+        for name, value in full_list_output:
+            with open(output_prefix + '.' + name + '.txt', 'w') as f:
+                f.write('%d' % value)
+        # now writing a table also
+        dct_ints = {'s': s}
+        dct_ints.update({'n_liftover_r2_'+left: right for (left, right) in tuple_list_output + other_list_output[1:len(other_list_output)]})
+        dct_ints.update({'n_liftover_r1_'+left: right for (left, right) in other_list_output[0:1]})
+        df = pd.DataFrame(dct_ints, index=[0])
+        df.to_csv(output_prefix + '.all_int_outputs.txt', sep='\t', index=False)
+    
+    # Output log
+    print('', file=log)
+    print('OUTCOME LOG:', file=log)
+    print(str_summary_1, file=log)
+    print(str_summary_2, file=log)
+    print(str_summary_3, file=log)
+    for k,v in ct_fixed_each_filter.items():
+        print('Repaired ' + str(v) + ' sites with ' + k + ' flag.', file=log)
+    for k,v in stage_ct_dict.items():
+        print('At the correction step for ' + k + ', ' + str(v) + ' sites were repaired.', file=log)
+    if skip_norm:
+        print('Left shifting was performed for ' + str(stage_ct_dict['left alignment of indels']) + ' sites via bcftools norm.', file=log)
+    print('Complex Liftover was performed for ' + str(complex_snp_liftover) + ' SNVs. This involved fixing scenarios where ' + \
+          'new SNVs were detected modifying GRCh38 ALT alleles. For example, if self-ref has G and GRCh38 has A>G, and self-ref recalling ' +\
+          'produced G>C, we recode this with A>C.', file=log)
+    print('New insertion haplotypes were constructed for ' + str(new_haplotypes) + ' sites. This involved fixing scenarios where ' + \
+          'SNVs or insertions were detected in self-reference impacting a self-ref region with an insertion relative to GRCh38.', file=log)
+    print(str(n_for_in_body) + ' heteroplasmic deletions needed fixing by changing the first allele to GRCh38 reference AND needed a change to an allele ' + \
+          'in the body due to mismatch with GRCh38.', file=log)
+    print(str(n_indels_in_dele) + ' heteroplasmic deletions had correct first base but had internal regions with sites that were indels in self-reference relative to GRCh38.', file=log)
+    print(str(n_complex_boundary) + ' heteroplasmic deletions spanned one side of a homoplasmic insertion (rel. to GRCh38) AND had to subsequently have internal base changes repaired also.', file=log)
+    if ct_failed_liftover > 0:
+        print('INVESTIGATING ' + str(ct_failed_liftover) + ' LIFTOVER FAILURES:', file=log)
+        for k,v in ct_each_filter.items():
+            print(str(v) + ' had ' + k + ' flag.', file=log)
+        print(str(ct_no_filter) + ' had none of the above flags.', file=log)
+        print(str(ct_snv) + ' were SNVs.', file=log)
+        print(str(ct_indel) + ' were indels.', file=log)
+        print(str(n_dele_spans_ins) + ' were deletions that spanned insertion boundaries.', file=log)
+        print(str(n_dupe_removed) + ' were lifted over but ended up duplicating another variant lifted by Picard and thus were failed. Currently this only happens if the new duplicate was generated by left-shifting.', file=log)
+        print('In self-reference coordinates, the following failed to liftover:', file=log)
+        for x in failed_strings:
+            print(x, file=log)
+
+
+def main(vcf_file, success_vcf_file, individual_name, self_to_ref_chain, ref_to_self_chain, self_fasta, self_fai, self_homoplasmies, logging,
+         reference_fasta, reference_fai, allow_NONREF, simple_entry_field_correction, output_prefix, export_homoplasmic_deletions_coverage, output_txt_for_wdl, 
+         skip_checkpoint, skip_norm, always_fail_on_dupe, debug):
+    ###### SET UP SELF-REFERENCE AND LOGGING ########
+    individual_name_input = individual_name
+    individual_name = compatiblify_sample_name(individual_name)
+    self_ref = hl.ReferenceGenome(individual_name, ['chrM'], {'chrM':fai_to_len(self_fai)}, mt_contigs=['chrM'])
+    ref = hl.ReferenceGenome(MTREF, ['chrM'], {'chrM':fai_to_len(reference_fai)}, mt_contigs=['chrM'])
+    self_ref.add_sequence(self_fasta, self_fai)
+    ref.add_sequence(reference_fasta, reference_fai)
+    self_ref.add_liftover(self_to_ref_chain, MTREF)
+    ref.add_liftover(ref_to_self_chain, self_ref)
+    chain_table = read_chain_file(self_to_ref_chain, MTREF, self_ref)
+    log = initialize_log(logging, individual_name_input, debug)
+
+
+    ###### READ REJECTED VCF ########
+    # Key of rejection reasons:
+    # MismatchedRefAllele: GRCh38 reference is not the same as original reference
+    # NoTarget: Target location does not exist (probably inside an indel)
+    # IndelStraddlesMultipleIntevals: Target locus is different in size from the source
+    # CannotLiftOver: ??
+    failed_to_liftover, failed_to_liftover_meta = read_mito_vcf(vcf_file, self_ref)
+    failed_to_liftover = add_filter(failed_to_liftover, 'FailedPicardLiftoverVcf')
+
+
+    ###### READ SUCCESS VCF ########
+    success_vcf_original, success_vcf_meta = read_mito_vcf(success_vcf_file, ref, debug=debug)
+
+
+    ###### ADD FILTERS FROM HOMOPLASMIES VCF ########
+    homoplasmies, homoplasmies_meta = read_mito_vcf(self_homoplasmies, self_ref, avoid_dropping_gt=True)
+    if homoplasmies.anti_join_rows(failed_to_liftover.rows()).count_rows() > 0:
+        raise ValueError('ERROR: All homoplasmies should be found in the VCF of sites that failed to Liftover.')
+    failed_to_liftover_homoplas = failed_to_liftover.semi_join_rows(homoplasmies.rows())
+    failed_to_liftover_homoplas = failed_to_liftover_homoplas.annotate_rows(filters = hl.empty_set('tstr').union(homoplasmies.rows()[failed_to_liftover_homoplas.row_key].filters))
+    failed_to_liftover_homoplas = add_filter(failed_to_liftover_homoplas, 'ForceCalledHomoplasmy')
+    failed_to_liftover = failed_to_liftover.anti_join_rows(homoplasmies.rows()).union_rows(failed_to_liftover_homoplas).persist()
+    filters_in_homoplasmies_table = list({y for x in homoplasmies.filters.collect() for y in ([x] if x is None else list(x))})
+    filters_in_homoplasmies_table = [x for x in filters_in_homoplasmies_table if x is not None]
+    filters_missing = [x for x in filters_in_homoplasmies_table if x not in failed_to_liftover_meta['filter'].keys()]
+    for filt in filters_missing:
+        failed_to_liftover_meta['filter'].update({filt: homoplasmies_meta['filter'][filt]})
+
+
+    ###### DROP INFO FIELDS THAT ARE MISSING IN ALL RECORDS ########
+    to_keep_1 = [x for x in list(failed_to_liftover.info) if check_missing_row_field(failed_to_liftover, failed_to_liftover.info[x])]
+    to_keep_2 = [x for x in list(success_vcf_original.info) if check_missing_row_field(success_vcf_original, success_vcf_original.info[x])]
+    to_keep = list(set(to_keep_1 + to_keep_2))
+    failed_to_liftover, success_vcf = unify_info(failed_to_liftover, success_vcf_original, to_keep)
+    shared_info = unify_dicts(failed_to_liftover_meta['info'], success_vcf_meta['info'], to_keep)
+    failed_to_liftover_meta.update({'info': deepcopy(shared_info)})
+    success_vcf_meta.update({'info': deepcopy(shared_info)})
+
+
+    ###### INJECT "LIFTOVER SUCCESS" VARIANTS THAT ACTUALLY NEED FIXING #########
+    print('Scanning success VCF for any variants that acutally need repair...', file=log)
+    if debug: # when debugging, success VCF is usually sparse
+        entries_to_add = [x for x in failed_to_liftover.entry if x not in success_vcf.entry]
+        success_vcf = success_vcf.annotate_entries(**{x: hl.missing(failed_to_liftover[x].dtype) for x in entries_to_add})
+        success_vcf = success_vcf.select_entries(*[x for x in failed_to_liftover.entry])
+    failed_to_liftover, success_vcf, n_injected = inject_success_variants_to_fix(failed_to_liftover, success_vcf, homoplasmies.rows(), self_ref)
+
+
+    ###### FINALIZE INPUTS AND RUN GLOBAL CONSISTANCY CHECKS ON VCFs ######
+    failed_to_liftover = failed_to_liftover.annotate_rows(locus_grch38 = hl.liftover(failed_to_liftover.locus, MTREF))
+    failed_to_liftover = failed_to_liftover.annotate_rows(grch38_seq = failed_to_liftover.locus_grch38.sequence_context())
+    #if not skip_checkpoint:
+        #failed_to_liftover = failed_to_liftover.checkpoint('failed_tmp.mt')
+        #success_vcf = success_vcf.checkpoint('success_tmp.mt')
+    original_force_homoplasmies = failed_to_liftover.semi_join_rows(homoplasmies.rows())
+    global_consistancy_checks(failed_to_liftover, allow_NONREF, self_ref, debug)
+    global_consistancy_checks(success_vcf, allow_NONREF, ref, debug)
+    print('Files imported and initial checks passed.', file=log)
+
+
+    ###### FIX SNVs SHOWING MismatchRefAllele ########
+    print('Looking for and repairing SNVs with MismatchRefAllele...', file=log)
+    tf_mismatch_easy = ~failed_to_liftover.filters.contains('NoTarget') \
+        & ~failed_to_liftover.filters.contains('CannotLiftOver') \
+        & ~failed_to_liftover.filters.contains('IndelStraddlesMultipleIntevals') \
+        & is_snv(failed_to_liftover)
+    need_to_flip = failed_to_liftover.filter_rows(tf_mismatch_easy)
+    flipped, ct_complex = swap_alleles(need_to_flip, failed_to_liftover_meta, allow_NONREF=allow_NONREF, log=log)
+    failed_to_liftover = failed_to_liftover.filter_rows(~tf_mismatch_easy).persist()
+
+
+    ###### FIX INDELS CREATED DURING SELF-REFERENCE PRODUCTION ########
+    insertions = get_insertion_sites(chain_table, MTREF, self_ref)
+    deletions = get_deletion_sites(chain_table, MTREF, self_ref)
+    confirm_reference_indels(failed_to_liftover, insertions.union(deletions))
+    all_possible_sites_insertions = explode_indel(insertions, insertions.coord_s, insertions.ns, self_ref, 'sites')
+
+    # Remove any deletions spanning insertions, as these are explicitly unsupported.
+    dele_span_insertion_boundary = dele_spans_insertion(failed_to_liftover, all_possible_sites_insertions, self_ref, ignore_identical=True)
+    failed_to_liftover = failed_to_liftover.anti_join_rows(dele_span_insertion_boundary.rows())
+
+    # Start with insertions.
+    # All GRCh38 reference sites should now have associated variant calls.
+    # The simplest case is simply reversing the insertion relative to GRCh38 -- this is handled here.
+    # More complex is situations where there are SNVs or indels within an insertion relative to GRCh38. These are also handled here.
+    # Note this ONLY deals with variation related to homoplasmic insertions relative to GRCh38.
+    print('Looking for and repairing sites overlapping insertions in self-reference relative to GRCh38...', file=log)
+    tf_reference_indel = ~failed_to_liftover.filters.contains('CannotLiftOver') & ~failed_to_liftover.filters.contains('IndelStraddlesMultipleIntevals')
+    insertions_to_fix = failed_to_liftover.filter_rows(tf_reference_indel).key_rows_by('locus').semi_join_rows(all_possible_sites_insertions).key_rows_by('locus', 'alleles')
+    insertions_to_fix = insertions_to_fix.annotate_rows(is_reversed_grch38_to_self = hl.is_defined(homoplasmies.rows()[insertions_to_fix.row_key]))
+    failed_to_liftover_tmp = failed_to_liftover.filter_rows(~tf_reference_indel)
+    failed_to_liftover = failed_to_liftover_tmp.union_rows(failed_to_liftover.filter_rows(tf_reference_indel).key_rows_by('locus').anti_join_rows(all_possible_sites_insertions).key_rows_by('locus', 'alleles')).persist()
+    fixed_ref_insertions, n_new_haplotypes = fix_ref_insertions(insertions_to_fix, failed_to_liftover_meta, all_possible_sites_insertions, self_reference=self_ref, allow_NONREF=allow_NONREF, log=log)
+
+    # Deal with deletions from the reference
+    # Should always be present in the callset because we force-call changes from reference.
+    # Filter to only those deletions specified in the reference.
+    print('Looking for and repairing deletions in self-reference relative to GRCh38...', file=log)
+    tf_reference_indel = ~failed_to_liftover.filters.contains('CannotLiftOver') & ~failed_to_liftover.filters.contains('IndelStraddlesMultipleIntevals')
+    deletions = deletions.annotate(self_ref_alleles = [deletions.alt_allele, deletions.ref_allele]).key_by('coord_s', 'self_ref_alleles')
+    deletions_to_fix = failed_to_liftover.filter_rows(tf_reference_indel).semi_join_rows(deletions)
+    deletions_to_fix = deletions_to_fix.annotate_rows(from_deletions_locus38 = deletions[deletions_to_fix.row_key].coord_t)
+    if deletions_to_fix.aggregate_rows(~hl.agg.all(deletions_to_fix.from_deletions_locus38 == deletions_to_fix.locus_grch38)):
+        raise ValueError('ERROR: the Liftover-based GRCh38 coordinates for deletions from GRCh38 do not match those obtained form the chain file.')
+    else:
+        deletions_to_fix = deletions_to_fix.drop('from_deletions_locus38')
+    deletions_to_fix = deletions_to_fix.annotate_rows(grch38_seq = deletions[deletions_to_fix.row_key].ref_allele)
+    failed_to_liftover = failed_to_liftover_tmp.union_rows(failed_to_liftover.filter_rows(tf_reference_indel).anti_join_rows(deletions)).persist()
+    flipped_deletions, _ = swap_alleles(deletions_to_fix, failed_to_liftover_meta, allow_NONREF=allow_NONREF, log=log, fail_on_complex=True)
+
+
+    ###### DEAL WITH STRAGGLING INDELS ########
+    # ~failed_to_liftover.filters.contains('IndelStraddlesMultipleIntevals') removed 220615 to allow additional edge case processing
+    # Deal with the case of indels where the first base is changed because of a reference SNV
+    print('Looking for and repairing indels which failed Liftover because their first base differs from GRCh38...', file=log)
+    homoplasmies_snvs = homoplasmies.filter_rows(is_snv(homoplasmies))
+    failed_to_liftover = failed_to_liftover.key_rows_by('locus')
+    tf_swap = ~failed_to_liftover.filters.contains('CannotLiftOver') \
+        & hl.any(hl.map(lambda x: ~hl.literal(NONINDEL).contains(x), failed_to_liftover.alleles))
+    for_swapping_first_site = failed_to_liftover.filter_rows(tf_swap).semi_join_rows(homoplasmies_snvs.rows().key_by('locus')).key_rows_by('locus','alleles')
+    matching_homoplasmies_firstswap = homoplasmies_snvs.key_rows_by('locus').semi_join_rows(for_swapping_first_site.rows().key_by('locus'))
+    failed_to_liftover_tmp = failed_to_liftover.filter_rows(~tf_swap)
+    failed_to_liftover = failed_to_liftover_tmp.union_rows(failed_to_liftover.filter_rows(tf_swap).anti_join_rows(homoplasmies_snvs.rows().key_by('locus'))).key_rows_by('locus','alleles').persist()
+    first_site_swapped, needs_body_changes, n_for_in_body = make_first_indel_site_ref(for_swapping_first_site, failed_to_liftover_meta, matching_homoplasmies_firstswap, flipped, self_ref, ref, all_possible_sites_insertions, allow_NONREF)
+
+    # Deal with the case of deletions where the body of the allele spans changed alleles
+    print('Looking for and repairing deletions which failed Liftover because of internal differences with GRCh38...', file=log)
+    tf_fix_deletion = ~failed_to_liftover.filters.contains('CannotLiftOver') \
+        & ~hl.literal(NONINDEL).contains(failed_to_liftover.alleles[0]) \
+        & hl.literal(NONINDEL).contains(failed_to_liftover.alleles[1])
+    candidates_for_deletion_fix = failed_to_liftover.filter_rows(tf_fix_deletion)
+    failed_to_liftover_tmp = failed_to_liftover.filter_rows(~tf_fix_deletion)
+    fixed_deletion, did_not_fix_deletion, n_indels_in_dele = recode_deletion_allele(candidates_for_deletion_fix, needs_body_changes, all_possible_sites_insertions, ref, self_ref, allow_NONREF, self_homoplasmies=original_force_homoplasmies, mt_meta=failed_to_liftover_meta, allow_spanning=False)
+    failed_to_liftover_tmp = add_missing_new_entry_fields(failed_to_liftover_tmp)
+    failed_to_liftover = failed_to_liftover_tmp.union_rows(did_not_fix_deletion)
+
+    # Deal with the case of a heteroplasmic insertion at the same starting position as a reference deletion (e.g., homoplasmic self-ref insertion)
+    print('Looking for and repairing insertions which share a first base with a reference deletion...', file=log)
+    tf_fix_ins_overlap = failed_to_liftover.filters.contains('InsertionSharesForceCalledInsertion') \
+        & is_insertion(failed_to_liftover)
+    candidates_for_ins_overlap_fix = failed_to_liftover.filter_rows(tf_fix_ins_overlap).persist()
+    failed_to_liftover_tmp = failed_to_liftover.filter_rows(~tf_fix_ins_overlap)
+    fixed_ins_overlap, did_not_fix_ins, n_fixed_ins_overlap = fix_insertion_overlapping_ref_dele(candidates_for_ins_overlap_fix, failed_to_liftover_meta, flipped_deletions, fixed_ref_insertions, insertions, deletions, rely_on_left_shift=True)
+    failed_to_liftover = failed_to_liftover_tmp.union_rows(did_not_fix_ins)
+
+
+    ###### TRY TO RESOLVE DELETION BOUNDARY CASES ########
+    print('Trying to rescue sites that span one boundary of a reference insertion...', file=log)
+    tf_fix_boundary = ~dele_span_insertion_boundary.filters.contains('CannotLiftOver') \
+        & ~dele_span_insertion_boundary.filters.contains('IndelStraddlesMultipleIntevals') \
+        & ~hl.literal(NONINDEL).contains(dele_span_insertion_boundary.alleles[0]) \
+        & hl.literal(NONINDEL).contains(dele_span_insertion_boundary.alleles[1])
+    candidates_for_boundary_fix = dele_span_insertion_boundary.filter_rows(tf_fix_boundary)
+    dele_span_insertion_boundary_tmp = dele_span_insertion_boundary.filter_rows(~tf_fix_boundary)
+    fixed_boundary, did_not_fix_boundary, n_indels_dele_2, n_complex_boundary, n_rightside_sharedstart, n_leftside_span = resolve_deletion_boundary_cases(candidates_for_boundary_fix, failed_to_liftover_meta, all_possible_sites_insertions, original_force_homoplasmies, insertions, ref, self_ref, allow_NONREF)
+    dele_span_insertion_boundary_tmp = add_missing_new_entry_fields(dele_span_insertion_boundary_tmp)
+    dele_span_insertion_boundary = dele_span_insertion_boundary_tmp.union_rows(did_not_fix_boundary)
+    print('Allele rescue completed.', file=log)
+
+
+    ###### COLLATE RESULTS ########
+    failed_to_liftover = failed_to_liftover.union_rows(dele_span_insertion_boundary).drop('locus_grch38', 'grch38_seq').persist()
+    final_metadata = global_modify_meta(failed_to_liftover_meta)
+    final_success_metadata = global_modify_meta(success_vcf_meta)
+    final_mt = flipped.union_rows(fixed_ref_insertions).union_rows(flipped_deletions).union_rows(first_site_swapped
+                     ).union_rows(fixed_deletion).union_rows(fixed_ins_overlap).union_rows(fixed_boundary).persist()
+    if not simple_entry_field_correction:
+        print('Performing fancy AF flip for force-called alleles based on other alleles sharing a start site...', file=log)
+        final_mt, n_fancy_flip = fancy_flip_entries(final_mt, failed_to_liftover_meta, success_vcf, debug=debug)
+        print('Performing change of reference INFO/entry fields for successfully lifted alleles sharing a position with force-called indels...', file=log)
+        final_success_mt, n_success_flipped = flip_success_fields(success_vcf, failed_to_liftover_meta, final_mt, insertions, deletions)
+        fancy_flip_dict = {'sites with fancy flip': n_fancy_flip, 'success sites flipped': n_success_flipped}
+    else:
+        final_success_mt = success_vcf
+        fancy_flip_dict = {}
+    _, _, _, ROW_drop_fields, _, _, ENTRY_drop_fields = get_fields_for_flipping(failed_to_liftover_meta)
+    final_success_mt = drop_info(final_success_mt.drop(*ENTRY_drop_fields), ROW_drop_fields).persist()
+    final_mt = drop_info(final_mt.drop(*ENTRY_drop_fields), ROW_drop_fields).persist()
+    if not skip_norm:
+        print('Running bcftools norm to left-align and shift indels...', file=log)
+        final_mt, final_metadata_2, n_left_aligned, message = left_align_and_normalize(final_mt, final_metadata, ref, reference_fasta)
+        print('bcftools returned: ' + message, file=log)
+    else:
+        final_mt = final_mt.key_rows_by().select_rows(*final_success_mt.row).key_rows_by('locus','alleles')
+        final_metadata_2 = final_metadata
+    
+    # Check for duplicates
+    if final_mt.rows().distinct().count() != final_mt.rows().count():
+        raise ValueError('ERROR: during liftover duplicated alleles were introduced. This is not currently supported.')
+    if not always_fail_on_dupe:
+        final_mt, failed_to_liftover, failed_to_liftover_meta, n_failed_dupe = rescue_duplicated_alleles(final_mt, final_success_mt, failed_to_liftover, final_metadata_2, failed_to_liftover_meta, self_ref)
+    else:
+        n_failed_dupe = 0
+    final_success_ht = final_success_mt.rows()
+    final_ht = final_mt.rows()
+    final_ht = final_ht.select(**{k: final_ht[k] for k in final_success_ht.row if k not in final_ht.key})
+    for_test_all_data = final_success_ht.union(final_ht)
+    if for_test_all_data.distinct().count() != for_test_all_data.count():
+        raise ValueError('ERROR: during liftover duplicated alleles were introduced when testing with both fixed and success VCF. This is not currently supported.')
+    
+    # Check to make sure all REF alleles are indeed ref
+    confirm_ref(final_mt, ref)
+
+    # Confirm that resultant alleles are appropriately formatted
+    if final_mt.aggregate_rows(~hl.agg.all(hl.any(hl.map(lambda x: hl.literal(NONINDEL).contains(x), final_mt.alleles)))):
+        raise ValueError('ERROR: despite using left shifting, there is at least one allele with no NONINDEL variants (e.g., [GCA, GCACA]). This is not allowed.')
+
+    ###### OUTPUT FILES AND LOG ########
+    dict_of_filters = {'SNVs with MismatchRefAllele': flipped.count_rows(),
+                       'homoplasmic insertions rel to GRCh38': fixed_ref_insertions.count_rows(),
+                       'homoplasmic deletions rel to GRCh38': flipped_deletions.count_rows(),
+                       'heteroplasmic indels first site swapped to GRCh38': first_site_swapped.count_rows(),
+                       'heteroplasmic deletions with internal sites swapped to GRCh38': fixed_deletion.count_rows(),
+                       'het insertions sharing LHS with hom ref deletion': n_fixed_ins_overlap,
+                       'heteroplasmic deletions sharing LHS with homoplasmic insertion spanning RHS': n_rightside_sharedstart,
+                       'heteroplasmic deletions spanning only LHS of homoplasmic insertion': n_leftside_span}
+    dict_of_filters.update(fancy_flip_dict)
+    dict_of_filters.update({'left alignment of indels': (float("nan") if skip_norm else n_left_aligned)})
+    write_outcome_log(individual_name_input, final_mt, read_mito_vcf(vcf_file, self_ref)[0], failed_to_liftover, final_success_mt, n_injected, ct_complex, n_new_haplotypes, 
+                      n_for_in_body, n_indels_in_dele+n_indels_dele_2, n_complex_boundary, dele_span_insertion_boundary.count_rows(), n_dupe_removed=n_failed_dupe,
+                      skip_norm=skip_norm, stage_ct_dict=dict_of_filters, output_txt_for_wdl=output_txt_for_wdl, output_prefix=output_prefix, log=log)
+    hl.export_vcf(final_mt, output_prefix + '.fixed.vcf.bgz', metadata=final_metadata_2)
+    hl.export_vcf(final_success_mt, output_prefix + '.updated_success.vcf.bgz', metadata=final_success_metadata)
+    hl.export_vcf(failed_to_liftover, output_prefix + '.rejected.vcf.bgz', metadata=failed_to_liftover_meta)
+    if export_homoplasmic_deletions_coverage:
+        ht_dele_cov = produce_ref_deletions_table(flipped_deletions, deletions)
+        ht_dele_cov.export(output_prefix + '.deletions_coverage.tsv')
+    print('', file=log)
+    print('End time: ' + datetime.now().strftime('%Y-%m-%d %H:%M:%S'), file=log)
+    log.close()
+
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--logging', required=True, default='fix_liftover.log', help='Path to output log.')
+parser.add_argument('--vcf-file', required=True, help='The VCF file of reads failing liftover.')
+parser.add_argument('--success-vcf-file', required=True, help='VCF file of variants that passed first round liftover. Used for the fancy AF correction.')
+parser.add_argument('--self-homoplasmies', required=True, help='VCF with self-coordinate homoplasmies. Filters from here will be grafted onto the final VCF.')
+parser.add_argument('--individual-name', default='self_reference', help='ID of individual with self-reference.')
+parser.add_argument('--self-to-ref-chain', required=True, help='Chain file mapping from self-ref to reference.')
+parser.add_argument('--ref-to-self-chain', required=True, help='Chain file mapping from reference to self-ref.')
+parser.add_argument('--self-fasta', required=True, help='Self-reference fasta file.')
+parser.add_argument('--self-fai', required=True, help='Self-reference fai file.')
+parser.add_argument('--reference-fasta', required=True, help='Reference fasta file.')
+parser.add_argument('--reference-fai', required=True, help='Reference fai file.')
+parser.add_argument('--allow-NONREF', action='store_true', help='If true, will try to handle alleles with <NON_REF> coding.')
+parser.add_argument('--export-homoplasmic-deletions-coverage', action='store_true', help='If true, will ')
+parser.add_argument('--output-prefix', required=True, help='Output prefix for outputting results. Will add .fixed.vcf.bgz and .rejected.vcf.bgz suffixes.')
+parser.add_argument('--output-txt-for-wdl', action='store_true', help='If true, will use --output-prefix to also output txt files with numbers counting the number of sites fixed at each step.')
+parser.add_argument('--simple-entry-field-correction', action='store_true', help='If enabled, will simply do 1-AF when flipping reference alleles and will not change any fields in Liftover passed alleles. ' + \
+                                                                                 'Otherwise, a more sophisticated approach is used, reading in all variant calls and then doing total-AF where total are 1-the AF ' + \
+                                                                                 'estimates for all sites sharing that locus. Further we now flip INFO/entry fields for variants that passed Liftover but share a site with a failed reference indel.')
+parser.add_argument('--debug', action='store_true', help='If enabled, skips a few consistency checks to make using custom edge case VCFs easier to make.')
+parser.add_argument('--skip-checkpoint', action='store_true')
+parser.add_argument('--skip-norm', action='store_true', help='If enabled, will avoid using bcftools norm to left-align indels.')
+parser.add_argument('--always-fail-on-dupe', action='store_true', help='If enabled, will always fail on any type of post-liftover duplicate variant.')
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    main(**vars(args))

--- a/3rd-party-tools/aou_mito_single_sample/jsontools.py
+++ b/3rd-party-tools/aou_mito_single_sample/jsontools.py
@@ -1,0 +1,89 @@
+import json
+import argparse
+import os
+
+def parse_var(s):
+    """
+    Parse a key, value pair, separated by '='
+    That's the reverse of ShellArgs.
+
+    On the command line (argparse) a declaration will typically look like:
+        foo=hello
+    or
+        foo="hello world"
+    """
+    items = s.split('=')
+    key = items[0].strip() # we remove blanks around keys, as is logical
+    if len(items) > 1:
+        # rejoin the rest:
+        value = '='.join(items[1:])
+    return (key, value)
+
+
+def parse_vars(items, type):
+    """
+    Parse a series of key-value pairs and return a dictionary
+    """
+    d = {}
+
+    if items:
+        for item in items:
+            key, value = parse_var(item)
+            d[key] = type(value)
+    return d
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--path', type=str, required=True)
+parser.add_argument("--set",
+                        metavar="KEY=VALUE",
+                        nargs='+',
+                        help="Set a number of key-value pairs "
+                             "(do not put spaces before or after the = sign). "
+                             "If a value contains spaces, you should define "
+                             "it with double quotes: "
+                             'foo="this is a sentence". Note that '
+                             "values are always treated as strings.")
+parser.add_argument("--set-int",
+                        metavar="KEY=VALUE",
+                        nargs='+',
+                        help="Set a number of key-value pairs "
+                             "(do not put spaces before or after the = sign). "
+                             "If a value contains spaces, you should define "
+                             "it with double quotes: "
+                             'foo="this is a sentence". Note that '
+                             "values are always treated as ints.")
+parser.add_argument("--set-float",
+                        metavar="KEY=VALUE",
+                        nargs='+',
+                        help="Set a number of key-value pairs "
+                             "(do not put spaces before or after the = sign). "
+                             "If a value contains spaces, you should define "
+                             "it with double quotes: "
+                             'foo="this is a sentence". Note that '
+                             "values are always treated as ints.")
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    data_in = parse_vars(args.set, type=str)
+    data_in_int = parse_vars(args.set_int, type=int)
+    data_in_float = parse_vars(args.set_float, type=float)
+    data_in.update(data_in_int)
+    data_in.update(data_in_float)
+    keys_in = list(data_in.keys())
+    
+    if os.path.exists(args.path):
+        with open(args.path, 'r') as json_file:    
+            file_of_interest = json.load(json_file)
+        k_in_file = list(file_of_interest.keys())
+        new_in_old = all([x in k_in_file for x in keys_in])
+        old_in_new = all([x in keys_in for x in k_in_file])
+        if not new_in_old or not old_in_new:
+            raise ValueError('ERROR: json file contains different keys from input.')
+        
+        for k in keys_in:
+            file_of_interest[k].append(data_in[k])
+    else:
+        file_of_interest = {k: [data_in[k]] for k in keys_in}
+    
+    with open(args.path, 'w') as new_file:
+        json.dump(file_of_interest, new_file)


### PR DESCRIPTION
this PR adds input scripts and interval list necessary to run the MtSwirl single sample pipeline in WARP. This analysis was used for CDRv9.